### PR TITLE
ios: fix compilation of replay example app

### DIFF
--- a/platform/swift/source/replay/Replay.swift
+++ b/platform/swift/source/replay/Replay.swift
@@ -13,7 +13,7 @@ private let kIgnoredWindows = Set(["UIRemoteKeyboardWindow"])
 
 /// Main replay logic. This class can traverse UIWindow(s) as well as serialize view informations into a
 /// byte array.
-final class Replay {
+package final class Replay {
     /// The last known rendering time, expressed in seconds.
     private(set) var renderTime: CFAbsoluteTime = 0
 


### PR DESCRIPTION
Fixes a compilation issue from https://github.com/bitdriftlabs/capture-sdk/actions/runs/11727054780/job/32667231774