### PR TITLE
[ci] Fix release auto-pr creation

### DIFF
--- a/.github/workflows/update_sdk_version.yaml
+++ b/.github/workflows/update_sdk_version.yaml
@@ -66,4 +66,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.org-pr-create-token.outputs.token }}
         run: |
-          gh pr create --fill
+          gh pr create --fill --head update-sdk-version-${{ inputs.version }}


### PR DESCRIPTION
Attempt to fix error: https://github.com/bitdriftlabs/capture-sdk/actions/runs/12809837288/job/35715520945#step:6:7
`aborted: you must first push the current branch to a remote, or use the --head flag`