### PR TITLE
[andr][replay] Handle hybrid AndroidViews inside Compose

### DIFF
--- a/platform/jvm/gradle-test-app/src/androidTest/java/io/bitdrift/gradletestapp/ComposeReplayTest.kt
+++ b/platform/jvm/gradle-test-app/src/androidTest/java/io/bitdrift/gradletestapp/ComposeReplayTest.kt
@@ -8,6 +8,7 @@
 package io.bitdrift.gradletestapp
 
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.TextView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
@@ -324,9 +325,9 @@ class ComposeReplayTest {
                 Column {
                     AndroidView(::TextView) {
                         it.layoutParams = ViewGroup.LayoutParams(200, 80)
-                        it.text = "Baguette Avec Fromage"
+                        it.text = "hi"
                     }
-                    AndroidView(::TextView) {
+                    AndroidView(::Button) {
                         it.layoutParams = ViewGroup.LayoutParams(200, 80)
                         it.text = "short"
                     }
@@ -337,12 +338,10 @@ class ComposeReplayTest {
         val capture = verifyReplayScreen(viewCount = 10)
         // Column
         assertThat(capture).contains(ReplayRect(ReplayType.View, 0, 88, 200, 160))
-        // AndroidView Top
-        // TODO(murki): The ReplayRect should be a Label
-        assertThat(capture).contains(ReplayRect(ReplayType.View, 0, 88, 200, 80))
-        // AndroidView Bottom
-        // TODO(murki): The ReplayRect should be a Label
-        assertThat(capture).contains(ReplayRect(ReplayType.View, 0, 168, 200, 80))
+        // AndroidView w/TextView Top (width reflects the text length
+        assertThat(capture).contains(ReplayRect(ReplayType.Label, 3, 88, 33, 37))
+        // AndroidView w/Button Bottom
+        assertThat(capture).contains(ReplayRect(ReplayType.Button, 0, 168, 200, 80))
     }
 
     @Test

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/ScannableView.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/ScannableView.kt
@@ -29,7 +29,7 @@ internal sealed class ScannableView {
     /** The children of this view. */
     abstract val children: Sequence<ScannableView>
 
-    class AndroidView(val view: View, private val skipReplayComposeViews: Boolean) : ScannableView() {
+    class AndroidView(val view: View, skipReplayComposeViews: Boolean) : ScannableView() {
         override val displayName: String get() = view::class.java.simpleName
         override val children: Sequence<ScannableView> =
             view.scannableChildren(skipReplayComposeViews)


### PR DESCRIPTION
This took an embarrassingly long time to figure out, but after following the rabbit hole in https://github.com/androidx/androidx/blob/48f6421f6615572456ee94984209cd110a4694d4/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/accessibility/android_a11y_implementation_notes.md#androidview-children I realized that the Compose LayoutNode has an (internal) reference to the legacy AndroidView if it exists.

In the example below we're creating an hybrid view via: https://github.com/bitdriftlabs/capture-sdk/blob/f6edcc166a5f4bb1c9a5c6e1d2f6bcc1ddf89c1f/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ComposeScreen.kt#L82-L91


|Screen|Before|After|
|---|---|---|
|<img width="277" alt="Screenshot 2024-11-18 at 10 52 38 AM" src="https://github.com/user-attachments/assets/0604228b-e014-4332-a4bf-f7b2213a9128">|<img width="311" alt="Screenshot 2024-11-18 at 10 52 51 AM" src="https://github.com/user-attachments/assets/90365e80-5dad-40ec-a43a-d8b1980b8775">|<img width="301" alt="Screenshot 2024-11-18 at 10 52 59 AM" src="https://github.com/user-attachments/assets/6c567d99-c6bf-419d-aefa-6f425c6e7877">|