### PR TITLE
fix crash when interacting with 3rd parties

### DIFF
--- a/platform/swift/source/integrations/url_session/extensions/URLSession+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSession+Swizzling.swift
@@ -41,7 +41,7 @@ extension URLSession {
             //  * https://github.com/google/gtm-session-fetcher/issues/190#issuecomment-604757154
             let disabledDelegateClassNames = [
                 "GMPx_GTMSessionFetcherSessionDelegateDispatcher", // GooglePlaces SDK
-                "GTMSessionFetcherSessionDelegateDispatcher",      // GoogleMaps/GTMSessionFetcher SDK
+                "GTMSessionFetcherSessionDelegateDispatcher", // GoogleMaps/GTMSessionFetcher SDK
             ]
 
             let shouldDisableProxying = disabledDelegateClassNames


### PR DESCRIPTION
This time I was able to repro the reported crash https://bitdrifters.slack.com/archives/C077NA22DU6/p1725661717394759?thread_ts=1724364825.781749&cid=C077NA22DU6 locally and confirmed that the proposed patch gets rid of the crash.