### PR TITLE
[ANDR] Adding linker flags to only android platform

### DIFF
--- a/platform/jvm/BUILD.bazel
+++ b/platform/jvm/BUILD.bazel
@@ -15,7 +15,10 @@ cc_binary(
         "-lm",  # Required to avoid dlopen runtime failures unrelated to rust
         "-lz",  # Link against system zlib library
     ] + select({
-        "@platforms//os:android": ["-Wl,-z,max-page-size=16384,--retain-symbols-file=$(location :jni_symbols.lds)"],
+        "@platforms//os:android": [
+            "-Wl,-z,max-page-size=16384", # nable 16 KB ELF alignment on Android to support API 35+
+            "-Wl,--retain-symbols-file=$(location :jni_symbols.lds)",
+            ],
         "@platforms//os:linux": ["-Wl,--retain-symbols-file=$(location :jni_symbols.lds)"],
         # The linker on macos doesn't support the same options or file formats as linux, so use a pattern match here (not availabile on linux).
         # We could use another file which prefixes all the symbols with _, but this seems easier.

--- a/platform/jvm/BUILD.bazel
+++ b/platform/jvm/BUILD.bazel
@@ -14,9 +14,8 @@ cc_binary(
     linkopts = [
         "-lm",  # Required to avoid dlopen runtime failures unrelated to rust
         "-lz",  # Link against system zlib library
-        "-Wl,-z,max-page-size=16384",  # enable 16 KB ELF alignment
     ] + select({
-        "@platforms//os:android": ["-Wl,--retain-symbols-file=$(location :jni_symbols.lds)"],
+        "@platforms//os:android": ["-Wl,-z,max-page-size=16384,--retain-symbols-file=$(location :jni_symbols.lds)"],
         "@platforms//os:linux": ["-Wl,--retain-symbols-file=$(location :jni_symbols.lds)"],
         # The linker on macos doesn't support the same options or file formats as linux, so use a pattern match here (not availabile on linux).
         # We could use another file which prefixes all the symbols with _, but this seems easier.

--- a/platform/jvm/BUILD.bazel
+++ b/platform/jvm/BUILD.bazel
@@ -16,9 +16,9 @@ cc_binary(
         "-lz",  # Link against system zlib library
     ] + select({
         "@platforms//os:android": [
-            "-Wl,-z,max-page-size=16384", # nable 16 KB ELF alignment on Android to support API 35+
+            "-Wl,-z,max-page-size=16384",  # enable 16 KB ELF alignment on Android to support API 35+
             "-Wl,--retain-symbols-file=$(location :jni_symbols.lds)",
-            ],
+        ],
         "@platforms//os:linux": ["-Wl,--retain-symbols-file=$(location :jni_symbols.lds)"],
         # The linker on macos doesn't support the same options or file formats as linux, so use a pattern match here (not availabile on linux).
         # We could use another file which prefixes all the symbols with _, but this seems easier.

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -84,9 +84,11 @@ cargo {
     targetDirectory = "../../../target"
     targets = listOf("arm64", "x86_64")
     pythonCommand = "python3"
-    exec = { spec, _ ->
-        // enable 16 KB ELF alignment
-        spec.environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,-z,max-page-size=16384")
+    exec = { spec, toolchain ->
+        if (toolchain.platform == "arm64") {
+            // enable 16 KB ELF alignment on Android to support API 35+
+            spec.environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,-z,max-page-size=16384")
+        }
     }
 }
 


### PR DESCRIPTION
# Issue
Potential fix for building issues on previous 0.16.9 attempt (see previous failure on https://github.com/bitdriftlabs/capture-sdk/actions/runs/12916680190/job/36022967272)

# Test plan

Will follow similar steps listed on prior PR's description https://github.com/bitdriftlabs/capture-sdk/pull/173 

- [ ] Validate locally bazel android builds
- [ ] Verify that the Android app is 16 KB-aligned
- [ ] Validate app runs and the SDK is reporting last session  
Check that Android test app is https://developer.android.com/guide/practices/page-sizes 
