### PR TITLE
[Android] Add thread count metadata to AppExit and UncaughtExceptionHandler

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -33,6 +33,7 @@ import io.bitdrift.capture.events.performance.BatteryMonitor
 import io.bitdrift.capture.events.performance.DiskUsageMonitor
 import io.bitdrift.capture.events.performance.MemoryMetricsProvider
 import io.bitdrift.capture.events.performance.ResourceUtilizationTarget
+import io.bitdrift.capture.events.performance.ThreadMetricsProvider
 import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
@@ -80,6 +81,7 @@ internal class LoggerImpl(
 ) : ILogger {
     private val metadataProvider: MetadataProvider
     private val memoryMetricsProvider = MemoryMetricsProvider(context)
+    private val threadMetricsProvider = ThreadMetricsProvider()
     private val batteryMonitor = BatteryMonitor(context)
     private val powerMonitor = PowerMonitor(context)
     private val diskUsageMonitor: DiskUsageMonitor
@@ -248,6 +250,7 @@ internal class LoggerImpl(
                         runtime,
                         errorHandler,
                         memoryMetricsProvider = memoryMetricsProvider,
+                        threadMetricsProvider = threadMetricsProvider,
                     )
 
                 // Install the app exit logger before the Capture logger is started to ensure

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/IThreadMetricsProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/IThreadMetricsProvider.kt
@@ -1,0 +1,18 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.performance
+
+/**
+ * Provides attributes for threads running in the app
+ */
+interface IThreadMetricsProvider {
+    /**
+     * Returns Thread information (e.g. Thread count)
+     */
+    fun getThreadAttributes(): Map<String, String>
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ThreadMetricsProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ThreadMetricsProvider.kt
@@ -1,0 +1,21 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.performance
+
+/**
+ * Concrete implementation of [IMemoryMetricsProvider]
+ */
+internal class ThreadMetricsProvider : IThreadMetricsProvider {
+    override fun getThreadAttributes(): Map<String, String> = mapOf(THREAD_COUNT_KEY to getCurrentThreadCount())
+
+    private fun getCurrentThreadCount(): String = Thread.getAllStackTraces().size.toString()
+
+    private companion object {
+        private const val THREAD_COUNT_KEY = "_total_thread_count"
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ThreadMetricsProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ThreadMetricsProvider.kt
@@ -11,11 +11,11 @@ package io.bitdrift.capture.events.performance
  * Concrete implementation of [IMemoryMetricsProvider]
  */
 internal class ThreadMetricsProvider : IThreadMetricsProvider {
-    override fun getThreadAttributes(): Map<String, String> = mapOf(THREAD_COUNT_KEY to getCurrentThreadCount())
+    override fun getThreadAttributes(): Map<String, String> = mapOf(THREAD_COUNT_KEY to getActiveThreadCount())
 
-    private fun getCurrentThreadCount(): String = Thread.getAllStackTraces().size.toString()
+    private fun getActiveThreadCount(): String = Thread.activeCount().toString()
 
     private companion object {
-        private const val THREAD_COUNT_KEY = "_total_thread_count"
+        private const val THREAD_COUNT_KEY = "_total_active_thread_count"
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/AppExitLoggerTest.kt
@@ -24,6 +24,8 @@ import io.bitdrift.capture.events.lifecycle.AppExitLogger
 import io.bitdrift.capture.events.lifecycle.CaptureUncaughtExceptionHandler
 import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider
 import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider.Companion.DEFAULT_MEMORY_ATTRIBUTES_MAP
+import io.bitdrift.capture.fakes.FakeThreadMetricsProvider
+import io.bitdrift.capture.fakes.FakeThreadMetricsProvider.Companion.DEFAULT_THREAD_ATTRIBUTES_MAP
 import io.bitdrift.capture.providers.toFields
 import io.bitdrift.capture.utils.BuildVersionChecker
 import org.junit.Before
@@ -42,6 +44,8 @@ class AppExitLoggerTest {
     private val crashHandler: CaptureUncaughtExceptionHandler = mock()
     private val versionChecker: BuildVersionChecker = mock()
     private val memoryMetricsProvider = FakeIMemoryMetricsProvider()
+    private val fakeThreadMetricsProvider = FakeThreadMetricsProvider()
+
     private val appExitLogger =
         AppExitLogger(
             logger,
@@ -51,6 +55,7 @@ class AppExitLoggerTest {
             crashHandler,
             versionChecker,
             memoryMetricsProvider,
+            fakeThreadMetricsProvider,
         )
 
     @Before
@@ -163,6 +168,7 @@ class AppExitLoggerTest {
                 put("_app_exit_rss", "2")
                 put("_app_exit_description", "test-description")
                 putAll(DEFAULT_MEMORY_ATTRIBUTES_MAP)
+                putAll(DEFAULT_THREAD_ATTRIBUTES_MAP)
             }.toFields()
         verify(logger).log(
             eq(LogType.LIFECYCLE),
@@ -206,6 +212,7 @@ class AppExitLoggerTest {
                 put("_app_exit_details", appException.message.orEmpty())
                 put("_app_exit_thread", currentThread.name)
                 putAll(DEFAULT_MEMORY_ATTRIBUTES_MAP)
+                putAll(DEFAULT_THREAD_ATTRIBUTES_MAP)
             }.toFields()
         verify(logger).log(
             eq(LogType.LIFECYCLE),

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeThreadMetricsProvider.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeThreadMetricsProvider.kt
@@ -1,0 +1,22 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.fakes
+
+import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
+import io.bitdrift.capture.events.performance.IThreadMetricsProvider
+
+/**
+ * Fake [IMemoryMetricsProvider] with default memory attribute values
+ */
+class FakeThreadMetricsProvider : IThreadMetricsProvider {
+    override fun getThreadAttributes(): Map<String, String> = DEFAULT_THREAD_ATTRIBUTES_MAP
+
+    companion object {
+        val DEFAULT_THREAD_ATTRIBUTES_MAP = mapOf("_total_thread_count" to "25")
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeThreadMetricsProvider.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeThreadMetricsProvider.kt
@@ -17,6 +17,6 @@ class FakeThreadMetricsProvider : IThreadMetricsProvider {
     override fun getThreadAttributes(): Map<String, String> = DEFAULT_THREAD_ATTRIBUTES_MAP
 
     companion object {
-        val DEFAULT_THREAD_ATTRIBUTES_MAP = mapOf("_total_thread_count" to "25")
+        val DEFAULT_THREAD_ATTRIBUTES_MAP = mapOf("_total_active_thread_count" to "25")
     }
 }

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("com.jakewharton.timber:timber:5.0.1")
     implementation("com.google.android.material:material:1.8.0")
     implementation("com.squareup.papa:papa:0.26")
+    implementation("io.reactivex.rxjava3:rxjava:3.1.5")
 
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.4.0")
     debugImplementation("androidx.fragment:fragment-testing:1.6.2")

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -41,6 +41,7 @@ import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.apollo.CaptureApolloInterceptor
 import io.bitdrift.capture.network.okhttp.CaptureOkHttpEventListenerFactory
+import io.bitdrift.gradletestapp.appterminations.ArtifitialAppTerminations
 import io.bitdrift.gradletestapp.databinding.FragmentFirstBinding
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -259,11 +260,14 @@ class FirstFragment : Fragment() {
     private fun forceAppExit(view: View) {
         val selectedAppExitReason = binding.spnAppExitOptions.selectedItem.toString()
         when (AppExitReason.valueOf(selectedAppExitReason)) {
-            AppExitReason.APP_CRASH_EXCEPTION -> {
-                throw RuntimeException("Forced unhandled exception")
+            AppExitReason.APP_REGULAR_CRASH -> {
+                ArtifitialAppTerminations.forceRegularCrash()
+            }
+            AppExitReason.APP_CRASH_TOO_MANY_THREADS -> {
+                ArtifitialAppTerminations.forceTooManyThreadsCrash()
             }
             AppExitReason.ANR -> {
-                Thread.sleep(15000)
+                ArtifitialAppTerminations.forceAnr()
             }
             AppExitReason.SYSTEM_EXIT -> {
                 exitProcess(0)
@@ -277,8 +281,9 @@ class FirstFragment : Fragment() {
     }
 
     enum class AppExitReason {
-        APP_CRASH_EXCEPTION,
+        APP_REGULAR_CRASH,
         APP_CRASH_NATIVE,
+        APP_CRASH_TOO_MANY_THREADS,
         SYSTEM_EXIT,
         ANR
     }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/appterminations/ArtifitialAppTerminations.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/appterminations/ArtifitialAppTerminations.kt
@@ -1,0 +1,28 @@
+package io.bitdrift.gradletestapp.appterminations
+
+import io.bitdrift.capture.Capture
+import java.util.concurrent.Executors
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+
+object ArtifitialAppTerminations {
+
+    fun forceAnr() {
+        Thread.sleep(15000)
+    }
+
+    fun forceRegularCrash() {
+        throw RuntimeException("Forced unhandled exception")
+    }
+
+    fun forceTooManyThreadsCrash() {
+        Observable.interval(0, 100, TimeUnit.MICROSECONDS)
+            .observeOn(Schedulers.io())
+            .subscribeOn(Schedulers.io())
+            .subscribe {
+                Thread.sleep(200)
+            }
+    }
+}


### PR DESCRIPTION
For now adding current thread count to AppExit and UncaughtExceptionHandler.

For OOM crashes due to Too many threads this will be useful information for Crash reporting (this thread count can be comparable to the number of threads at initial cold launch via AppExit report)

# Verification

https://timeline.bitdrift.dev/session/a39246be-9910-4348-8dfe-23bac740ffdb?pages=1&utilization=0&expanded=2918627673516284925

![Screenshot 2025-02-06 at 7 13 50 PM](https://github.com/user-attachments/assets/87f689fe-65db-4b6d-8f42-e57b1637c24e)

![Screenshot 2025-02-06 at 7 16 29 PM](https://github.com/user-attachments/assets/eeb2367b-4d13-42b0-aade-1a92fcd402b6)


