### PR TITLE
bring in latest shared-core

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5cf8bb106c7d0a4179bb96fc224d805fcd9983a0d88ac933e83ed5e2e025631f",
+  "checksum": "0777963bba99fc84f627ac1d5a6a5a3b049376d2c767a4f9726b3a64cc9be179",
   "crates": {
     "addr2line 0.22.0": {
       "name": "addr2line",
@@ -1462,7 +1462,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-api"
         }
@@ -1591,7 +1591,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -1720,7 +1720,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -1820,7 +1820,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -1937,7 +1937,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2009,7 +2009,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2065,7 +2065,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-device"
         }
@@ -2149,7 +2149,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-events"
         }
@@ -2218,7 +2218,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -2422,7 +2422,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -2505,7 +2505,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -2621,7 +2621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -2685,7 +2685,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -2761,7 +2761,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-log"
         }
@@ -2845,7 +2845,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -2925,7 +2925,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -2997,7 +2997,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -3053,7 +3053,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -3109,7 +3109,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-logger"
         }
@@ -3318,7 +3318,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-matcher"
         }
@@ -3386,7 +3386,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -3462,7 +3462,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -3527,7 +3527,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -3622,7 +3622,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-proto"
         }
@@ -3725,7 +3725,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -3806,7 +3806,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -3878,7 +3878,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -3970,7 +3970,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-session"
         }
@@ -4066,7 +4066,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -4118,7 +4118,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -4157,7 +4157,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -4314,7 +4314,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-time"
         }
@@ -4383,7 +4383,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "f311f7472c80cbbd0047ca4657862cbf746f9111"
+            "Rev": "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
           },
           "strip_prefix": "bd-workflows"
         }
@@ -4460,6 +4460,10 @@
             {
               "id": "bd-stats-common 1.0.0",
               "target": "bd_stats_common"
+            },
+            {
+              "id": "bd-time 1.0.0",
+              "target": "bd_time"
             },
             {
               "id": "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -312,7 +312,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -336,7 +336,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "log",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -377,7 +377,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -426,7 +426,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -475,7 +475,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "base64",
@@ -490,7 +490,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -617,7 +617,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "base64",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "log",
  "protobuf",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "log",
  "tokio",
@@ -744,12 +744,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f311f7472c80cbbd0047ca4657862cbf746f9111#f311f7472c80cbbd0047ca4657862cbf746f9111"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77#3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -811,6 +811,7 @@ dependencies = [
  "bd-runtime",
  "bd-shutdown",
  "bd-stats-common",
+ "bd-time",
  "bincode",
  "itertools 0.13.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,25 +17,25 @@ android_logger = { version = "0.14.1", default-features = false }
 anyhow = "1.0.86"
 assert_matches = "1.5.0"
 async-trait = "0.1.82"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111", default-features = false }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f311f7472c80cbbd0047ca4657862cbf746f9111" }
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77", default-features = false }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3b3b0d832bc4c4e908ddde1f2fd18d1ca1d39c77" }
 chrono = "0.4.38"
 clap = { version = "4.5.16", features = ["derive", "env"] }
 ctor = "0.2.8"


### PR DESCRIPTION
This brings in a change that allows dropping old logs during buffer flush depending on a runtime value 