### PR TITLE
[Android] Make memoryClass return default megabytes

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProvider.kt
@@ -35,5 +35,5 @@ internal class MemoryMetricsProvider(
 
     private fun totalNativeHeapSize(): String = (Debug.getNativeHeapSize() / KB).toString()
 
-    private fun memoryClass(): String = (activityManager.memoryClass * KB).toString()
+    private fun memoryClass(): String = (activityManager.memoryClass).toString()
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ResourceUtilizationTargetTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ResourceUtilizationTargetTest.kt
@@ -76,7 +76,7 @@ class ResourceUtilizationTargetTest {
                     "_jvm_total_kb" to "100",
                     "_native_used_kb" to "200",
                     "_native_total_kb" to "500",
-                    "_memory_class" to "1024",
+                    "_memory_class" to "1",
                     "_battery_val" to "0.75",
                     "_state" to "charging",
                     "_low_power_enabled" to "1",

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeIMemoryMetricsProvider.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeIMemoryMetricsProvider.kt
@@ -37,7 +37,7 @@ class FakeIMemoryMetricsProvider : IMemoryMetricsProvider {
                 "_jvm_total_kb" to "100",
                 "_native_used_kb" to "200",
                 "_native_total_kb" to "500",
-                "_memory_class" to "1024",
+                "_memory_class" to "1",
             )
     }
 }


### PR DESCRIPTION
# What

Change `_memory_class` to return the default MB (currently is sending KB)

Related frontend PR 

# Verification

Verified on this session 

