### PR TITLE
make code coverage report work

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,30 +78,30 @@ rust_register_toolchains(
     # can't include a compromised tool.
     #
     # tl;dr; run e.g. $ ./tools/rust_std_checksum.sh 1.80.0
-    sha256s = {
-        "rust-std-" + RUST_VERSION + "-aarch64-apple-ios-sim.tar.gz": "a4bdf0c2ecd0d899629db9ae0e940863da4047f379bec4a969df3f33dce911db",
-        "rust-std-" + RUST_VERSION + "-aarch64-apple-ios.tar.gz": "09bd46b2b9297b61dd172da42c9455aaa1c85676715f6b8473b55612c1de10ed",
-        "rust-std-" + RUST_VERSION + "-x86_64-apple-ios.tar.gz": "989852a7e82e2a3ad01473a9157ad92f8ff2ebce5300ecb4a716b5987be1bf6b",
-        "rust-std-" + RUST_VERSION + "-aarch64-linux-android.tar.gz": "e8bc1c411e60cd8b290afe8bcc903e18ab904efe9782e491ce781f38a19647f0",
-        "rust-std-" + RUST_VERSION + "-armv7-linux-androideabi.tar.gz": "84c15635750c1228366189aab6f95d26dcaed6069cac3c1fb3dad2f985952d8a",
-        "rust-std-" + RUST_VERSION + "-i686-linux-android.tar.gz": "d205cddae43645e259eb4a1dbbbf6757b08e7408f48d339b5737d7773d749e0e",
-        "rustc-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "9c3d36b8860011bddec580b12e4b6937aa0657b393e7aeb20f1dc90e743ffa7e",
-        "cargo-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "bca2ed0f3b5dec19bd53b0a7d999eb1b495cd5ace69aafa088b44d83f44e3a8d",
-        "llvm-tools-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "7b39fb1d477271d1232e704ef47ea5ec7d323c0cbe358c9a3986bdf6ce27ca55",
-        "rust-std-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "44809c3b92c7500c64517151f1e3389b32913a35414553395104bc4a0ee35f69",
-        "clippy-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "8666f5241c437f7074488c67819d80af8514ac280cc22973c1b15de3086d8dcc",
-        "rustfmt-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "e17c1adda089e922376b2cf0ad3844c132cc1fb2225e1e59fe60af164974883a",
-    },
-    urls = [
-        # NOTE: `urls` are technically mirrors so we want to make sure we always try our own first then the official ones.
-        # We'll ensure that the ones we want to serve always come from us by the previous sha256s dictionary. Please ensure
-        # that the extensions on both of these are the same.
-        "https://github.com/bitdriftlabs/rust-std-mobile/releases/download/" + RUST_VERSION + "/{}.tar.gz",
+    # sha256s = {
+    #     "rust-std-" + RUST_VERSION + "-aarch64-apple-ios-sim.tar.gz": "a4bdf0c2ecd0d899629db9ae0e940863da4047f379bec4a969df3f33dce911db",
+    #     "rust-std-" + RUST_VERSION + "-aarch64-apple-ios.tar.gz": "09bd46b2b9297b61dd172da42c9455aaa1c85676715f6b8473b55612c1de10ed",
+    #     "rust-std-" + RUST_VERSION + "-x86_64-apple-ios.tar.gz": "989852a7e82e2a3ad01473a9157ad92f8ff2ebce5300ecb4a716b5987be1bf6b",
+    #     "rust-std-" + RUST_VERSION + "-aarch64-linux-android.tar.gz": "e8bc1c411e60cd8b290afe8bcc903e18ab904efe9782e491ce781f38a19647f0",
+    #     "rust-std-" + RUST_VERSION + "-armv7-linux-androideabi.tar.gz": "84c15635750c1228366189aab6f95d26dcaed6069cac3c1fb3dad2f985952d8a",
+    #     "rust-std-" + RUST_VERSION + "-i686-linux-android.tar.gz": "d205cddae43645e259eb4a1dbbbf6757b08e7408f48d339b5737d7773d749e0e",
+    #     "rustc-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "9c3d36b8860011bddec580b12e4b6937aa0657b393e7aeb20f1dc90e743ffa7e",
+    #     "cargo-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "bca2ed0f3b5dec19bd53b0a7d999eb1b495cd5ace69aafa088b44d83f44e3a8d",
+    #     "llvm-tools-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "7b39fb1d477271d1232e704ef47ea5ec7d323c0cbe358c9a3986bdf6ce27ca55",
+    #     "rust-std-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "44809c3b92c7500c64517151f1e3389b32913a35414553395104bc4a0ee35f69",
+    #     "clippy-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "8666f5241c437f7074488c67819d80af8514ac280cc22973c1b15de3086d8dcc",
+    #     "rustfmt-" + RUST_VERSION + "-aarch64-apple-darwin.tar.gz": "e17c1adda089e922376b2cf0ad3844c132cc1fb2225e1e59fe60af164974883a",
+    # },
+    # urls = [
+    #     # NOTE: `urls` are technically mirrors so we want to make sure we always try our own first then the official ones.
+    #     # We'll ensure that the ones we want to serve always come from us by the previous sha256s dictionary. Please ensure
+    #     # that the extensions on both of these are the same.
+    #     "https://github.com/bitdriftlabs/rust-std-mobile/releases/download/" + RUST_VERSION + "/{}.tar.gz",
 
-        # We need this because we only serve std for mobile archs but rustc, clippy, cargo, llvm-tools and even std for
-        # apple-darwin/linux are served from the official mirror.
-        "https://static.rust-lang.org/dist/{}.tar.gz",
-    ],
+    #     # We need this because we only serve std for mobile archs but rustc, clippy, cargo, llvm-tools and even std for
+    #     # apple-darwin/linux are served from the official mirror.
+    #     "https://static.rust-lang.org/dist/{}.tar.gz",
+    # ],
     versions = [
         RUST_VERSION,
     ],

--- a/test/platform/swift/unit_integration/BUILD
+++ b/test/platform/swift/unit_integration/BUILD
@@ -2,17 +2,17 @@ load("//bazel:bitdrift_swift_test.bzl", "bitdrift_mobile_swift_test")
 
 bitdrift_mobile_swift_test(
     name = "test",
-    srcs = glob(["**/*.swift"]),
+    srcs = glob(["ConfigurationTests.swift"]),
     repository = "@capture",
     tags = ["macos_only"],
     visibility = ["//visibility:public"],
     deps = [
         "//platform/swift/source:ios_lib",
-        "//platform/swift/source:rust_bridge",
-        "//test/platform/swift/benchmark:benchmarks",
-        "//test/platform/swift/bridging:rust_bridge",
-        "@Difference//:difference",
-        "@SwiftBenchmark//:swift_benchmark",
+        # "//platform/swift/source:rust_bridge",
+        # "//test/platform/swift/benchmark:benchmarks",
+        # "//test/platform/swift/bridging:rust_bridge",
+        # "@Difference//:difference",
+        # "@SwiftBenchmark//:swift_benchmark",
     ],
 )
 


### PR DESCRIPTION
This is the command I tried to use to generate test coverage report:

```bash
RUST_LOG=debug ./bazelw coverage //test/platform/swift/unit_integration:test --verbose_failures --test_output=streamed --combined_report=lcov
```

Without any changes, this is the error that I was getting:

<details>
  <summary>Bazel command output</summary>

  ```bash
  RUST_LOG=debug ./bazelw coverage //test/platform/swift/unit_integration:test --verbose_failures --test_output=streamed --combined_report=lcov
WARNING: Download from https://github.com/bitdriftlabs/rust-std-mobile/releases/download/1.81.0/2024-09-09/rustfmt-nightly-aarch64-apple-darwin.tar.gz failed: class java.io.FileNotFoundException GET returned 404 Not Found
DEBUG: Rule 'rust_darwin_aarch64__aarch64-apple-darwin__stable_tools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256s = {"rust-std-1.81.0-aarch64-apple-ios-sim.tar.gz": "a4bdf0c2ecd0d899629db9ae0e940863da4047f379bec4a969df3f33dce911db", "rust-std-1.81.0-aarch64-apple-ios.tar.gz": "09bd46b2b9297b61dd172da42c9455aaa1c85676715f6b8473b55612c1de10ed", "rust-std-1.81.0-x86_64-apple-ios.tar.gz": "989852a7e82e2a3ad01473a9157ad92f8ff2ebce5300ecb4a716b5987be1bf6b", "rust-std-1.81.0-aarch64-linux-android.tar.gz": "e8bc1c411e60cd8b290afe8bcc903e18ab904efe9782e491ce781f38a19647f0", "rust-std-1.81.0-armv7-linux-androideabi.tar.gz": "84c15635750c1228366189aab6f95d26dcaed6069cac3c1fb3dad2f985952d8a", "rust-std-1.81.0-i686-linux-android.tar.gz": "d205cddae43645e259eb4a1dbbbf6757b08e7408f48d339b5737d7773d749e0e", "rustc-1.81.0-aarch64-apple-darwin.tar.gz": "9c3d36b8860011bddec580b12e4b6937aa0657b393e7aeb20f1dc90e743ffa7e", "cargo-1.81.0-aarch64-apple-darwin.tar.gz": "bca2ed0f3b5dec19bd53b0a7d999eb1b495cd5ace69aafa088b44d83f44e3a8d", "llvm-tools-1.81.0-aarch64-apple-darwin.tar.gz": "7b39fb1d477271d1232e704ef47ea5ec7d323c0cbe358c9a3986bdf6ce27ca55", "rust-std-1.81.0-aarch64-apple-darwin.tar.gz": "44809c3b92c7500c64517151f1e3389b32913a35414553395104bc4a0ee35f69", "clippy-1.81.0-aarch64-apple-darwin.tar.gz": "8666f5241c437f7074488c67819d80af8514ac280cc22973c1b15de3086d8dcc", "rustfmt-1.81.0-aarch64-apple-darwin.tar.gz": "e17c1adda089e922376b2cf0ad3844c132cc1fb2225e1e59fe60af164974883a", "2024-09-09/rustfmt-nightly-aarch64-apple-darwin.tar.gz": "7fac724ebc9da0c9ba5b339ac2245d742cd4e6edf08a0261fd59509d9df39334"}
DEBUG: Repository rust_darwin_aarch64__aarch64-apple-darwin__stable_tools instantiated at:
  /Users/rafal/src/capture-sdk/WORKSPACE:64:25: in <toplevel>
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:236:14: in rust_register_toolchains
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/bazel_tools/tools/build_defs/repo/utils.bzl:240:18: in maybe
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:1100:61: in rust_repository_set
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:617:36: in rust_toolchain_repository
Repository rule rust_toolchain_tools_repository defined at:
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:487:50: in <toplevel>
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Using default value for --instrumentation_filter: "^//test/platform/swift/unit_integration[/:]".
INFO: Override the above default with --instrumentation_filter
DEBUG: Rule 'rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256s = {"rust-std-1.81.0-aarch64-apple-ios-sim.tar.gz": "a4bdf0c2ecd0d899629db9ae0e940863da4047f379bec4a969df3f33dce911db", "rust-std-1.81.0-aarch64-apple-ios.tar.gz": "09bd46b2b9297b61dd172da42c9455aaa1c85676715f6b8473b55612c1de10ed", "rust-std-1.81.0-x86_64-apple-ios.tar.gz": "989852a7e82e2a3ad01473a9157ad92f8ff2ebce5300ecb4a716b5987be1bf6b", "rust-std-1.81.0-aarch64-linux-android.tar.gz": "e8bc1c411e60cd8b290afe8bcc903e18ab904efe9782e491ce781f38a19647f0", "rust-std-1.81.0-armv7-linux-androideabi.tar.gz": "84c15635750c1228366189aab6f95d26dcaed6069cac3c1fb3dad2f985952d8a", "rust-std-1.81.0-i686-linux-android.tar.gz": "d205cddae43645e259eb4a1dbbbf6757b08e7408f48d339b5737d7773d749e0e", "rustc-1.81.0-aarch64-apple-darwin.tar.gz": "9c3d36b8860011bddec580b12e4b6937aa0657b393e7aeb20f1dc90e743ffa7e", "cargo-1.81.0-aarch64-apple-darwin.tar.gz": "bca2ed0f3b5dec19bd53b0a7d999eb1b495cd5ace69aafa088b44d83f44e3a8d", "llvm-tools-1.81.0-aarch64-apple-darwin.tar.gz": "7b39fb1d477271d1232e704ef47ea5ec7d323c0cbe358c9a3986bdf6ce27ca55", "rust-std-1.81.0-aarch64-apple-darwin.tar.gz": "44809c3b92c7500c64517151f1e3389b32913a35414553395104bc4a0ee35f69", "clippy-1.81.0-aarch64-apple-darwin.tar.gz": "8666f5241c437f7074488c67819d80af8514ac280cc22973c1b15de3086d8dcc", "rustfmt-1.81.0-aarch64-apple-darwin.tar.gz": "e17c1adda089e922376b2cf0ad3844c132cc1fb2225e1e59fe60af164974883a", "2024-09-09/rustfmt-nightly-aarch64-apple-darwin.tar.gz": "7fac724ebc9da0c9ba5b339ac2245d742cd4e6edf08a0261fd59509d9df39334"}
DEBUG: Repository rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools instantiated at:
  /Users/rafal/src/capture-sdk/WORKSPACE:64:25: in <toplevel>
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:236:14: in rust_register_toolchains
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/bazel_tools/tools/build_defs/repo/utils.bzl:240:18: in maybe
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:1100:61: in rust_repository_set
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:617:36: in rust_toolchain_repository
Repository rule rust_toolchain_tools_repository defined at:
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:487:50: in <toplevel>
ERROR: /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/crate_index__flatbuffers-24.3.25/BUILD.bazel:96:19: in @build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl%coverage_files_aspect aspect on cargo_build_script rule @crate_index__flatbuffers-24.3.25//:_bs: 
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/build_bazel_rules_apple/apple/internal/testing/apple_test_rule_support.bzl", line 77, column 34, in _coverage_files_aspect_impl
                coverage_files.append(dep[_CoverageFilesInfo].coverage_files)
Error: <merged target @crate_index__rustc_version-0.4.0//:rustc_version> (rule 'rust_library') doesn't contain declared provider '_CoverageFilesInfo'
ERROR: Analysis of target '@crate_index__flatbuffers-24.3.25//:_bs' failed
ERROR: Analysis of target '//test/platform/swift/unit_integration:test' failed; build aborted
INFO: Elapsed time: 13.894s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
ERROR: No test targets were found, yet testing was requested
  ```
</details>

The error seems to have been coming from the `//test/platform/swift/bridging:rust_bridge` dependency of the used bazel BUILD target so I tried to limit the number of run tests and their dependencies next.

After I changed a bazel BUILD target to run tests from `ConfigurationTests.swift` file only I started getting following error:

<details>
  <summary>Bazel command output</summary>
  
  ```bash
  RUST_LOG=debug ./bazelw coverage //test/platform/swift/unit_integration:test --verbose_failures --test_output=streamed --combined_report=lcov    
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Using default value for --instrumentation_filter: "^//test/platform/swift/unit_integration[/:]".
INFO: Override the above default with --instrumentation_filter
INFO: Analyzed target //test/platform/swift/unit_integration:test (0 packages loaded, 7 targets configured).
ERROR: /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/crate_index__cfg-if-1.0.0/BUILD.bazel:16:13: Compiling Rust rlib cfg_if v1.0.0 (2 files) failed: (Exit 1): process_wrapper failed: error executing Rustc command (from target @crate_index__cfg-if-1.0.0//:cfg_if) 
  (cd /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/sandbox/darwin-sandbox/30/execroot/__main__ && \
  exec env - \
    CARGO_CFG_TARGET_ARCH=aarch64 \
    CARGO_CFG_TARGET_OS=ios \
    CARGO_CRATE_NAME=cfg_if \
    CARGO_MANIFEST_DIR='${pwd}/external/crate_index__cfg-if-1.0.0' \
    CARGO_PKG_AUTHORS='' \
    CARGO_PKG_DESCRIPTION='' \
    CARGO_PKG_HOMEPAGE='' \
    CARGO_PKG_NAME=cfg_if \
    CARGO_PKG_VERSION=1.0.0 \
    CARGO_PKG_VERSION_MAJOR=1 \
    CARGO_PKG_VERSION_MINOR=0 \
    CARGO_PKG_VERSION_PATCH=0 \
    CARGO_PKG_VERSION_PRE='' \
    REPOSITORY_NAME=crate_index__cfg-if-1.0.0 \
  bazel-out/darwin_arm64-opt-exec-ST-e846b08c7501/bin/external/rules_rust/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' -- bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/rust_toolchain/bin/rustc external/crate_index__cfg-if-1.0.0/src/lib.rs '--crate-name=cfg_if' '--crate-type=rlib' '--error-format=human' '--codegen=metadata=-2241051819' '--codegen=extra-filename=-2241051819' '--out-dir=bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/crate_index__cfg-if-1.0.0' '--codegen=opt-level=0' '--codegen=debuginfo=0' '--codegen=strip=none' '--remap-path-prefix=${pwd}=' '--emit=dep-info,link' '--color=always' '--target=aarch64-apple-ios-sim' -L bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/rust_toolchain/lib/rustlib/aarch64-apple-ios-sim/lib '--cap-lints=allow' '--edition=2018' '--codegen=instrument-coverage' '--sysroot=bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/rust_toolchain')
# Configuration: dcc8e0893655bbec48206eb1893b9ae39bf0a92b9ed958bd3548aa95201588c6
# Execution platform: @local_config_platform//:host

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0463]: can't find crate for `profiler_builtins`
  |
  = note: the compiler may have been built without the profiler runtime

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0463`.
Target //test/platform/swift/unit_integration:test failed to build
INFO: Elapsed time: 1.326s, Critical Path: 0.34s
INFO: 18 processes: 18 internal.
ERROR: Build did NOT complete successfully
//test/platform/swift/unit_integration:test                     FAILED TO BUILD

Executed 0 out of 1 test: 1 fails to build.

  ```
</details>

The above error makes sense since our custom Rust build doesn't include profiling-related symbols. After moving to standard Rust build this is the error I am getting:

<details>
  <summary>Bazel command output</summary>
  
  ```bash
  RUST_LOG=debug ./bazelw coverage //test/platform/swift/unit_integration:test --verbose_failures --test_output=streamed --combined_report=lcov
DEBUG: Rule 'rust_darwin_aarch64__aarch64-apple-darwin__stable_tools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256s = {"rustc-1.81.0-aarch64-apple-darwin.tar.xz": "bed00f549a08030b232ad811728e3a5d7239e2e53b667df9cfb11eabf87f2cf3", "clippy-1.81.0-aarch64-apple-darwin.tar.xz": "fcab64f49cd2fb47f3c9ee96cf31ce178b05be66b7dbc0543c3ea217bd4786bf", "cargo-1.81.0-aarch64-apple-darwin.tar.xz": "cc826e6592016db7a5750a97051b71b48aca2d79f146daf08e953d56000ae43d", "2024-09-09/rustfmt-nightly-aarch64-apple-darwin.tar.xz": "01e7f192a459699dd5caac1ad7a27b3237035925e66864f2c51c01b1271e7774", "llvm-tools-1.81.0-aarch64-apple-darwin.tar.xz": "907aaf74df0dd97a23da03fde3a5162535498e5ab67c0adb6fee22999ca461fb", "rust-std-1.81.0-aarch64-apple-darwin.tar.xz": "2dba5210a79617a9240570c1f7fcc24912a2c96689a3159324727e5a516c6326"}
DEBUG: Repository rust_darwin_aarch64__aarch64-apple-darwin__stable_tools instantiated at:
  /Users/rafal/src/capture-sdk/WORKSPACE:64:25: in <toplevel>
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:236:14: in rust_register_toolchains
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/bazel_tools/tools/build_defs/repo/utils.bzl:240:18: in maybe
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:1100:61: in rust_repository_set
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:617:36: in rust_toolchain_repository
Repository rule rust_toolchain_tools_repository defined at:
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:487:50: in <toplevel>
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Using default value for --instrumentation_filter: "^//test/platform/swift/unit_integration[/:]".
INFO: Override the above default with --instrumentation_filter
DEBUG: Rule 'rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256s = {"rustc-1.81.0-aarch64-apple-darwin.tar.xz": "bed00f549a08030b232ad811728e3a5d7239e2e53b667df9cfb11eabf87f2cf3", "clippy-1.81.0-aarch64-apple-darwin.tar.xz": "fcab64f49cd2fb47f3c9ee96cf31ce178b05be66b7dbc0543c3ea217bd4786bf", "cargo-1.81.0-aarch64-apple-darwin.tar.xz": "cc826e6592016db7a5750a97051b71b48aca2d79f146daf08e953d56000ae43d", "2024-09-09/rustfmt-nightly-aarch64-apple-darwin.tar.xz": "01e7f192a459699dd5caac1ad7a27b3237035925e66864f2c51c01b1271e7774", "llvm-tools-1.81.0-aarch64-apple-darwin.tar.xz": "907aaf74df0dd97a23da03fde3a5162535498e5ab67c0adb6fee22999ca461fb", "rust-std-1.81.0-aarch64-apple-ios-sim.tar.xz": "d7b0c8ae04598940796df6836f63a710914f6ad0ff24a2454f57ef738ca1c6b0"}
DEBUG: Repository rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools instantiated at:
  /Users/rafal/src/capture-sdk/WORKSPACE:64:25: in <toplevel>
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:236:14: in rust_register_toolchains
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/bazel_tools/tools/build_defs/repo/utils.bzl:240:18: in maybe
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:1100:61: in rust_repository_set
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:617:36: in rust_toolchain_repository
Repository rule rust_toolchain_tools_repository defined at:
  /private/var/tmp/_bazel_rafal/f8a6f48f0f5223db4a016a73328045fe/external/rules_rust/rust/repositories.bzl:487:50: in <toplevel>
INFO: Analyzed target //test/platform/swift/unit_integration:test (2 packages loaded, 362 targets configured).
INFO: From Linking test/platform/swift/unit_integration/test.__internal__.__test_bundle_bin:
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[4](22694fbe9949e10a-GCDAProfiling.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[5](22694fbe9949e10a-InstrProfiling.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[6](22694fbe9949e10a-InstrProfilingBuffer.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[7](22694fbe9949e10a-InstrProfilingFile.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[8](22694fbe9949e10a-InstrProfilingMerge.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[9](22694fbe9949e10a-InstrProfilingMergeFile.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[12](22694fbe9949e10a-InstrProfilingPlatformDarwin.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[17](22694fbe9949e10a-InstrProfilingRuntime.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[18](22694fbe9949e10a-InstrProfilingUtil.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[19](22694fbe9949e10a-InstrProfilingValue.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[20](22694fbe9949e10a-InstrProfilingVersionVar.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[21](22694fbe9949e10a-InstrProfilingWriter.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
ld: warning: object file (bazel-out/ios_sim_arm64-fastbuild-ios-sim_arm64-min13.0-applebin_ios-ST-a740a340715d/bin/external/rust_darwin_aarch64__aarch64-apple-ios-sim__stable_tools/lib/rustlib/aarch64-apple-ios-sim/lib/libprofiler_builtins-fb7d612191d56a35.a[22](22694fbe9949e10a-InstrProfilingInternal.o)) was built for newer 'iOS-simulator' version (16.4) than being linked (14.0)
2024-09-12 14:37:55,980 Creating a new simulator:
Name: New-iPhone 13-17.5
OS: iOS 17.5
Type: iPhone 13
2024-09-12 14:37:56,660 Created new simulator B51E32ED-174F-4E2B-B828-39CC16E42521.
2024-09-12 14:37:56,660 Will consider the test as test type Logic Test to run. Because the app under test is not given.
Test Suite 'All tests' started at 2024-09-12 10:37:57.759.
Test Suite 'test.xctest' started at 2024-09-12 10:37:57.760.
Test Suite 'ConfigurationTests' started at 2024-09-12 10:37:57.761.
Test Case '-[test_platform_swift_unit_integration_test_lib.ConfigurationTests testConfigurationDefault]' started.
2024-09-12T14:37:57.777408Z  INFO bd_logger::builder: bitdrift Capture SDK: "0.14.3"    
2024-09-12T14:37:57.788179Z  INFO bd_device: bitdrift Capture device ID: "47f45de6-c470-4484-a7f8-43e50dfdee7d"    
2024-09-12T14:37:57.796963Z  INFO bd_session::fixed: bitdrift Capture initialized with session ID: "4E3A2CF0-E8B9-472C-91F2-B7721A2843BC"    
Test Case '-[test_platform_swift_unit_integration_test_lib.ConfigurationTests testConfigurationDefault]' passed (0.040 seconds).
Test Case '-[test_platform_swift_unit_integration_test_lib.ConfigurationTests testConfigurationSimple]' started.
2024-09-12T14:37:57.800732Z  INFO bd_logger::builder: bitdrift Capture SDK: "0.14.3"    
Test Case '-[test_platform_swift_unit_integration_test_lib.ConfigurationTests testConfigurationSimple]' passed (0.009 seconds).
Test Suite 'ConfigurationTests' passed at 2024-09-12 10:37:57.810.
         Executed 2 tests, with 0 failures (0 unexpected) in 0.049 (0.049) seconds
Test Suite 'test.xctest' passed at 2024-09-12 10:37:57.810.
         Executed 2 tests, with 0 failures (0 unexpected) in 0.049 (0.049) seconds
Test Suite 'All tests' passed at 2024-09-12 10:37:57.810.
         Executed 2 tests, with 0 failures (0 unexpected) in 0.049 (0.050) seconds
2024-09-12T14:37:57.809935Z  INFO bd_device: bitdrift Capture device ID: "b4fca9d5-33a7-4e99-9705-e12ed89fa3ff"    
2024-09-12T14:37:57.811065Z  INFO bd_session::fixed: bitdrift Capture initialized with session ID: "B1FB4CB9-8EA0-4808-9870-42CF1DED0B2F"    
[766 / 767] Testing //test/platform/swift/unit_integration:test; 22s darwin-sandbox
  ```

</details>

In the above bazel command output you can see that bazel appears to be stuck after it's done running all tests from the specified target. I tried to update bazel to 7.3.1 to see whether that would get rid of the "stuck" error but it didn't help.

