### PR TITLE
fix publishing of capture plugin

### DIFF
--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -35,6 +35,7 @@ function generate_maven_file() {
 
   releases=$(aws s3 ls "$location/" \
     | grep -v 'maven-metadata.xml' \
+    | grep -v 'io.bitdrift' \
     | awk '{print $2}' \
     | sed 's/^\///;s/\/$//')
 


### PR DESCRIPTION
The new plugin directory structure has a nested artifact within the artifact directory for the capture-plugin which messes up the script that tries to pull all the published releases. This should ignore that nested directory 

Fixes BIT-4242