### PR TITLE
[ci] Fix bazel check for changes

### DIFF
--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# Compares the head ref and $GITHUB_BASE_REF (PR branch + target branch, usually main) to
+# Compares the head ref and ${{ github.ref_name }} (PR branch + target branch, usually main) to
 # determine which Bazel targets have changed. This is done by analyzing the cache keys and
 # should be authoritative assuming the builds are hermetic.
 #
@@ -12,12 +12,12 @@ set -euo pipefail
 trap 'echo "An unexpected error occurred during Bazel check."; echo "check_result=1" >> "$GITHUB_OUTPUT"; exit 1' ERR
 
 # Ensure we fetch the base branch (main) to make it available
-git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"
+git fetch origin "${{ github.ref_name }}":"${{ github.ref_name }}"
 
-echo "GITHUB_BASE_REF = $GITHUB_BASE_REF"
+echo "GITHUB_BASE_REF = ${{ github.ref_name }}"
 
 # Get the latest commit SHA for the base branch (target branch of the PR)
-base_sha=$(git rev-parse "$GITHUB_BASE_REF")
+base_sha=$(git rev-parse "${{ github.ref_name }}")
 # Get the latest commit SHA for the PR branch (the head ref in the forked repository)
 final_revision=$GITHUB_SHA
 

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# Compares the head ref and $GITHUB_REF_NAME (PR branch + target branch, usually main) to
+# Compares the head ref and $GITHUB_BASE_REF (PR branch + target branch, usually main) to
 # determine which Bazel targets have changed. This is done by analyzing the cache keys and
 # should be authoritative assuming the builds are hermetic.
 #
@@ -11,13 +11,15 @@ set -euo pipefail
 # Trap to handle unexpected errors and log them
 trap 'echo "An unexpected error occurred during Bazel check."; echo "check_result=1" >> "$GITHUB_OUTPUT"; exit 1' ERR
 
-# Ensure we fetch the base branch (main) to make it available
-git fetch origin "$GITHUB_REF_NAME":"$GITHUB_REF_NAME"
+# Check if GITHUB_BASE_REF is set (i.e., you're in a pull request)
+if [ -n "$GITHUB_BASE_REF" ]; then
+  git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"
+  base_sha=$(git rev-parse "$GITHUB_BASE_REF")
+else
+  echo "Not in a pull request, skipping base ref fetch."
+  base_sha=$(git rev-parse HEAD)
+fi
 
-echo "GITHUB_REF_NAME = $GITHUB_REF_NAME"
-
-# Get the latest commit SHA for the base branch (target branch of the PR)
-base_sha=$(git rev-parse "$GITHUB_REF_NAME")
 # Get the latest commit SHA for the PR branch (the head ref in the forked repository)
 final_revision=$GITHUB_SHA
 

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# Compares the head ref and ${{ github.ref_name }} (PR branch + target branch, usually main) to
+# Compares the head ref and $GITHUB_REF_NAME (PR branch + target branch, usually main) to
 # determine which Bazel targets have changed. This is done by analyzing the cache keys and
 # should be authoritative assuming the builds are hermetic.
 #
@@ -12,12 +12,12 @@ set -euo pipefail
 trap 'echo "An unexpected error occurred during Bazel check."; echo "check_result=1" >> "$GITHUB_OUTPUT"; exit 1' ERR
 
 # Ensure we fetch the base branch (main) to make it available
-git fetch origin "${{ github.ref_name }}":"${{ github.ref_name }}"
+git fetch origin "$GITHUB_REF_NAME":"$GITHUB_REF_NAME"
 
-echo "GITHUB_BASE_REF = ${{ github.ref_name }}"
+echo "GITHUB_REF_NAME = $GITHUB_REF_NAME"
 
 # Get the latest commit SHA for the base branch (target branch of the PR)
-base_sha=$(git rev-parse "${{ github.ref_name }}")
+base_sha=$(git rev-parse "$GITHUB_REF_NAME")
 # Get the latest commit SHA for the PR branch (the head ref in the forked repository)
 final_revision=$GITHUB_SHA
 

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -14,6 +14,8 @@ trap 'echo "An unexpected error occurred during Bazel check."; echo "check_resul
 # Ensure we fetch the base branch (main) to make it available
 git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"
 
+echo "GITHUB_BASE_REF = $GITHUB_BASE_REF"
+
 # Get the latest commit SHA for the base branch (target branch of the PR)
 base_sha=$(git rev-parse "$GITHUB_BASE_REF")
 # Get the latest commit SHA for the PR branch (the head ref in the forked repository)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
@@ -169,6 +169,7 @@ class ClientAttributesTest {
         doReturn(state).`when`(mockedLifecycle).currentState
         val mockedLifecycleOwner = mock(LifecycleOwner::class.java)
         doReturn(mockedLifecycle).`when`(mockedLifecycleOwner).lifecycle
+
         return mockedLifecycleOwner
     }
 
@@ -176,12 +177,14 @@ class ClientAttributesTest {
         val mockedPackageManager = obtainMockedPackageManager(context)
         val mockedPackageInfo: PackageInfo = mock(PackageInfo::class.java)
         doReturn(mockedPackageInfo).`when`(mockedPackageManager).getPackageInfo(anyString(), eq(0))
+
         return mockedPackageInfo
     }
 
     private fun obtainMockedPackageManager(context: Context): PackageManager {
         val mockedPackageManager: PackageManager = mock(PackageManager::class.java)
         doReturn(mockedPackageManager).`when`(context).packageManager
+        
         return mockedPackageManager
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
@@ -169,7 +169,6 @@ class ClientAttributesTest {
         doReturn(state).`when`(mockedLifecycle).currentState
         val mockedLifecycleOwner = mock(LifecycleOwner::class.java)
         doReturn(mockedLifecycle).`when`(mockedLifecycleOwner).lifecycle
-
         return mockedLifecycleOwner
     }
 
@@ -177,14 +176,12 @@ class ClientAttributesTest {
         val mockedPackageManager = obtainMockedPackageManager(context)
         val mockedPackageInfo: PackageInfo = mock(PackageInfo::class.java)
         doReturn(mockedPackageInfo).`when`(mockedPackageManager).getPackageInfo(anyString(), eq(0))
-
         return mockedPackageInfo
     }
 
     private fun obtainMockedPackageManager(context: Context): PackageManager {
         val mockedPackageManager: PackageManager = mock(PackageManager::class.java)
         doReturn(mockedPackageManager).`when`(context).packageManager
-        
         return mockedPackageManager
     }
 }


### PR DESCRIPTION
Quick fix for `$GITHUB_BASE_REF` being empty on `main` branch runs (variable is only available on pull requests: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables )

Fixes #27