### PR TITLE
ci: fix sha generation

### DIFF
--- a/ci/checksum.sh
+++ b/ci/checksum.sh
@@ -5,28 +5,28 @@ set -euo pipefail
 function create_MD5_file() {
   local -r file="$1"
   echo "+ Generating MD5 checksum for $file"
-  "$(md5sum "$file" | awk '{print $1}')" > "$file.md5"
+  md5sum "$file" | awk '{print $1}' > "$file.md5"
   cat "$file.md5"
 }
 
 function create_SHA1_file() {
   local -r file="$1"
   echo "+ Generating SHA-1 checksum for $file"
-  "$(sha1sum "$file" | awk '{print $1}')" > "$file.sha1"
+  sha1sum "$file" | awk '{print $1}' > "$file.sha1"
   cat "$file.sha1"
 }
 
 function create_SHA256_file() {
   local -r file="$1"
   echo "+ Generating SHA256 checksum for $file"
-  "$(shasum -a 256 "$file" | awk '{print $1}')" > "$file.sha256"
+  shasum -a 256 "$file" | awk '{print $1}' > "$file.sha256"
   cat "$file.sha256"
 }
 
 function create_SHA512_file() {
   local -r file="$1"
   echo "+ Generating SHA512 checksum for $file"
-  "$(shasum -a 512 "$file" | awk '{print $1}')" > "$file.sha512"
+  shasum -a 512 "$file" | awk '{print $1}' > "$file.sha512"
   cat "$file.sha512"
 }
 


### PR DESCRIPTION
Fix the release job failure. I blame recent shell linter introduction. 🙃 

The release CI job failed with:

```bash
/home/runner/work/capture-sdk/capture-sdk/ci/checksum.sh: line 8: fd30aa0639f1db55beecc5988e61226b: command not found
```

Link https://github.com/bitdriftlabs/capture-sdk/actions/runs/11237468246/job/31240684620