### PR TITLE
[andr][replay] Add support for ignoring Compose elements via Modifiers

### DIFF
--- a/platform/jvm/gradle-test-app/src/androidTest/java/io/bitdrift/gradletestapp/ComposeReplayTest.kt
+++ b/platform/jvm/gradle-test-app/src/androidTest/java/io/bitdrift/gradletestapp/ComposeReplayTest.kt
@@ -45,6 +45,7 @@ import com.google.common.truth.Truth.assertThat
 import io.bitdrift.capture.replay.ReplayCaptureMetrics
 import io.bitdrift.capture.replay.ReplayPreviewClient
 import io.bitdrift.capture.replay.ReplayType
+import io.bitdrift.capture.replay.compose.CaptureModifier.captureIgnore
 import io.bitdrift.capture.replay.internal.FilteredCapture
 import io.bitdrift.capture.replay.internal.ReplayRect
 import org.junit.Before
@@ -315,7 +316,49 @@ class ComposeReplayTest {
 
         val capture = verifyReplayScreen(viewCount = 13)
         assertThat(capture).contains(ReplayRect(ReplayType.Button, 0, 109, 351, 126))
+        assertThat(capture).contains(ReplayRect(ReplayType.Label, 28, 144, 295, 57))
         assertThat(capture).contains(ReplayRect(ReplayType.Button, 0, 277, 224, 126))
+        assertThat(capture).contains(ReplayRect(ReplayType.Label, 45, 312, 135, 57))
+    }
+
+    @Test
+    fun textButtonIgnoreOneButtonOnly() {
+        composeRule.setContentWithExplicitRoot {
+            Column(Modifier.wrapContentWidth()) {
+                TextButton(onClick = {}) {
+                    Text("Button Text")
+                }
+                TextButton(onClick = {}, modifier = Modifier.captureIgnore(ignoreSubTree = false)) {
+                    Text("short")
+                }
+            }
+        }
+
+        val capture = verifyReplayScreen(viewCount = 13)
+        assertThat(capture).contains(ReplayRect(ReplayType.Button, 0, 109, 351, 126))
+        assertThat(capture).contains(ReplayRect(ReplayType.Label, 28, 144, 295, 57))
+        assertThat(capture).doesNotContain(ReplayRect(ReplayType.Button, 0, 277, 224, 126))
+        assertThat(capture).contains(ReplayRect(ReplayType.Label, 45, 312, 135, 57))
+    }
+
+    @Test
+    fun textButtonIgnoreOneFullTextButton() {
+        composeRule.setContentWithExplicitRoot {
+            Column(Modifier.wrapContentWidth()) {
+                TextButton(onClick = {}) {
+                    Text("Button Text")
+                }
+                TextButton(onClick = {}, modifier = Modifier.captureIgnore(ignoreSubTree = true)) {
+                    Text("short")
+                }
+            }
+        }
+
+        val capture = verifyReplayScreen(viewCount = 13)
+        assertThat(capture).contains(ReplayRect(ReplayType.Button, 0, 109, 351, 126))
+        assertThat(capture).contains(ReplayRect(ReplayType.Label, 28, 144, 295, 57))
+        assertThat(capture).doesNotContain(ReplayRect(ReplayType.Button, 0, 277, 224, 126))
+        assertThat(capture).doesNotContain(ReplayRect(ReplayType.Label, 45, 312, 135, 57))
     }
 
     @Test

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ComposeScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ComposeScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.text.HtmlCompat
-import io.bitdrift.capture.replay.internal.compose.CaptureModifier.captureIgnore
+import io.bitdrift.capture.replay.compose.CaptureModifier.captureIgnore
 import timber.log.Timber
 
 @Composable

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ComposeScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ComposeScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.text.HtmlCompat
-import io.bitdrift.capture.Capture
+import io.bitdrift.capture.replay.internal.compose.CaptureModifier.captureIgnore
 import timber.log.Timber
 
 @Composable
@@ -62,7 +62,7 @@ fun SecondScreen() {
             )
             ElevatedButton(
                 onClick = { Timber.w("Warning logged from Compose Screen") },
-                modifier = centerWithPaddingModifier.padding(top = normalSpacing)
+                modifier = centerWithPaddingModifier.padding(top = normalSpacing).captureIgnore(ignoreSubTree = false)
             ) {
                 Text("Log-a-log (Warning)")
             }

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/compose/CaptureModifier.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/compose/CaptureModifier.kt
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-package io.bitdrift.capture.replay.internal.compose
+package io.bitdrift.capture.replay.compose
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsPropertyKey

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/compose/CaptureModifier.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/compose/CaptureModifier.kt
@@ -11,15 +11,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
 
+/**
+ * Compose Modifiers exposed by the Capture SDK.
+ */
 object CaptureModifier {
 
-    val CaptureIgnore = SemanticsPropertyKey<Boolean>(
+    internal val CaptureIgnore = SemanticsPropertyKey<Boolean>(
         name = "CaptureIgnoreModifier",
         mergePolicy = { parentValue, _ ->
             parentValue
         },
     )
 
+    /**
+     * Semantic Modifier that can be used to ignore elements of the Compose tree from being captured by Session Replay.
+     */
     @JvmStatic
     fun Modifier.captureIgnore(ignoreSubTree: Boolean = false): Modifier {
         return semantics(

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/CaptureModifier.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/CaptureModifier.kt
@@ -1,3 +1,10 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 package io.bitdrift.capture.replay.internal.compose
 
 import androidx.compose.ui.Modifier
@@ -10,7 +17,7 @@ object CaptureModifier {
         name = "CaptureIgnoreModifier",
         mergePolicy = { parentValue, _ ->
             parentValue
-        }
+        },
     )
 
     @JvmStatic
@@ -18,7 +25,7 @@ object CaptureModifier {
         return semantics(
             properties = {
                 this[CaptureIgnore] = ignoreSubTree
-            }
+            },
         )
     }
 }

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/CaptureModifier.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/CaptureModifier.kt
@@ -1,0 +1,24 @@
+package io.bitdrift.capture.replay.internal.compose
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.semantics
+
+object CaptureModifier {
+
+    val CaptureIgnore = SemanticsPropertyKey<Boolean>(
+        name = "CaptureIgnoreModifier",
+        mergePolicy = { parentValue, _ ->
+            parentValue
+        }
+    )
+
+    @JvmStatic
+    fun Modifier.captureIgnore(ignoreSubTree: Boolean = false): Modifier {
+        return semantics(
+            properties = {
+                this[CaptureIgnore] = ignoreSubTree
+            }
+        )
+    }
+}

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/ComposeTreeParser.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/ComposeTreeParser.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.toSize
 import io.bitdrift.capture.replay.ReplayType
 import io.bitdrift.capture.replay.SessionReplayController
+import io.bitdrift.capture.replay.compose.CaptureModifier
 import io.bitdrift.capture.replay.internal.ReplayRect
 import io.bitdrift.capture.replay.internal.ScannableView
 


### PR DESCRIPTION
|(current)|`captureIgnore(ignoreSubTree = false)`|`captureIgnore(ignoreSubTree = true)`|
|---|---|---|
|![Screenshot 2024-11-20 at 7 15 46 PM](https://github.com/user-attachments/assets/96877f91-4507-4d41-ab45-09c727f0c286)|![Screenshot 2024-11-20 at 7 14 32 PM](https://github.com/user-attachments/assets/8ca9d38d-d81f-4741-85df-c8b6bd2154cb)|![Screenshot 2024-11-20 at 7 14 44 PM](https://github.com/user-attachments/assets/c9702f8a-8a30-432b-b445-ef4f8d6a38f4)|