### PR TITLE
[ANDR][dev] Run lint on every project and apply same config everywhere

### DIFF
--- a/platform/jvm/capture-apollo3/build.gradle.kts
+++ b/platform/jvm/capture-apollo3/build.gradle.kts
@@ -25,6 +25,16 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    lint {
+        quiet = false
+        ignoreWarnings = false
+        warningsAsErrors = true
+        checkAllWarnings = true
+        abortOnError = true
+        checkDependencies = true
+        checkReleaseBuilds = true
+    }
 }
 
 detekt {

--- a/platform/jvm/capture-timber/build.gradle.kts
+++ b/platform/jvm/capture-timber/build.gradle.kts
@@ -29,6 +29,16 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    lint {
+        quiet = false
+        ignoreWarnings = false
+        warningsAsErrors = true
+        checkAllWarnings = true
+        abortOnError = true
+        checkDependencies = true
+        checkReleaseBuilds = true
+    }
 }
 
 detekt {

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -1,7 +1,9 @@
 plugins {
+    // The rust android gradle plugin needs to go first
+    //  see: https://github.com/mozilla/rust-android-gradle/issues/147
+    alias(libs.plugins.rust.android)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.rust.android)
     alias(libs.plugins.detekt)
 
     // Publish
@@ -79,8 +81,8 @@ android {
 cargo {
     libname = "capture"
     extraCargoBuildArguments = listOf("--package", "capture")
-    module  = "../.."
-    targetDirectory =  "../../../target"
+    module = "../.."
+    targetDirectory = "../../../target"
     targets = listOf("arm64", "x86_64")
     pythonCommand = "python3"
 }

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
 }
 
 android {
+    namespace = "io.bitdrift.capture"
+
     compileSdk = 34
     buildToolsVersion = "34.0.0"
 
@@ -58,6 +60,8 @@ android {
         languageVersion = "1.9"
     }
 
+    // TODO(murki): Move this common configuration to a reusable buildSrc plugin once it's fully supported for kotlin DSL
+    //  see: https://github.com/gradle/kotlin-dsl-samples/issues/1287
     lint {
         quiet = false
         ignoreWarnings = false
@@ -67,8 +71,6 @@ android {
         checkDependencies = true
         checkReleaseBuilds = true
     }
-
-    namespace = "io.bitdrift.capture"
 
     ndkVersion = "27.0.12077973"
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ErrorHandler.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ErrorHandler.kt
@@ -26,7 +26,6 @@ internal class ErrorHandler : ErrorHandler {
      * @param detail a string identifying the action that resulted in an error.
      * @param e the throwable associated with the error.
      */
-    @Suppress("TooGenericExceptionCaught")
     override fun handleError(detail: String, e: Throwable?) {
         try {
             // Delegate to the JNI function over using the error reporter directly. This is done so

--- a/platform/jvm/common/build.gradle.kts
+++ b/platform/jvm/common/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 }
 
 android {
+    namespace = "io.bitdrift.capture.common"
+
     compileSdk = 34
 
     compileOptions {
@@ -21,9 +23,10 @@ android {
     lint {
         quiet = false
         ignoreWarnings = false
+        warningsAsErrors = true
+        checkAllWarnings = true
         abortOnError = true
         checkDependencies = true
+        checkReleaseBuilds = true
     }
-
-    namespace = "io.bitdrift.capture.common"
 }

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.tasks.factory.dependsOn
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.apollo.graphql)
@@ -18,7 +16,7 @@ dependencies {
     implementation("androidx.navigation:navigation-ui-ktx:2.5.3")
     implementation("com.apollographql.apollo3:apollo-runtime:3.8.3")
     implementation("com.apollographql.apollo3:apollo-runtime:3.8.3")
-    implementation ("com.jakewharton.timber:timber:5.0.1")
+    implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("com.google.android.material:material:1.8.0")
     implementation(libs.androidx.material3.android)
 
@@ -41,7 +39,7 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.4.0")
 }
 
-android {   
+android {
     namespace = "io.bitdrift.gradletestapp"
     compileSdk = 34
 
@@ -67,7 +65,7 @@ android {
     // Run lint checks on every build
     applicationVariants.configureEach {
         val lintTask = tasks.named("lint${name.replaceFirstChar(Char::titlecase)}")
-        assembleProvider.dependsOn(lintTask)
+        assembleProvider.get().dependsOn(lintTask)
     }
     lint {
         checkDependencies = true

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.apollo.graphql)
@@ -63,9 +65,9 @@ android {
     }
 
     // Run lint checks on every build
-    applicationVariants.all {
-        val lintTask = tasks["lint${name.capitalize()}"]
-        assembleProvider.get().dependsOn.add(lintTask)
+    applicationVariants.configureEach {
+        val lintTask = tasks.named("lint${name.replaceFirstChar(Char::titlecase)}")
+        assembleProvider.dependsOn(lintTask)
     }
     lint {
         checkDependencies = true

--- a/platform/jvm/gradle.properties
+++ b/platform/jvm/gradle.properties
@@ -16,3 +16,4 @@ android.useAndroidX=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 org.gradle.warning.mode=all
+android.experimental.lint.analysisPerComponent=false

--- a/platform/jvm/gradle.properties
+++ b/platform/jvm/gradle.properties
@@ -16,4 +16,3 @@ android.useAndroidX=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 org.gradle.warning.mode=all
-android.experimental.lint.analysisPerComponent=false

--- a/platform/jvm/gradle/libs.versions.toml
+++ b/platform/jvm/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 androidBenchkmarkPlugin = "1.2.4"
-androidGradlePlugin = "8.3.2"
+androidGradlePlugin = "8.2.2" # have to pin to this version due to 8.3.x breaking our lint https://issuetracker.google.com/issues/332755363
 apolloGraphqlPlugin = "3.8.3"
 appcompat = "1.5.1"
 assertjCore = "3.22.0"
@@ -57,7 +57,7 @@ android-benchmark = { id = "androidx.benchmark", version.ref = "androidBenchkmar
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 apollo-graphql = { id = "com.apollographql.apollo3", version.ref = "apolloGraphqlPlugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektPlugin" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaPlugin"}
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublishPlugin"}
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaPlugin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublishPlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinAndroidPlugin" }
-rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rustAndroidPlugin"}
+rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rustAndroidPlugin" }

--- a/platform/jvm/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/jvm/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/jvm/replay/build.gradle.kts
+++ b/platform/jvm/replay/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
 }
 
 android {
+    namespace = "io.bitdrift.capture.replay"
+
     compileSdk = 34
 
     defaultConfig {
@@ -41,9 +43,10 @@ android {
     lint {
         quiet = false
         ignoreWarnings = false
+        warningsAsErrors = true
+        checkAllWarnings = true
         abortOnError = true
         checkDependencies = true
+        checkReleaseBuilds = true
     }
-
-    namespace = "io.bitdrift.capture.replay"
 }

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/WindowManager.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/WindowManager.kt
@@ -19,6 +19,7 @@ internal class WindowManager(private val errorHandler: ErrorHandler) {
     private var tryWindowInspector = true
 
     private val global by lazy(LazyThreadSafetyMode.NONE) {
+        //noinspection PrivateApi
         Class.forName("android.view.WindowManagerGlobal")
     }
 

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/WindowManager.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/WindowManager.kt
@@ -36,7 +36,7 @@ internal class WindowManager(private val errorHandler: ErrorHandler) {
     /**
      * Find all DecorViews from [android.view.WindowManagerGlobal]
      */
-    @Suppress("KDocUnresolvedReference")
+    @Suppress("KDocUnresolvedReference", "SwallowedException")
     fun findRootViews(): List<View> {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && tryWindowInspector) {
             try {

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/WindowManager.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/WindowManager.kt
@@ -36,7 +36,7 @@ internal class WindowManager(private val errorHandler: ErrorHandler) {
     /**
      * Find all DecorViews from [android.view.WindowManagerGlobal]
      */
-    @Suppress("KDocUnresolvedReference", "SwallowedException")
+    @Suppress("KDocUnresolvedReference")
     fun findRootViews(): List<View> {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && tryWindowInspector) {
             try {

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/mappers/TextMapper.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/mappers/TextMapper.kt
@@ -126,7 +126,7 @@ internal class TextMapper(
         return view.text.substring(lineStart, lineEnd)
     }
 
-    @SuppressLint("SwitchIntDef")
+    @SuppressLint("SwitchIntDef", "RtlHardcoded")
     private fun alignHorizontal(
         view: TextView,
         alignment: Int = view.textAlignment,


### PR DESCRIPTION
Simplify (and make fwd compatible) the lint gradle task configuration on the `gradle-test-app`. Also run the same configuration in all of our artifact modules (and suppress any existing warnings).

In order to make this work we had to downgrade gradle from 8.3 --> 8.2 due to this open bug: https://issuetracker.google.com/issues/332755363