### PR TITLE
Use objcopy instead of dump for symbols

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -104,7 +104,7 @@ android_debug_info(
 genrule(
     name = "capture_symbols",
     srcs = [
-        ":capture_aar_objdump_collector",
+        ":capture_aar_symbols_collector",
     ],
     outs = ["symbols.tar"],
     cmd = """

--- a/bazel/android/artifacts.bzl
+++ b/bazel/android/artifacts.bzl
@@ -63,9 +63,9 @@ def android_artifacts(name, android_library, manifest, archive_name, native_deps
     aar_output = _create_aar(name, classes_jar, jni_archive, proguard_rules, manifest, visibility)
 
     native.filegroup(
-        name = name + "_objdump_collector",
+        name = name + "_symbols_collector",
         srcs = native_deps,
-        output_group = "objdump",
+        output_group = "objcopy",
         visibility = ["//visibility:public"],
     )
 


### PR DESCRIPTION
Fixes BIT-3752