### PR TITLE
[Android] Consolidate existing ExecutorServices

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -45,7 +45,7 @@ import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFields
-import io.bitdrift.capture.threading.CaptureDispatcher
+import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import java.io.File
 import kotlin.time.Duration
@@ -76,7 +76,7 @@ internal class LoggerImpl(
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
     private val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     private val bridge: IBridge = CaptureJniLibrary,
-    private val eventListenerDispatcher: CaptureDispatcher = CaptureDispatcher.EventListener
+    private val eventListenerDispatcher: CaptureDispatchers.EventListener = CaptureDispatchers.EventListener
 ) : ILogger {
     private val metadataProvider: MetadataProvider
     private val memoryMonitor = MemoryMonitor(context)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -76,6 +76,7 @@ internal class LoggerImpl(
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
     private val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     private val bridge: IBridge = CaptureJniLibrary,
+    private val eventListenerDispatcher: CaptureDispatcher = CaptureDispatcher.EventListener
 ) : ILogger {
     private val metadataProvider: MetadataProvider
     private val memoryMonitor = MemoryMonitor(context)
@@ -93,8 +94,6 @@ internal class LoggerImpl(
     private val eventsListenerTarget = EventsListenerTarget()
 
     private val sessionReplayTarget: SessionReplayTarget?
-
-    private val processingQueue = CaptureDispatcher.EventListener.executorService
 
     @VisibleForTesting
     internal val loggerId: LoggerId
@@ -158,7 +157,7 @@ internal class LoggerImpl(
                         diskUsageMonitor,
                         errorHandler,
                         this,
-                        processingQueue,
+                        eventListenerDispatcher.executorService,
                     )
 
                 val sessionReplayTarget =
@@ -207,7 +206,7 @@ internal class LoggerImpl(
                         this,
                         ProcessLifecycleOwner.get(),
                         runtime,
-                        processingQueue,
+                        eventListenerDispatcher.executorService,
                     ),
                 )
 
@@ -218,7 +217,7 @@ internal class LoggerImpl(
                         batteryMonitor,
                         powerMonitor,
                         runtime,
-                        processingQueue,
+                        eventListenerDispatcher.executorService,
                     ),
                 )
 
@@ -228,7 +227,7 @@ internal class LoggerImpl(
                         context,
                         memoryMonitor,
                         runtime,
-                        processingQueue,
+                        eventListenerDispatcher.executorService,
                     ),
                 )
 
@@ -238,7 +237,7 @@ internal class LoggerImpl(
                         clientAttributes,
                         context,
                         runtime,
-                        processingQueue,
+                        eventListenerDispatcher.executorService,
                     ),
                 )
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -76,7 +76,7 @@ internal class LoggerImpl(
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
     private val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     private val bridge: IBridge = CaptureJniLibrary,
-    private val eventListenerDispatcher: CaptureDispatchers.EventListener = CaptureDispatchers.EventListener
+    private val eventListenerDispatcher: CaptureDispatchers.EventListener = CaptureDispatchers.EventListener,
 ) : ILogger {
     private val metadataProvider: MetadataProvider
     private val memoryMonitor = MemoryMonitor(context)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -45,10 +45,9 @@ import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.threading.CaptureDispatcher
 import okhttp3.HttpUrl
 import java.io.File
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.measureTime
@@ -65,10 +64,6 @@ internal class LoggerImpl(
     fieldProviders: List<FieldProvider>,
     dateProvider: DateProvider,
     private val errorHandler: ErrorHandler = ErrorHandler(),
-    processingQueue: ExecutorService =
-        Executors.newSingleThreadExecutor {
-            Thread(it, "io.bitdrift.capture.event-listener")
-        },
     sessionStrategy: SessionStrategy,
     context: Context = ContextHolder.APP_CONTEXT,
     clientAttributes: ClientAttributes =
@@ -98,6 +93,8 @@ internal class LoggerImpl(
     private val eventsListenerTarget = EventsListenerTarget()
 
     private val sessionReplayTarget: SessionReplayTarget?
+
+    private val processingQueue = CaptureDispatcher.EventListener.executorService
 
     @VisibleForTesting
     internal val loggerId: LoggerId

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
@@ -25,6 +25,7 @@ import io.bitdrift.capture.replay.ScreenshotCaptureMetrics
 import io.bitdrift.capture.replay.SessionReplayConfiguration
 import io.bitdrift.capture.replay.SessionReplayController
 import io.bitdrift.capture.replay.internal.FilteredCapture
+import io.bitdrift.capture.threading.CaptureDispatcher
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -50,6 +51,7 @@ internal class SessionReplayTarget(
             configuration,
             context,
             mainThreadHandler,
+            CaptureDispatcher.SessionReplay.executorService
         )
 
     override fun captureScreen() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
@@ -25,7 +25,7 @@ import io.bitdrift.capture.replay.ScreenshotCaptureMetrics
 import io.bitdrift.capture.replay.SessionReplayConfiguration
 import io.bitdrift.capture.replay.SessionReplayController
 import io.bitdrift.capture.replay.internal.FilteredCapture
-import io.bitdrift.capture.threading.CaptureDispatcher
+import io.bitdrift.capture.threading.CaptureDispatchers
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -51,7 +51,7 @@ internal class SessionReplayTarget(
             configuration,
             context,
             mainThreadHandler,
-            CaptureDispatcher.SessionReplay.executorService
+            CaptureDispatchers.SessionReplay.executorService
         )
 
     override fun captureScreen() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
@@ -51,7 +51,7 @@ internal class SessionReplayTarget(
             configuration,
             context,
             mainThreadHandler,
-            CaptureDispatchers.SessionReplay.executorService
+            CaptureDispatchers.SessionReplay.executorService,
         )
 
     override fun captureScreen() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -11,7 +11,7 @@ import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.network.ICaptureStream
 import io.bitdrift.capture.network.Jni
-import io.bitdrift.capture.threading.CaptureDispatcher
+import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.HttpUrl
@@ -76,7 +76,7 @@ internal fun newDuplexRequestBody(contentType: MediaType): PipeDuplexRequestBody
 internal class OkHttpNetwork(
     apiBaseUrl: HttpUrl,
     timeoutSeconds: Long = 2L * 60,
-    private val networkDispatcher: CaptureDispatcher.Network = CaptureDispatcher.Network
+    private val networkDispatcher: CaptureDispatchers.Network = CaptureDispatchers.Network
 ) : ICaptureNetwork {
     private val client: OkHttpClient =
         run {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -11,6 +11,7 @@ import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.network.ICaptureStream
 import io.bitdrift.capture.network.Jni
+import io.bitdrift.capture.threading.CaptureDispatcher
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.HttpUrl
@@ -26,8 +27,6 @@ import okio.BufferedSink
 import okio.Pipe
 import okio.buffer
 import java.io.IOException
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
@@ -100,10 +99,8 @@ internal class OkHttpNetwork(
                 .build()
         }
 
-    private val executor: ExecutorService =
-        Executors.newSingleThreadExecutor {
-            Thread(it, "io.bitdrift.capture.network.okhttp")
-        }
+    private val networkDispatcher: CaptureDispatcher.Network = CaptureDispatcher.Network
+
     private val url: HttpUrl =
         apiBaseUrl
             .newBuilder()
@@ -176,7 +173,7 @@ internal class OkHttpNetwork(
                         response: Response,
                     ) {
                         // Once we get a response handle, hand it over to the executor for async processing.
-                        executor.execute {
+                        networkDispatcher.executorService.execute {
                             response.use {
                                 consumeResponse(response)
                             }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -76,6 +76,7 @@ internal fun newDuplexRequestBody(contentType: MediaType): PipeDuplexRequestBody
 internal class OkHttpNetwork(
     apiBaseUrl: HttpUrl,
     timeoutSeconds: Long = 2L * 60,
+    private val networkDispatcher: CaptureDispatcher.Network = CaptureDispatcher.Network
 ) : ICaptureNetwork {
     private val client: OkHttpClient =
         run {
@@ -98,8 +99,6 @@ internal class OkHttpNetwork(
                 .retryOnConnectionFailure(false) // Retrying messes up the write pipe state management, so disable.
                 .build()
         }
-
-    private val networkDispatcher: CaptureDispatcher.Network = CaptureDispatcher.Network
 
     private val url: HttpUrl =
         apiBaseUrl

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -76,7 +76,7 @@ internal fun newDuplexRequestBody(contentType: MediaType): PipeDuplexRequestBody
 internal class OkHttpNetwork(
     apiBaseUrl: HttpUrl,
     timeoutSeconds: Long = 2L * 60,
-    private val networkDispatcher: CaptureDispatchers.Network = CaptureDispatchers.Network
+    private val networkDispatcher: CaptureDispatchers.Network = CaptureDispatchers.Network,
 ) : ICaptureNetwork {
     private val client: OkHttpClient =
         run {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
@@ -18,7 +18,7 @@ sealed class CaptureDispatcher private constructor(private val threadName: Strin
     }
 
     /**
-     * [ExecutorService] to be used for processing main events
+     * [ExecutorService] to be used for handling different types of [EventsListenerTarget]
      */
     object EventListener : CaptureDispatcher("event-listener")
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
@@ -33,11 +33,6 @@ sealed class CaptureDispatcher private constructor(private val threadName: Strin
     object SessionReplay: CaptureDispatcher("session-replay")
 
     /**
-     * Returns the associated [ExecutorService] for the [CaptureDispatcher] type
-     */
-    fun get():ExecutorService = executorService
-
-    /**
      * Tears down the existing service
      */
     fun shutDown() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
@@ -1,0 +1,56 @@
+package io.bitdrift.capture.threading
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * Different Dispatchers used by Capture.
+ *
+ * The initial implementation exposes an [executorService]
+ */
+sealed class CaptureDispatcher private constructor(private val threadName: String) {
+
+    /**
+     * Returns the associated [ExecutorService] for the [CaptureDispatcher] type
+     */
+    val executorService: ExecutorService by lazy {
+        buildExecutorService(threadName)
+    }
+
+    /**
+     * [ExecutorService] to be used for processing main events
+     */
+    object EventListener : CaptureDispatcher("event-listener")
+
+    /**
+     * [ExecutorService] to be used for networking capture
+     */
+    object Network: CaptureDispatcher("network.okhttp")
+
+    /**
+     * [ExecutorService] to be used for Session-Replay
+     */
+    object SessionReplay: CaptureDispatcher("session-replay")
+
+    /**
+     * Returns the associated [ExecutorService] for the [CaptureDispatcher] type
+     */
+    fun get():ExecutorService = executorService
+
+    /**
+     * Tears down the existing service
+     */
+    fun shutDown() {
+        executorService.shutdown()
+    }
+
+    private fun buildExecutorService(threadName: String): ExecutorService {
+        return Executors.newSingleThreadExecutor {
+            Thread(it, "$CAPTURE_EXECUTOR_SERVICE_NAME.$threadName")
+        }
+    }
+
+    private companion object {
+        private const val CAPTURE_EXECUTOR_SERVICE_NAME = "io.bitdrift.capture"
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
@@ -30,13 +30,6 @@ sealed class CaptureDispatcher private constructor(private val threadName: Strin
      */
     object SessionReplay: CaptureDispatcher("session-replay")
 
-    /**
-     * Tears down the existing service
-     */
-    fun shutDown() {
-        executorService.shutdown()
-    }
-
     private fun buildExecutorService(threadName: String): ExecutorService {
         return Executors.newSingleThreadExecutor {
             Thread(it, "$CAPTURE_EXECUTOR_SERVICE_NAME.$threadName")

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
@@ -14,6 +14,7 @@ sealed class CaptureDispatcher private constructor(private val threadName: Strin
      * Returns the associated [ExecutorService] for the [CaptureDispatcher] type
      */
     val executorService: ExecutorService = buildExecutorService(threadName)
+            .also { register(this) }
 
     /**
      * [ExecutorService] to be used for handling different types of [EventsListenerTarget]
@@ -36,7 +37,26 @@ sealed class CaptureDispatcher private constructor(private val threadName: Strin
         }
     }
 
-    private companion object {
+    @Suppress("UndocumentedPublicClass")
+    companion object {
         private const val CAPTURE_EXECUTOR_SERVICE_NAME = "io.bitdrift.capture"
+
+        private val initializedDispatchers = mutableListOf<CaptureDispatcher>()
+
+        /**
+         * Shuts down all used dispatchers
+         */
+        fun shutdownAll() {
+            initializedDispatchers.forEach { captureDispatcher ->
+                captureDispatcher.executorService.shutdown()
+            }
+            initializedDispatchers.clear()
+        }
+
+        private fun register(dispatcher: CaptureDispatcher) {
+            if (!initializedDispatchers.contains(dispatcher)) {
+                initializedDispatchers.add(dispatcher)
+            }
+        }
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatcher.kt
@@ -13,9 +13,7 @@ sealed class CaptureDispatcher private constructor(private val threadName: Strin
     /**
      * Returns the associated [ExecutorService] for the [CaptureDispatcher] type
      */
-    val executorService: ExecutorService by lazy {
-        buildExecutorService(threadName)
-    }
+    val executorService: ExecutorService = buildExecutorService(threadName)
 
     /**
      * [ExecutorService] to be used for handling different types of [EventsListenerTarget]

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
@@ -71,8 +71,8 @@ internal sealed class CaptureDispatchers private constructor(
          */
         @JvmStatic
         @VisibleForTesting
-        internal fun setTestExecutorService(testExecutorService:ExecutorService){
-            listOf(EventListener, Network, SessionReplay).forEach{
+        internal fun setTestExecutorService(testExecutorService: ExecutorService) {
+            listOf(EventListener, Network, SessionReplay).forEach {
                 it._executorService = testExecutorService
             }
         }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
@@ -8,12 +8,14 @@ import java.util.concurrent.Executors
  *
  * The initial implementation exposes an [executorService]
  */
-sealed class CaptureDispatchers private constructor(private val threadName: String) {
-
+sealed class CaptureDispatchers private constructor(
+    threadName: String,
+) {
     /**
      * Returns the associated [ExecutorService] for the [CaptureDispatchers] type
      */
-    val executorService: ExecutorService = buildExecutorService(threadName)
+    val executorService: ExecutorService =
+        buildExecutorService(threadName)
             .also { register(this) }
 
     /**
@@ -24,18 +26,17 @@ sealed class CaptureDispatchers private constructor(private val threadName: Stri
     /**
      * [ExecutorService] to be used for networking capture
      */
-    object Network: CaptureDispatchers("network.okhttp")
+    object Network : CaptureDispatchers("network.okhttp")
 
     /**
      * [ExecutorService] to be used for Session-Replay
      */
-    object SessionReplay: CaptureDispatchers("session-replay")
+    object SessionReplay : CaptureDispatchers("session-replay")
 
-    private fun buildExecutorService(threadName: String): ExecutorService {
-        return Executors.newSingleThreadExecutor {
+    private fun buildExecutorService(threadName: String): ExecutorService =
+        Executors.newSingleThreadExecutor {
             Thread(it, "$CAPTURE_EXECUTOR_SERVICE_NAME.$threadName")
         }
-    }
 
     /**
      * Exposes [CapturedDispatchers.shutdownAll]

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
@@ -1,3 +1,10 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 package io.bitdrift.capture.threading
 
 import java.util.concurrent.ExecutorService
@@ -8,7 +15,7 @@ import java.util.concurrent.Executors
  *
  * The initial implementation exposes an [executorService]
  */
-sealed class CaptureDispatchers private constructor(
+internal sealed class CaptureDispatchers private constructor(
     threadName: String,
 ) {
     /**

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
@@ -7,13 +7,16 @@
 
 package io.bitdrift.capture
 
+import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.network.okhttp.OkHttpNetwork
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
+import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -43,6 +46,11 @@ class CaptureLoggerNetworkTest {
 
     companion object {
         val loggerBridge: TestMetadataProvider = TestMetadataProvider()
+    }
+
+    @Before
+    fun setUp() {
+        CaptureDispatchers.setTestExecutorService(MoreExecutors.newDirectExecutorService())
     }
 
     @After

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerSessionOverrideTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerSessionOverrideTest.kt
@@ -12,12 +12,14 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -52,6 +54,7 @@ class CaptureLoggerSessionOverrideTest {
         val initializer = ContextHolder()
         initializer.create(ApplicationProvider.getApplicationContext())
 
+        CaptureDispatchers.setTestExecutorService(MoreExecutors.newDirectExecutorService())
         CaptureJniLibrary.load()
 
         testServerPort = CaptureTestJniLibrary.startTestApiServer(-1)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -9,6 +9,7 @@ package io.bitdrift.capture
 
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -30,6 +31,7 @@ import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -64,6 +66,7 @@ class CaptureLoggerTest {
         val initializer = ContextHolder()
         initializer.create(ApplicationProvider.getApplicationContext())
 
+        CaptureDispatchers.setTestExecutorService(MoreExecutors.newDirectExecutorService())
         CaptureJniLibrary.load()
 
         testServerPort = CaptureTestJniLibrary.startTestApiServer(-1)

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/SessionReplayController.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/SessionReplayController.kt
@@ -15,7 +15,6 @@ import io.bitdrift.capture.replay.internal.ReplayCaptureEngine
 import io.bitdrift.capture.replay.internal.ScreenshotCaptureEngine
 import io.bitdrift.capture.replay.internal.WindowManager
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
  * Sets up and controls the replay feature

--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/SessionReplayController.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/SessionReplayController.kt
@@ -31,10 +31,7 @@ class SessionReplayController(
     sessionReplayConfiguration: SessionReplayConfiguration,
     context: Context,
     mainThreadHandler: MainThreadHandler,
-    executor: ExecutorService =
-        Executors.newSingleThreadExecutor {
-            Thread(it, "io.bitdrift.capture.session-replay")
-        },
+    executor: ExecutorService,
 ) {
     private val replayCaptureEngine: ReplayCaptureEngine
     private val screenshotCaptureEngine: ScreenshotCaptureEngine


### PR DESCRIPTION
# What

This is a follow up from @murki on https://github.com/bitdriftlabs/capture-sdk/pull/128/files#diff-118bdebccae8c1bde50314ef9d78f897d272e1f222d57a5d8a44d4f0f348b5d4R13 that proposes to consolidates all existing ExecutorService

This will be useful later on for https://github.com/bitdriftlabs/capture-sdk/pull/205 

# Verification

Verify sessions are captured in same manner and existing thread names remain the same:

- io.bitdrift.capture.event-listener
- io.bitdrift.capture.network.okhttp
- io.bitdrift.capture.session-replay