### PR TITLE
bump shared-core to bring in delay timer fixes

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "da00403ae9ee2b11be463221b01b2eba9af585b8539b2b571c1a1016e4fab2be",
+  "checksum": "0cf5e385dab731db5a205286de7e000edc540d2cb8fd388efde517e5fb9913a6",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -570,6 +570,78 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "async-compression 0.4.18": {
+      "name": "async-compression",
+      "version": "0.4.18",
+      "package_url": "https://github.com/Nullus157/async-compression",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/async-compression/0.4.18/download",
+          "sha256": "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "async_compression",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "async_compression",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "flate2",
+            "tokio",
+            "zlib"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "flate2 1.0.35",
+              "target": "flate2"
+            },
+            {
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
+            },
+            {
+              "id": "memchr 2.7.4",
+              "target": "memchr"
+            },
+            {
+              "id": "pin-project-lite 0.2.15",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "tokio 1.42.0",
+              "target": "tokio"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.4.18"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "async-trait 0.1.83": {
       "name": "async-trait",
       "version": "0.1.83",
@@ -832,7 +904,7 @@
               "target": "tokio"
             },
             {
-              "id": "tower 0.5.1",
+              "id": "tower 0.5.2",
               "target": "tower"
             },
             {
@@ -1337,7 +1409,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-api"
         }
@@ -1474,7 +1546,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -1561,7 +1633,7 @@
               "target": "static_assertions"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -1603,7 +1675,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -1674,7 +1746,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -1707,7 +1779,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -1824,7 +1896,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -1871,7 +1943,7 @@
               "target": "sketches_rust"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -1896,7 +1968,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-completion"
         }
@@ -1952,7 +2024,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-device"
         }
@@ -2036,7 +2108,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-events"
         }
@@ -2105,7 +2177,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -2232,11 +2304,19 @@
               "target": "protobuf"
             },
             {
+              "id": "serde 1.0.215",
+              "target": "serde"
+            },
+            {
+              "id": "serde_json 1.0.133",
+              "target": "serde_json"
+            },
+            {
               "id": "snap 1.1.1",
               "target": "snap"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -2252,8 +2332,12 @@
               "target": "tokio_stream"
             },
             {
-              "id": "tower 0.5.1",
+              "id": "tower 0.5.2",
               "target": "tower"
+            },
+            {
+              "id": "tower-http 0.6.2",
+              "target": "tower_http"
             },
             {
               "id": "unwrap-infallible 0.1.5",
@@ -2313,7 +2397,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -2375,7 +2459,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             }
           ],
@@ -2396,7 +2480,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -2512,7 +2596,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -2576,7 +2660,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -2652,7 +2736,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-log"
         }
@@ -2736,7 +2820,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -2816,7 +2900,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -2888,7 +2972,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -2944,7 +3028,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -3000,7 +3084,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-logger"
         }
@@ -3167,7 +3251,7 @@
               "target": "serde"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -3179,7 +3263,7 @@
               "target": "tokio"
             },
             {
-              "id": "tower 0.5.1",
+              "id": "tower 0.5.2",
               "target": "tower"
             },
             {
@@ -3217,7 +3301,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-matcher"
         }
@@ -3264,7 +3348,7 @@
               "target": "regex"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             }
           ],
@@ -3285,7 +3369,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -3361,7 +3445,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -3400,7 +3484,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -3465,7 +3549,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -3516,7 +3600,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             }
           ],
@@ -3560,7 +3644,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-proto"
         }
@@ -3663,7 +3747,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -3710,8 +3794,16 @@
               "target": "bd_shutdown"
             },
             {
+              "id": "bd-time 1.0.0",
+              "target": "bd_time"
+            },
+            {
               "id": "log 0.4.22",
               "target": "log"
+            },
+            {
+              "id": "time 0.3.37",
+              "target": "time"
             },
             {
               "id": "tokio 1.42.0",
@@ -3744,7 +3836,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -3816,7 +3908,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -3879,7 +3971,7 @@
               "target": "regex"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -3908,7 +4000,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-session"
         }
@@ -4004,7 +4096,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -4109,7 +4201,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -4161,7 +4253,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -4200,7 +4292,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -4257,6 +4349,10 @@
             {
               "id": "bd-key-value 1.0.0",
               "target": "bd_key_value"
+            },
+            {
+              "id": "bd-log 1.0.0",
+              "target": "bd_log"
             },
             {
               "id": "bd-log-metadata 1.0.0",
@@ -4365,7 +4461,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-time"
         }
@@ -4438,7 +4534,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c6d73cee51b319d102292e92f77b8dbdb662eff0"
+            "Rev": "c74e918200020ead8e23c13cfb74ad8f46b865b2"
           },
           "strip_prefix": "bd-workflows"
         }
@@ -4549,7 +4645,7 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "thiserror"
             },
             {
@@ -4701,10 +4797,51 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-apple-darwin": [
+              "std"
+            ],
+            "aarch64-pc-windows-msvc": [
+              "std"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "std"
+            ],
+            "arm-unknown-linux-gnueabi": [
+              "std"
+            ],
+            "i686-pc-windows-msvc": [
+              "std"
+            ],
+            "i686-unknown-linux-gnu": [
+              "std"
+            ],
+            "powerpc-unknown-linux-gnu": [
+              "std"
+            ],
+            "s390x-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-apple-darwin": [
+              "std"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "std"
+            ],
+            "x86_64-unknown-freebsd": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ]
+          }
         },
         "edition": "2021",
         "version": "2.6.0"
@@ -5205,14 +5342,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "chrono 0.4.38": {
+    "chrono 0.4.39": {
       "name": "chrono",
-      "version": "0.4.38",
+      "version": "0.4.39",
       "package_url": "https://github.com/chronotope/chrono",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/chrono/0.4.38/download",
-          "sha256": "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+          "url": "https://static.crates.io/crates/chrono/0.4.39/download",
+          "sha256": "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
         }
       },
       "targets": [
@@ -5451,7 +5588,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.4.38"
+        "version": "0.4.39"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7278,7 +7415,10 @@
           "common": [
             "any_impl",
             "any_zlib",
+            "default",
             "libz-sys",
+            "miniz_oxide",
+            "rust_backend",
             "zlib"
           ],
           "selects": {}
@@ -7292,16 +7432,13 @@
             {
               "id": "libz-sys 1.1.20",
               "target": "libz_sys"
+            },
+            {
+              "id": "miniz_oxide 0.8.0",
+              "target": "miniz_oxide"
             }
           ],
-          "selects": {
-            "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))": [
-              {
-                "id": "miniz_oxide 0.8.0",
-                "target": "miniz_oxide"
-              }
-            ]
-          }
+          "selects": {}
         },
         "edition": "2018",
         "version": "1.0.35"
@@ -16273,44 +16410,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "sync_wrapper 0.1.2": {
-      "name": "sync_wrapper",
-      "version": "0.1.2",
-      "package_url": "https://github.com/Actyx/sync_wrapper",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/sync_wrapper/0.1.2/download",
-          "sha256": "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sync_wrapper",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "sync_wrapper",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.1.2"
-      },
-      "license": "Apache-2.0",
-      "license_ids": [
-        "Apache-2.0"
-      ],
-      "license_file": "LICENSE"
-    },
     "sync_wrapper 1.0.2": {
       "name": "sync_wrapper",
       "version": "1.0.2",
@@ -16525,7 +16624,7 @@
               "target": "bd_test_helpers"
             },
             {
-              "id": "chrono 0.4.38",
+              "id": "chrono 0.4.39",
               "target": "chrono"
             },
             {
@@ -16713,14 +16812,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror 2.0.5": {
+    "thiserror 2.0.8": {
       "name": "thiserror",
-      "version": "2.0.5",
+      "version": "2.0.8",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/2.0.5/download",
-          "sha256": "643caef17e3128658ff44d85923ef2d28af81bb71e0d67bbfe1d76f19a73e053"
+          "url": "https://static.crates.io/crates/thiserror/2.0.8/download",
+          "sha256": "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
         }
       },
       "targets": [
@@ -16764,7 +16863,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 2.0.5",
+              "id": "thiserror 2.0.8",
               "target": "build_script_build"
             }
           ],
@@ -16774,13 +16873,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 2.0.5",
+              "id": "thiserror-impl 2.0.8",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "2.0.5"
+        "version": "2.0.8"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -16853,14 +16952,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 2.0.5": {
+    "thiserror-impl 2.0.8": {
       "name": "thiserror-impl",
-      "version": "2.0.5",
+      "version": "2.0.8",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/2.0.5/download",
-          "sha256": "995d0bbc9995d1f19d28b7215a9352b0fc3cd3a2d2ec95c2cadc485cdedbcdde"
+          "url": "https://static.crates.io/crates/thiserror-impl/2.0.8/download",
+          "sha256": "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
         }
       },
       "targets": [
@@ -16900,7 +16999,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.5"
+        "version": "2.0.8"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -18034,14 +18133,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tower 0.5.1": {
+    "tower 0.5.2": {
       "name": "tower",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "package_url": "https://github.com/tower-rs/tower",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tower/0.5.1/download",
-          "sha256": "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+          "url": "https://static.crates.io/crates/tower/0.5.2/download",
+          "sha256": "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
         }
       },
       "targets": [
@@ -18094,7 +18193,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "sync_wrapper 0.1.2",
+              "id": "sync_wrapper 1.0.2",
               "target": "sync_wrapper"
             },
             {
@@ -18117,7 +18216,105 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.5.1"
+        "version": "0.5.2"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "tower-http 0.6.2": {
+      "name": "tower-http",
+      "version": "0.6.2",
+      "package_url": "https://github.com/tower-rs/tower-http",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tower-http/0.6.2/download",
+          "sha256": "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tower_http",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tower_http",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "async-compression",
+            "compression-deflate",
+            "default",
+            "futures-core",
+            "tokio",
+            "tokio-util"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "async-compression 0.4.18",
+              "target": "async_compression"
+            },
+            {
+              "id": "bitflags 2.6.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "bytes 1.9.0",
+              "target": "bytes"
+            },
+            {
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
+            },
+            {
+              "id": "http 1.2.0",
+              "target": "http"
+            },
+            {
+              "id": "http-body 1.0.1",
+              "target": "http_body"
+            },
+            {
+              "id": "pin-project-lite 0.2.15",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "tokio 1.42.0",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.13",
+              "target": "tokio_util"
+            },
+            {
+              "id": "tower-layer 0.3.3",
+              "target": "tower_layer"
+            },
+            {
+              "id": "tower-service 0.3.3",
+              "target": "tower_service"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.6.2"
       },
       "license": "MIT",
       "license_ids": [
@@ -21882,10 +22079,6 @@
       "aarch64-apple-ios-sim"
     ],
     "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [],
-    "cfg(all(target_arch = \"wasm32\", not(target_os = \"emscripten\")))": [
-      "wasm32-unknown-unknown",
-      "wasm32-wasip1"
-    ],
     "cfg(all(target_arch = \"wasm32\", not(target_os = \"wasi\")))": [
       "wasm32-unknown-unknown"
     ],
@@ -22243,7 +22436,7 @@
     "bd-shutdown 1.0.0",
     "bd-test-helpers 1.0.0",
     "bd-time 1.0.0",
-    "chrono 0.4.38",
+    "chrono 0.4.39",
     "criterion 0.5.1",
     "ctor 0.2.9",
     "jni 0.21.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,9 +150,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -160,7 +173,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -231,7 +244,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -260,7 +273,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -278,7 +291,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "static_assertions",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "time",
  "tokio",
  "tracing",
@@ -287,7 +300,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -300,7 +313,7 @@ dependencies = [
  "log",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "time",
  "tokio",
  "uuid",
@@ -309,7 +322,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -333,21 +346,21 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
  "log",
  "parking_lot",
  "sketches-rust",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "tokio",
 ]
 
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "log",
@@ -357,7 +370,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -374,7 +387,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -386,7 +399,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -411,12 +424,15 @@ dependencies = [
  "prometheus",
  "protobuf",
  "protobuf-codegen",
+ "serde",
+ "serde_json",
  "snap",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "time",
  "tokio",
  "tokio-stream",
- "tower 0.5.1",
+ "tower 0.5.2",
+ "tower-http",
  "unwrap-infallible",
  "urlencoding",
 ]
@@ -424,7 +440,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -433,13 +449,13 @@ dependencies = [
  "flate2",
  "log",
  "protobuf",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -461,7 +477,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -473,7 +489,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "base64",
@@ -488,7 +504,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -505,7 +521,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -521,7 +537,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -535,7 +551,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -545,7 +561,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -555,7 +571,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -593,10 +609,10 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "serde",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "time",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tracing",
  "unwrap-infallible",
 ]
@@ -604,20 +620,20 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
  "bd-proto",
  "protobuf",
  "regex",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "base64",
@@ -632,12 +648,12 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -648,18 +664,18 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "log",
  "protobuf",
  "protobuf-codegen",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -672,22 +688,24 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
  "bd-log-primitives",
  "bd-runtime",
  "bd-shutdown",
+ "bd-time",
  "ctor",
  "log",
+ "time",
  "tokio",
 ]
 
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -701,7 +719,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -712,7 +730,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "regex",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "time",
  "tokio",
 ]
@@ -720,7 +738,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -740,7 +758,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -761,7 +779,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "log",
  "tokio",
@@ -770,12 +788,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -786,6 +804,7 @@ dependencies = [
  "bd-grpc",
  "bd-grpc-codec",
  "bd-key-value",
+ "bd-log",
  "bd-log-metadata",
  "bd-log-primitives",
  "bd-matcher",
@@ -811,7 +830,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -824,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c6d73cee51b319d102292e92f77b8dbdb662eff0#c6d73cee51b319d102292e92f77b8dbdb662eff0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c74e918200020ead8e23c13cfb74ad8f46b865b2#c74e918200020ead8e23c13cfb74ad8f46b865b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -848,7 +867,7 @@ dependencies = [
  "regex",
  "serde",
  "sha2",
- "thiserror 2.0.5",
+ "thiserror 2.0.8",
  "time",
  "tokio",
 ]
@@ -960,9 +979,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2626,12 +2645,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2708,11 +2721,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.5"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643caef17e3128658ff44d85923ef2d28af81bb71e0d67bbfe1d76f19a73e053"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
 dependencies = [
- "thiserror-impl 2.0.5",
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -2728,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.5"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995d0bbc9995d1f19d28b7215a9352b0fc3cd3a2d2ec95c2cadc485cdedbcdde"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2868,18 +2881,37 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "async-compression",
+ "bitflags 2.6.0",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,26 +17,26 @@ android_logger = { version = "0.14.1", default-features = false }
 anyhow = "1.0.94"
 assert_matches = "1.5.0"
 async-trait = "0.1.83"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0", default-features = false }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c6d73cee51b319d102292e92f77b8dbdb662eff0" }
-chrono = "0.4.38"
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2", default-features = false }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c74e918200020ead8e23c13cfb74ad8f46b865b2" }
+chrono = "0.4.39"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 ctor = "0.2.9"
 env_logger = { version = "0.11.5", default-features = false }

--- a/platform/swift/source/src/bridge.rs
+++ b/platform/swift/source/src/bridge.rs
@@ -62,10 +62,12 @@ fn initialize_logging() {
       .with_default_directive(LevelFilter::INFO.into())
       .from_env_lossy();
 
-    tracing_subscriber::Registry::default()
+    // Use try_init() to avoid situations where the logger has already been initialized by test
+    // harnesses. This is not ideal but it's the easiest fix for now.
+    let _ = tracing_subscriber::Registry::default()
       .with(filter)
       .with(stderr)
-      .init();
+      .try_init();
   });
 }
 

--- a/test/platform/jvm/src/lib.rs
+++ b/test/platform/jvm/src/lib.rs
@@ -50,7 +50,6 @@ pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_startTestApiSer
 
 #[ctor::ctor]
 fn setup() {
-  bd_log::SwapLogger::initialize();
   bd_test_helpers::test_global_init();
 }
 


### PR DESCRIPTION
Due to another change in shared-core in which I removed the "test-logger" feature we have an issue where we are double initializing the logging on iOS tests. I did a targeted fix for this and we can see how it goes.