### PR TITLE
[ci] Fix `files_changed` `merge` main issues and `files_changed` and `check_bazel` script's `base_sha` to point to `HEAD~1`

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Check for Bazel build file changes
       - name: Check for Bazel build file changes
         id: bazel_check
         run: ./ci/check_bazel.sh //examples/android:android_app

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -17,7 +17,7 @@ if [ -n "$GITHUB_BASE_REF" ]; then
   base_sha=$(git rev-parse "$GITHUB_BASE_REF")
 else
   echo "Not in a pull request, skipping base ref fetch."
-  base_sha=$(git rev-parse HEAD)
+  base_sha=$(git rev-parse HEAD~1)
 fi
 
 # Get the latest commit SHA for the PR branch (the head ref in the forked repository)

--- a/ci/files_changed.sh
+++ b/ci/files_changed.sh
@@ -5,16 +5,33 @@
 #
 # Usage: ./ci/files_changed.sh <regex>
 
-set -e
+set -euo pipefail
 
 # Trap to handle unexpected errors and log them
 trap 'echo "An unexpected error occurred during file change check."; echo "check_result=1" >> "$GITHUB_OUTPUT"; exit 1' ERR
 
-# Check for file changes
-if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only "origin/$GITHUB_BASE_REF" | grep -E "$1" ; then
+# Determine the base ref or fallback to HEAD~1 when running on main
+if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
+  echo "GITHUB_BASE_REF is empty, likely running on main branch. Using HEAD~1 for comparison."
+  base_ref="HEAD~1"
+else
+  base_ref="origin/$GITHUB_BASE_REF"
+fi
+
+if git rev-parse --abbrev-ref HEAD | grep -q ^main$ ; then
   echo "Relevant file changes detected!"
   echo "check_result=0" >> "$GITHUB_OUTPUT"
-  exit 0  # Relevant changes detected
+  exit 0
+fi
+
+# Run git diff and store output
+diff_output=$(git diff --name-only "$base_ref" || exit 1)  # Ensure git diff failures are caught
+
+# Check for relevant file changes
+if echo "$diff_output" | grep -E "$1" ; then
+  echo "Relevant file changes detected!"
+  echo "check_result=0" >> "$GITHUB_OUTPUT"
+  exit 0
 else
   echo "No relevant changes found."
   echo "check_result=2" >> "$GITHUB_OUTPUT"

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -320,9 +320,9 @@ object Capture {
                 val result = block()
                 span?.end(SpanResult.SUCCESS)
                 return result
-            } catch (e: Throwable) {
+            } catch (exception: Throwable) {
                 span?.end(SpanResult.FAILURE)
-                throw e
+                throw exception
             }
         }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -193,12 +193,12 @@ class FirstFragment : Fragment() {
         val url = HttpUrl.Builder().scheme("https").host(requestDef.host).addPathSegments(requestDef.path)
         requestDef.query.forEach { (key, value) -> url.addQueryParameter(key, value) }
 
-        val req = Request.Builder()
+        val request = Request.Builder()
             .url(url.build())
             .method(requestDef.method, if (requestDef.method == "POST") "requestBody".toRequestBody() else null)
             .build()
 
-        val call = okHttpClient.newCall(req)
+        val call = okHttpClient.newCall(request)
 
         call.enqueue(object : Callback {
             override fun onResponse(call: Call, response: Response) {


### PR DESCRIPTION
Follow up from https://github.com/bitdriftlabs/capture-sdk/pull/24 and https://github.com/bitdriftlabs/capture-sdk/pull/28

This PR fixes:

- https://github.com/bitdriftlabs/capture-sdk/actions/runs/10781042749/job/29898099793 👇

```
Check for workflow file changes
Run ./ci/files_changed.sh .github/workflows/android.yaml
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
No relevant changes found.
```

```
Check for relevant Gradle changes
Run ./ci/files_changed.sh "^platform/jvm/gradle-test-app/.*\.(gradle|kts|kt|xml)$"
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
No relevant changes found.
```

This is solved by fixing `files_changed` to differentiate when you are in a PR or `main`, as well as ensuring `git diff` failures are caught and reported accordingly.

- `check_bazel` and `files_changed` script's `base_sha` to point to `HEAD~1` when running on a `main` merge. I noticed that no changes were detected even though they were present as part of the PR. Root cause was that we were diffing pointing to the same references and hence no changes. Pointing to the commit before the current one (`HEAD~1`) fixes this. I've thoroughly tested locally and now changes are detected too after merging a PR.

cc @murki 