### PR TITLE
Capture objc exceptions on task delegate

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -138,6 +138,6 @@ build:ios-tsan --features=tsan
 
 build:asan --config=fake-nightly
 build:asan --features=address
-build:tsan --@rules_rust//rust/settings:extra_rustc_flag=-Zsanitizer=address
+build:asan --@rules_rust//rust/settings:extra_rustc_flag=-Zsanitizer=address
 
 try-import %workspace%/tmp/ci-bazelrc

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -44,19 +44,6 @@ jobs:
       # TODO(snowp): Add some kind of assertion that the app does that it's supposed to
       - run: ./bazelw run --config ci //examples/swift/hello_world:ios_app &> /tmp/envoy.log &
         name: 'Run app'
-  macos_asan:
-    runs-on: macos-14
-    needs: "pre_check"
-    if: needs.pre_check.outputs.should_run == 'true'
-    steps:
-      # Checkout repo to Github Actions runner
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: 'Install dependencies'
-        run: ./ci/mac_ci_setup.sh
-      - name: Run tests (asan)
-        run: env -u ANDROID_NDK_HOME ./bazelw test //core/... //platform/... //test/platform/swift/unit_integration/... --test_tag_filters=macos_only --test_output=errors --build_tests_only --config ci --config asan
   macos_tsan:
     runs-on: macos-14
     needs: "pre_check"
@@ -72,7 +59,7 @@ jobs:
         run: env -u ANDROID_NDK_HOME ./bazelw test $(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/core/...)') --test_tag_filters=macos_only --test_output=errors --config ci --config ios-tsan
   verify_ios:
     runs-on: ubuntu-latest
-    needs: ["macos_tsan", "macos_asan", "swift_hello_world"]
+    needs: ["macos_tsan", "swift_hello_world"]
     if: always()
     steps:
       # Checkout repo to Github Actions runner
@@ -82,5 +69,4 @@ jobs:
           fetch-depth: 1
       - run: |
           ./ci/check_result.sh ${{ needs.macos_tsan.result }} \
-          && ./ci/check_result.sh ${{ needs.macos_asan.result }} \
           && ./ci/check_result.sh ${{ needs.swift_hello_world.result }}

--- a/platform/swift/source/BUILD
+++ b/platform/swift/source/BUILD
@@ -35,7 +35,7 @@ swift_library(
     module_name = "Capture",
     private_deps = [
         ":CapturePassable",
-        ":rust_bridge",
+        ":objc_bridge",
     ],
     tags = [
         "macos_only",
@@ -71,12 +71,12 @@ bitdrift_rust_library(
 )
 
 objc_library(
-    name = "rust_bridge",
+    name = "objc_bridge",
+    srcs = ["ObjCWrapper.mm"],
     hdrs = [
         "CaptureRustBridge.h",
-        "ObjcWrapper.h",
+        "ObjCWrapper.h",
     ],
-    srcs = ["ObjcWrapper.mm"],
     module_name = "CaptureLoggerBridge",
     tags = ["macos_only"],
     visibility = ["//visibility:public"],

--- a/platform/swift/source/BUILD
+++ b/platform/swift/source/BUILD
@@ -74,7 +74,9 @@ objc_library(
     name = "rust_bridge",
     hdrs = [
         "CaptureRustBridge.h",
+        "ObjcWrapper.h",
     ],
+    srcs = ["ObjcWrapper.mm"],
     module_name = "CaptureLoggerBridge",
     tags = ["macos_only"],
     visibility = ["//visibility:public"],

--- a/platform/swift/source/ObjCWrapper.h
+++ b/platform/swift/source/ObjCWrapper.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+
+@interface ObjCWrapper: NSObject
+
+/**
+ * Try to execute the block and catch any exceptions.
+ */
++ (BOOL)doTry:(void(^)())block error:(NSError **)err;
+
+@end

--- a/platform/swift/source/ObjCWrapper.h
+++ b/platform/swift/source/ObjCWrapper.h
@@ -1,3 +1,10 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 #import <UIKit/UIKit.h>
 
 @interface ObjCWrapper: NSObject

--- a/platform/swift/source/ObjCWrapper.mm
+++ b/platform/swift/source/ObjCWrapper.mm
@@ -1,3 +1,10 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 #import <Foundation/Foundation.h>
 #import "ObjCWrapper.h"
 

--- a/platform/swift/source/ObjCWrapper.mm
+++ b/platform/swift/source/ObjCWrapper.mm
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import "ObjCWrapper.h"
+
+@implementation ObjCWrapper
+
++ (BOOL)doTry:(void(^)())block error:(NSError **)err {
+    @try {
+        block();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        *err = [NSError errorWithDomain:@"io.bitdrift"
+                                   code:-1
+                               userInfo:@{@"exception": exception}];
+        return NO;
+    }
+}
+
+@end

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -84,7 +84,10 @@ final class URLSessionIntegration {
         let session = URLSession(configuration: .ephemeral)
         defer { session.invalidateAndCancel() }
 
-        return type(of: session.dataTask(with: request))
+        let task = session.dataTask(with: request)
+        defer { task.cancel() }
+        
+        return type(of: task)
     }
 }
 

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -86,7 +86,7 @@ final class URLSessionIntegration {
 
         let task = session.dataTask(with: request)
         defer { task.cancel() }
-        
+
         return type(of: task)
     }
 }

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -7,13 +7,20 @@
 
 import Foundation
 import ObjectiveC
+@_implementationOnly import CaptureLoggerBridge
 
 extension URLSessionTask {
     @available(iOS 15.0, *)
     @objc
     func cap_resume() {
+        defer { self.cap_resume() }
+        if (self.state == .completed || self.state == .canceling) {
+            return
+        }
+
         URLSessionTaskTracker.shared.taskWillStart(self)
-        self.delegate = ProxyURLSessionTaskDelegate(target: self.delegate)
-        self.cap_resume()
+        try? ObjCTry.do {
+            self.delegate = ProxyURLSessionTaskDelegate(target: self.delegate)
+        }
     }
 }

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -5,21 +5,21 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+@_implementationOnly import CaptureLoggerBridge
 import Foundation
 import ObjectiveC
-@_implementationOnly import CaptureLoggerBridge
 
 extension URLSessionTask {
     @available(iOS 15.0, *)
     @objc
     func cap_resume() {
         defer { self.cap_resume() }
-        if (self.state == .completed || self.state == .canceling) {
+        if self.state == .completed || self.state == .canceling {
             return
         }
 
         URLSessionTaskTracker.shared.taskWillStart(self)
-        try? ObjCTry.do {
+        try? ObjCWrapper.doTry {
             self.delegate = ProxyURLSessionTaskDelegate(target: self.delegate)
         }
     }

--- a/test/platform/swift/unit_integration/core/BUILD
+++ b/test/platform/swift/unit_integration/core/BUILD
@@ -8,7 +8,7 @@ bitdrift_mobile_swift_test(
     visibility = ["//visibility:public"],
     deps = [
         "//platform/swift/source:ios_lib",
-        "//platform/swift/source:rust_bridge",
+        "//platform/swift/source:objc_bridge",
         "//test/platform/swift/benchmark:benchmarks",
         "//test/platform/swift/bridging:rust_bridge",
         "//test/platform/swift/unit_integration/mocks",

--- a/test/platform/swift/unit_integration/mocks/BUILD
+++ b/test/platform/swift/unit_integration/mocks/BUILD
@@ -12,6 +12,6 @@ swift_library(
     visibility = ["//visibility:public"],
     deps = [
         "//platform/swift/source:ios_lib",
-        "//platform/swift/source:rust_bridge",
+        "//platform/swift/source:objc_bridge",
     ],
 )


### PR DESCRIPTION
Setting a delegate on a "Background Task" throws an objc exception that we cannot catch on swift, so we are adding an objc helper to be able to catch those objc `@throw`s