### PR TITLE
android, session replay: fix session replay compose view parsing

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
@@ -46,8 +46,10 @@ internal class SessionReplayTarget(
     )
 
     override fun captureScreen() {
-        val skipReplayComposeViews = !(runtime?.isEnabled(RuntimeFeature.SESSION_REPLAY_COMPOSE)
-            ?: RuntimeFeature.SESSION_REPLAY_COMPOSE.defaultValue)
+        val skipReplayComposeViews = !(
+            runtime?.isEnabled(RuntimeFeature.SESSION_REPLAY_COMPOSE)
+                ?: RuntimeFeature.SESSION_REPLAY_COMPOSE.defaultValue
+            )
         replayModule.captureScreen(skipReplayComposeViews)
     }
 


### PR DESCRIPTION
The condition was flipped by accident in https://github.com/bitdriftlabs/capture-sdk/pull/93