### PR TITLE
ci: re-enable android emulator tests

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -94,7 +94,7 @@ jobs:
     - name: Checkout project sources
       uses: actions/checkout@v4
 
-      # See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+    # See https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
     - name: Enable KVM group perms
       run: |
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
It seems that Google has pushed a new `beta` version of the Android emulator. Moving us to a `stable` release channel to fix the issue (and reduce the number of possible breakages like that in general).