### PR TITLE
[sdk][andr] Don't use PowerManager if not available

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/common/PowerMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/common/PowerMonitor.kt
@@ -13,7 +13,7 @@ import android.os.PowerManager
 import androidx.annotation.RequiresApi
 
 internal class PowerMonitor(context: Context) {
-    val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private val thermalStatusMap = hashMapOf(
@@ -32,6 +32,6 @@ internal class PowerMonitor(context: Context) {
     }
 
     fun isPowerSaveModeEnabledAttribute(): Pair<String, String> {
-        return Pair("_low_power_enabled", if (powerManager.isPowerSaveMode) "1" else "0")
+        return Pair("_low_power_enabled", if (powerManager?.isPowerSaveMode == true) "1" else "0")
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/common/PowerMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/common/PowerMonitor.kt
@@ -13,6 +13,8 @@ import android.os.PowerManager
 import androidx.annotation.RequiresApi
 
 internal class PowerMonitor(context: Context) {
+    // Customers have reported encountering certain devices (particularly the Caterpillar S48C phone)
+    // where this returns null on Android 8.1.0. Even though it should always be available on API level >= 21.
     val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
 
     @RequiresApi(Build.VERSION_CODES.Q)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/device/DeviceStateListenerLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/device/DeviceStateListenerLogger.kt
@@ -66,7 +66,7 @@ internal class DeviceStateListenerLogger(
         context.registerComponentCallbacks(this)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            powerMonitor.powerManager.addThermalStatusListener(executor, thermalCallback)
+            powerMonitor.powerManager?.addThermalStatusListener(executor, thermalCallback)
         }
     }
 
@@ -75,7 +75,7 @@ internal class DeviceStateListenerLogger(
         context.unregisterComponentCallbacks(this)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            powerMonitor.powerManager.removeThermalStatusListener(thermalCallback)
+            powerMonitor.powerManager?.removeThermalStatusListener(thermalCallback)
         }
     }
 


### PR DESCRIPTION
Customers have reported encountering certain devices (particularly the Caterpillar S48C phone) where `context.getSystemService(Context.POWER_SERVICE)` would be `null` causing our `Logger.configure()` method to throw.