### PR TITLE
ios: fix passing of file, line, and function arguments

### DIFF
--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -240,9 +240,9 @@ public final class Logger {
     func log(
         level: LogLevel,
         message: @autoclosure () -> String,
-        file _: String? = #file,
-        line _: Int? = #line,
-        function _: String? = #function,
+        file: String? = #file,
+        line: Int? = #line,
+        function: String? = #function,
         fields: Fields? = nil,
         matchingFields: Fields? = nil,
         error: Error? = nil,
@@ -252,6 +252,9 @@ public final class Logger {
         self.underlyingLogger.log(
             level: level,
             message: message(),
+            file: file,
+            line: line,
+            function: function,
             fields: fields,
             matchingFields: matchingFields,
             error: error,

--- a/test/platform/swift/unit_integration/core/LoggerTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerTests.swift
@@ -162,6 +162,11 @@ final class LoggerTests: XCTestCase {
         XCTAssertEqual(bridge.logs.count, 1)
         let log = bridge.logs[0]
 
+        var logFields = try XCTUnwrap(log.fields?.toDictionary())
+        XCTAssertNotNil(logFields.removeValue(forKey: "_file"))
+        XCTAssertNotNil(logFields.removeValue(forKey: "_line"))
+        XCTAssertNotNil(logFields.removeValue(forKey: "_function"))
+
         XCTAssertEqual(log.level, .debug)
         XCTAssertEqual(log.message, "test")
         self.assertEqual(
@@ -170,7 +175,7 @@ final class LoggerTests: XCTestCase {
                 "_error_details": String(describing: error),
                 "foo": "bar",
             ],
-            try XCTUnwrap(log.fields)
+            logFields
         )
     }
 
@@ -198,6 +203,11 @@ final class LoggerTests: XCTestCase {
         XCTAssertEqual(bridge.logs.count, 1)
         let log = bridge.logs[0]
 
+        var logFields = try log.fields?.toDictionary()
+        XCTAssertNotNil(logFields?.removeValue(forKey: "_file"))
+        XCTAssertNotNil(logFields?.removeValue(forKey: "_line"))
+        XCTAssertNotNil(logFields?.removeValue(forKey: "_function"))
+
         XCTAssertEqual(log.message, "HTTPRequest")
         XCTAssertEqual(log.level, .debug)
         XCTAssertEqual(log.type, .span)
@@ -208,7 +218,7 @@ final class LoggerTests: XCTestCase {
             "_span_id": requestInfo.spanID,
             "_query": "bar",
             "foo": "bar",
-        ], try XCTUnwrap(log.fields?.toDictionary()))
+        ], logFields)
         XCTAssertTrue(try XCTUnwrap(log.matchingFields?.toDictionary()).isEmpty)
     }
 
@@ -247,6 +257,11 @@ final class LoggerTests: XCTestCase {
         XCTAssertEqual(bridge.logs.count, 1)
         let log = bridge.logs[0]
 
+        var logFields = try log.fields?.toDictionary()
+        XCTAssertNotNil(logFields?.removeValue(forKey: "_file"))
+        XCTAssertNotNil(logFields?.removeValue(forKey: "_line"))
+        XCTAssertNotNil(logFields?.removeValue(forKey: "_function"))
+
         XCTAssertEqual(log.message, "HTTPResponse")
         XCTAssertEqual(log.level, .debug)
         XCTAssertEqual(log.type, .span)
@@ -260,7 +275,7 @@ final class LoggerTests: XCTestCase {
             "_status_code": "200",
             "_query": "bar",
             "foo": "bar",
-        ], try log.fields?.toDictionary())
+        ], logFields)
         XCTAssertEqual([
             "_request.foo": "bar",
             "_request._host": "api.bitdrift.io",

--- a/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
+++ b/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
@@ -33,7 +33,8 @@ extension UploadedLog {
             $0.key < $1.key
         })
 
-        let sortedSelf = self.fields.sorted(by: { $0.key < $1.key })
+        var sortedSelf = self.fields.sorted(by: { $0.key < $1.key })
+        sortedSelf.removeAll { ["_file", "_line", "_function"].contains($0.key) }
 
         XCTAssertEqual(fields, sortedSelf)
     }


### PR DESCRIPTION
Fixes an issue where the information about file, line, and function was not properly propagated.