### PR TITLE
Revert portion of "[Andr][CI] Pom improvements (#103)"

### DIFF
--- a/platform/jvm/capture-timber/build.gradle.kts
+++ b/platform/jvm/capture-timber/build.gradle.kts
@@ -121,6 +121,6 @@ publishing {
 }
 
 // TODO(murki): Using this requires further setup in CI and local (e.g. signing entries in the local gradle.properties file)
-signing {
-    sign(publishing.publications)
-}
+// signing {
+//     sign(publishing.publications)
+// }


### PR DESCRIPTION
This reverts commit 0d1a73628b510e31d0e2f7526c25a71e663e3950.

Reverting https://github.com/bitdriftlabs/capture-sdk/pull/103 as it caused release failure. Example https://github.com/bitdriftlabs/capture-sdk/actions/runs/11725381311/job/32661563447