### PR TITLE
wire up release of the gradle plugin marker

### DIFF
--- a/.github/workflows/integrations_android.yaml
+++ b/.github/workflows/integrations_android.yaml
@@ -77,3 +77,9 @@ jobs:
         name: capture-plugin-${{ inputs.version }}.android.zip
         path: platform/jvm/capture-plugin-${{ inputs.version }}.android.zip
         if-no-files-found: error
+    - name: Upload Gradle Plugin marker
+      uses: actions/upload-artifact@v4
+      with:
+        name: capture-plugin-marker-${{ inputs.version }}.android.zip
+        path: platform/jvm/capture-plugin-marker-${{ inputs.version }}.android.zip
+        if-no-files-found: error

--- a/.github/workflows/integrations_android.yaml
+++ b/.github/workflows/integrations_android.yaml
@@ -54,7 +54,11 @@ jobs:
     - name: Compress Android Plugin artifacts
       run: |
         readonly dir=$(pwd)
-        (cd capture-plugin/build/repos/releases/io/bitdrift/capture-plugin/${{ inputs.version }} && zip -r "$dir/capture-plugin-${{ inputs.version }}.android.zip" ./*)        
+        (cd capture-plugin/build/repos/releases/io/bitdrift/capture-plugin/${{ inputs.version }} && zip -r "$dir/capture-plugin-${{ inputs.version }}.android.zip" ./*)
+    - name: Compress Android Plugin marker artifacts
+      run: |
+        readonly dir=$(pwd)
+        (cd capture-plugin/build/repos/releases/io/bitdrift/capture-plugin/io.bitdrift.capture-plugin.gradle.plugin/${{ inputs.version }} && zip -r "$dir/capture-plugin-marker-${{ inputs.version }}.android.zip" ./*)
     - name: Upload Timber artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -151,14 +151,7 @@ jobs:
       sha: ${{ inputs.sha }}
     secrets: inherit
   build-android-integrations:
-<<<<<<< Updated upstream
     name: Build Android Integrations
-||||||| Stash base
-  build-android-capture-timber:
-    name: Build Capture Timber
-=======
-    name: Build Capture Integrations
->>>>>>> Stashed changes
     needs: ["verify-version"]
     permissions:
       contents: write

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -151,7 +151,14 @@ jobs:
       sha: ${{ inputs.sha }}
     secrets: inherit
   build-android-integrations:
+<<<<<<< Updated upstream
     name: Build Android Integrations
+||||||| Stash base
+  build-android-capture-timber:
+    name: Build Capture Timber
+=======
+    name: Build Capture Integrations
+>>>>>>> Stashed changes
     needs: ["verify-version"]
     permissions:
       contents: write
@@ -211,6 +218,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: capture-plugin-${{ inputs.version }}.android.zip
+      - uses: actions/download-artifact@v4
+        with:
+          name: capture-plugin-marker-${{ inputs.version }}.android.zip
       - name: Prepare Android artifacts
         run: ./ci/gh_prepare_android_artifacts.sh "$VERSION"
         env:
@@ -240,8 +250,9 @@ jobs:
             "example-apps.ios.zip" \
             "example-apps.android.zip" \
             "capture-timber-$VERSION.android.zip" \
-            "capture-apollo3-$VERSION.android.zip" \
-            "capture-plugin-$VERSION.android.zip"
+            "capture-apollo3-$VERSION.android.zip" \            
+            "capture-plugin-$VERSION.android.zip" \
+            "capture-plugin-marker-$VERSION.android.zip"
         env:
           VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -211,7 +211,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: capture-plugin-${{ inputs.version }}.android.zip
-      - uses: actions/download-artifact@v4
+      - name: Download Android Plugin Marker
+        uses: actions/download-artifact@v4
         with:
           name: capture-plugin-marker-${{ inputs.version }}.android.zip
       - name: Prepare Android artifacts

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -244,7 +244,7 @@ jobs:
             "example-apps.ios.zip" \
             "example-apps.android.zip" \
             "capture-timber-$VERSION.android.zip" \
-            "capture-apollo3-$VERSION.android.zip" \            
+            "capture-apollo3-$VERSION.android.zip" \
             "capture-plugin-$VERSION.android.zip" \
             "capture-plugin-marker-$VERSION.android.zip"
         env:

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -92,7 +92,6 @@ jobs:
         gh release download "v$VERSION" -p 'capture-timber*.android.zip'
         gh release download "v$VERSION" -p 'capture-apollo3*.android.zip'
         gh release download "v$VERSION" -p 'capture-plugin*.android.zip'
-        gh release download "v$VERSION" -p 'capture-plugin-marker*.android.zip'
       env:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -96,5 +96,5 @@ jobs:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Android Artifacts to aws bucket
-      run: ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "capture-timber-${{ inputs.version }}.android.zip" "capture-apollo3-${{ inputs.version }}.android.zip" "capture-plugin-${{ inputs.version }}.android.zip"
+      run: ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "capture-timber-${{ inputs.version }}.android.zip" "capture-apollo3-${{ inputs.version }}.android.zip" "capture-plugin-${{ inputs.version }}.android.zip" "capture-plugin-marker-${{ inputs.version }}.android.zip"
 

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -92,6 +92,7 @@ jobs:
         gh release download "v$VERSION" -p 'capture-timber*.android.zip'
         gh release download "v$VERSION" -p 'capture-apollo3*.android.zip'
         gh release download "v$VERSION" -p 'capture-plugin*.android.zip'
+        gh release download "v$VERSION" -p 'capture-plugin-marker*.android.zip'
       env:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -123,7 +123,6 @@ function release_gradle_plugin() {
 
     generate_maven_file "$remote_location_prefix" "$plugin_marker"
     popd
-
 }
 
 release_capture_sdk

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -111,17 +111,17 @@ function release_gradle_plugin() {
 
   echo "+++ dl.bitdrift.io Android Integration plugin $plugin_name / $plugin_marker artifacts upload"
 
-  local -r remote_location_prefix="$remote_location_root_prefix/$library_name"
+  local -r remote_location_prefix="$remote_location_root_prefix/$plugin_name/$plugin_marker"
 
   pushd "$(mktemp -d)"
     unzip -o "$archive"
 
-    aws s3 cp "$sdk_repo/ci/LICENSE.txt" "$remote_location_prefix//$version/LICENSE.txt" --region us-east-1
+    aws s3 cp "$sdk_repo/ci/LICENSE.txt" "$remote_location_prefix/$version/LICENSE.txt" --region us-east-1
     aws s3 cp "$sdk_repo/ci/NOTICE.txt" "$remote_location_prefix/$version/NOTICE.txt" --region us-east-1
 
     aws s3 cp . "$remote_location_prefix/$version/" --recursive --region us-east-1
 
-    generate_maven_file "$remote_location_root_prefix/$plugin_name" "$plugin_name"
+    generate_maven_file "$remote_location_prefix" "$plugin_marker"
     popd
 
 }

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -114,7 +114,7 @@ function release_gradle_plugin() {
   local -r remote_location_prefix="$remote_location_root_prefix/$plugin_name/$plugin_marker"
 
   pushd "$(mktemp -d)"
-    unzip -o "$archive"
+    unzip -o "$sdk_repo/$archive"
 
     aws s3 cp "$sdk_repo/ci/LICENSE.txt" "$remote_location_prefix/$version/LICENSE.txt" --region us-east-1
     aws s3 cp "$sdk_repo/ci/NOTICE.txt" "$remote_location_prefix/$version/NOTICE.txt" --region us-east-1

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -11,6 +11,7 @@ readonly capture_archive="$2"
 readonly capture_timber_archive="$3"
 readonly capture_apollo3_archive="$4"
 readonly capture_plugin_archive="$5"
+readonly capture_plugin_archive="$6"
 
 function upload_file() {
   local -r location="$1"
@@ -103,7 +104,30 @@ function release_gradle_library() {
   popd
 }
 
+function release_gradle_plugin() {
+  local -r plugin_name="$1"
+  local -r plugin_marker="$2"
+  local -r archive="$3"
+
+  echo "+++ dl.bitdrift.io Android Integration plugin $plugin_name / $plugin_marker artifacts upload"
+
+  local -r remote_location_prefix="$remote_location_root_prefix/$library_name"
+
+  pushd "$(mktemp -d)"
+    unzip -o "$archive"
+
+    aws s3 cp "$sdk_repo/ci/LICENSE.txt" "$remote_location_prefix//$version/LICENSE.txt" --region us-east-1
+    aws s3 cp "$sdk_repo/ci/NOTICE.txt" "$remote_location_prefix/$version/NOTICE.txt" --region us-east-1
+
+    aws s3 cp . "$remote_location_prefix/$version/" --recursive --region us-east-1
+
+    generate_maven_file "$remote_location_root_prefix/$plugin_name" "$plugin_name"
+    popd
+
+}
+
 release_capture_sdk
 release_gradle_library "capture-timber" "$capture_timber_archive"
 release_gradle_library "capture-apollo3" "$capture_apollo3_archive"
 release_gradle_library "capture-plugin" "$capture_plugin_archive"
+release_gradle_plugin "capture-plugin" "io.bitdrift.capture-plugin.gradle.plugin" "$capture_plugin_archive"

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -11,7 +11,7 @@ readonly capture_archive="$2"
 readonly capture_timber_archive="$3"
 readonly capture_apollo3_archive="$4"
 readonly capture_plugin_archive="$5"
-readonly capture_plugin_archive="$6"
+readonly capture_plugin_marker_archive="$6"
 
 function upload_file() {
   local -r location="$1"
@@ -130,4 +130,4 @@ release_capture_sdk
 release_gradle_library "capture-timber" "$capture_timber_archive"
 release_gradle_library "capture-apollo3" "$capture_apollo3_archive"
 release_gradle_library "capture-plugin" "$capture_plugin_archive"
-release_gradle_plugin "capture-plugin" "io.bitdrift.capture-plugin.gradle.plugin" "$capture_plugin_archive"
+release_gradle_plugin "capture-plugin" "io.bitdrift.capture-plugin.gradle.plugin" "$capture_plugin_marker_archive"


### PR DESCRIPTION
The gradle plugin requires an additional artifact to be uploaded in order to get picked up by gradle