### PR TITLE
[andr][releases] Include sources.jar artifact in maven releases

### DIFF
--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -64,6 +64,7 @@ function release_capture_sdk() {
       "$sdk_repo/ci/NOTICE.txt" \
       "$name.pom" \
       "$name-javadoc.jar" \
+      "$name-sources.jar" \      
       "$name-symbols.tar" \
       "$name-dylib.tar" \
       "$name.aar" \
@@ -95,6 +96,7 @@ function release_capture_timber() {
       "$sdk_repo/ci/NOTICE.txt" \
       "$name.pom" \
       "$name-javadoc.jar" \
+      "$name-sources.jar" \      
       "$name.module" \
       "$name.aar" \
     )


### PR DESCRIPTION
Since the source is now available we should include the sources jar for ease of development and debugging on consumer apps.