### PR TITLE
gradle: allow publishing artifacts to maven local

### DIFF
--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -123,5 +123,6 @@ publishing {
         maven {
             url = uri(layout.buildDirectory.dir("repos/releases"))
         }
+      mavenLocal()
     }
 }

--- a/platform/jvm/common/build.gradle.kts
+++ b/platform/jvm/common/build.gradle.kts
@@ -3,7 +3,10 @@ plugins {
     alias(libs.plugins.kotlin.android)
 
     id("dependency-license-config")
+    alias(libs.plugins.maven.publish)
 }
+
+group = "io.bitdrift"
 
 android {
     namespace = "io.bitdrift.capture.common"
@@ -28,5 +31,11 @@ android {
         abortOnError = true
         checkDependencies = true
         checkReleaseBuilds = true
+    }
+}
+
+publishing {
+    repositories {
+      mavenLocal()
     }
 }

--- a/platform/jvm/replay/build.gradle.kts
+++ b/platform/jvm/replay/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.android)
 
     id("dependency-license-config")
+
+    alias(libs.plugins.maven.publish)
 }
 
 dependencies {
@@ -19,6 +21,8 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.junit)
 }
+
+group = "io.bitdrift"
 
 android {
     namespace = "io.bitdrift.capture.replay"
@@ -50,5 +54,11 @@ android {
         abortOnError = true
         checkDependencies = true
         checkReleaseBuilds = true
+    }
+}
+
+publishing {
+    repositories {
+      mavenLocal()
     }
 }


### PR DESCRIPTION
This sets up maven local as a publishing target for enough modules for us to be able to test the RN interaction

Running 
```
./gradlew publishMavenPublicationToMavenLocal -PVERSION_NAME=<version>
```

will now publish artifacts to maven local