### PR TITLE
Run ResourceUtilization log processor on the correct 'event-listener' thread

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTarget.kt
@@ -29,7 +29,7 @@ internal class ResourceUtilizationTarget(
 ) : IResourceUtilizationTarget {
 
     override fun tick() {
-        executor.run {
+        executor.execute {
             try {
                 val start = clock.elapsedRealtime()
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -314,9 +314,6 @@ class CaptureLoggerTest {
         val sdkConfigured = CaptureTestJniLibrary.nextUploadedLog()
         assertThat(sdkConfigured.message).isEqualTo("SDKConfigured")
 
-        val resourceLog = CaptureTestJniLibrary.nextUploadedLog()
-        assertThat(resourceLog.message).isEqualTo("")
-
         val log = CaptureTestJniLibrary.nextUploadedLog()
         assertThat(log.level).isEqualTo(LogLevel.DEBUG.value)
         assertThat(log.message).isEqualTo("test log")


### PR DESCRIPTION
Fixing what looks like a typo