### PR TITLE
[andr] Override _path_template field with gql operation

### DIFF
--- a/platform/jvm/capture-apollo3/src/main/kotlin/io/bitdrift/capture/apollo3/CaptureApolloInterceptor.kt
+++ b/platform/jvm/capture-apollo3/src/main/kotlin/io/bitdrift/capture/apollo3/CaptureApolloInterceptor.kt
@@ -28,9 +28,10 @@ class CaptureApolloInterceptor: ApolloInterceptor {
         val requestBuilder = request.newBuilder()
             .addHttpHeader("x-capture-span-key", "gql")
             .addHttpHeader("x-capture-span-gql-name", "graphql")
-            .addHttpHeader("x-capture-span-gql-field-operation-name", request.operation.name())
             .addHttpHeader("x-capture-span-gql-field-operation-id", request.operation.id())
             .addHttpHeader("x-capture-span-gql-field-operation-type", request.operation.type())
+            .addHttpHeader("x-capture-span-gql-field-operation-name", request.operation.name())
+            .addHttpHeader("x-capture-path-template", request.operation.name()) // set this to override the http _path_template field
         // TODO(murki): Augment request logs with
         //  request.executionContext[CustomScalarAdapters]?.let {
         //    addHttpHeader("x-capture-span-gql-field-operation-variables", request.operation.variables(it).valueMap.toString())

--- a/platform/jvm/capture-apollo3/src/main/kotlin/io/bitdrift/capture/apollo3/CaptureApolloInterceptor.kt
+++ b/platform/jvm/capture-apollo3/src/main/kotlin/io/bitdrift/capture/apollo3/CaptureApolloInterceptor.kt
@@ -31,7 +31,7 @@ class CaptureApolloInterceptor: ApolloInterceptor {
             .addHttpHeader("x-capture-span-gql-field-operation-id", request.operation.id())
             .addHttpHeader("x-capture-span-gql-field-operation-type", request.operation.type())
             .addHttpHeader("x-capture-span-gql-field-operation-name", request.operation.name())
-            .addHttpHeader("x-capture-path-template", request.operation.name()) // set this to override the http _path_template field
+            .addHttpHeader("x-capture-path-template", "gql-${request.operation.name()}") // set this to override the http _path_template field
         // TODO(murki): Augment request logs with
         //  request.executionContext[CustomScalarAdapters]?.let {
         //    addHttpHeader("x-capture-span-gql-field-operation-variables", request.operation.variables(it).valueMap.toString())

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
@@ -348,12 +348,14 @@ class CaptureOkHttpEventListenerFactoryTest {
             "x-capture-span-gql-field-operation-name" to "myOperationName",
             "x-capture-span-gql-field-operation-id" to "myOperationId",
             "x-capture-span-gql-field-operation-type" to "query",
+            "x-capture-path-template" to "myOperationName",
         )
         val expectedSpanName = "_mySpanName"
         val expectedFields = mapOf(
             "_operation_name" to "myOperationName",
             "_operation_id" to "myOperationId",
             "_operation_type" to "query",
+            "_path_template" to "myOperationName",
         )
 
         val request = Request.Builder()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
@@ -348,14 +348,14 @@ class CaptureOkHttpEventListenerFactoryTest {
             "x-capture-span-gql-field-operation-name" to "myOperationName",
             "x-capture-span-gql-field-operation-id" to "myOperationId",
             "x-capture-span-gql-field-operation-type" to "query",
-            "x-capture-path-template" to "myOperationName",
+            "x-capture-path-template" to "gql-myOperationName",
         )
         val expectedSpanName = "_mySpanName"
         val expectedFields = mapOf(
             "_operation_name" to "myOperationName",
             "_operation_id" to "myOperationId",
             "_operation_type" to "query",
-            "_path_template" to "myOperationName",
+            "_path_template" to "gql-myOperationName",
         )
 
         val request = Request.Builder()


### PR DESCRIPTION
That way the instant Insights > network dashboard will autopopulate with the operation names

<img width="2234" alt="Screenshot 2024-12-30 at 4 45 06 PM" src="https://github.com/user-attachments/assets/71c6e2e0-f1fd-4aed-9259-4d430d14521b" />

