### PR TITLE
[andr] Guard against subscribing more than once to event listeners

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/EventsListenerTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/EventsListenerTarget.kt
@@ -9,6 +9,7 @@ package io.bitdrift.capture.events.lifecycle
 
 import io.bitdrift.capture.IEventsListenerTarget
 import io.bitdrift.capture.events.IEventListenerLogger
+import io.bitdrift.capture.events.SafeEventListenerLogger
 
 /**
  * A wrapper around platform event listeners that subscribe to various system notifications
@@ -18,7 +19,7 @@ internal class EventsListenerTarget : IEventsListenerTarget {
     private var listeners: MutableList<IEventListenerLogger> = mutableListOf()
 
     fun add(eventListener: IEventListenerLogger) {
-        listeners.add(eventListener)
+        listeners.add(SafeEventListenerLogger(eventListener))
     }
     override fun start() {
         listeners.forEach { it.start() }


### PR DESCRIPTION
This used to be in place but it must have regressed around the time we moved the core listener logic to rust. 