### PR TITLE
[Android] Move expensive AppExitLogger methods off the main thread

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -76,7 +76,7 @@ internal class LoggerImpl(
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
     private val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     private val bridge: IBridge = CaptureJniLibrary,
-    private val eventListenerDispatcher: CaptureDispatchers.EventListener = CaptureDispatchers.EventListener,
+    private val eventListenerDispatcher: CaptureDispatchers.CommonBackground = CaptureDispatchers.CommonBackground,
 ) : ILogger {
     private val metadataProvider: MetadataProvider
     private val memoryMetricsProvider = MemoryMetricsProvider(context)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -60,7 +60,6 @@ internal class AppExitLogger(
         if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)) {
             return
         }
-//        checkIsNotOnMainThread()
         backgroundThreadHandler.runAsync {
             crashHandler.install(this)
             saveCurrentSessionId()

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -54,13 +54,16 @@ internal class AppExitLogger(
         private const val APP_EXIT_DESCRIPTION_KEY = "_app_exit_description"
     }
 
+    @WorkerThread
     fun installAppExitLogger() {
         if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)) {
             return
         }
-        crashHandler.install(this)
-        saveCurrentSessionId()
-        logPreviousExitReasonIfAny()
+        commonBackgroundDispatcher.launchAsync {
+            crashHandler.install(this)
+            saveCurrentSessionId()
+            logPreviousExitReasonIfAny()
+        }
     }
 
     fun uninstallAppExitLogger() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -172,7 +172,7 @@ internal class OkHttpNetwork(
                         response: Response,
                     ) {
                         // Once we get a response handle, hand it over to the executor for async processing.
-                        networkDispatcher.launchAsync {
+                        networkDispatcher.runAsync {
                             response.use {
                                 consumeResponse(response)
                             }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -172,7 +172,7 @@ internal class OkHttpNetwork(
                         response: Response,
                     ) {
                         // Once we get a response handle, hand it over to the executor for async processing.
-                        networkDispatcher.executorService.execute {
+                        networkDispatcher.launchAsync {
                             response.use {
                                 consumeResponse(response)
                             }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
@@ -30,9 +30,16 @@ internal sealed class CaptureDispatchers private constructor(
         get() = _executorService
 
     /**
-     * [ExecutorService] to be used for handling different types of [EventsListenerTarget]
+     * Run the specified task on the associated CaptureDispatcher
      */
-    object EventListener : CaptureDispatchers("event-listener")
+    fun launchAsync(task: () -> Unit) {
+        executorService.execute(task)
+    }
+
+    /**
+     * [ExecutorService] A common background single thread worker that will be used to process events sequentially
+     */
+    object CommonBackground : CaptureDispatchers("background-thread-worker")
 
     /**
      * [ExecutorService] to be used for networking capture
@@ -72,7 +79,7 @@ internal sealed class CaptureDispatchers private constructor(
         @JvmStatic
         @VisibleForTesting
         internal fun setTestExecutorService(testExecutorService: ExecutorService) {
-            listOf(EventListener, Network, SessionReplay).forEach {
+            listOf(CommonBackground, Network, SessionReplay).forEach {
                 it._executorService = testExecutorService
             }
         }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/threading/CaptureDispatchers.kt
@@ -8,6 +8,7 @@
 package io.bitdrift.capture.threading
 
 import androidx.annotation.VisibleForTesting
+import io.bitdrift.capture.common.IBackgroundThreadHandler
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -18,7 +19,7 @@ import java.util.concurrent.Executors
  */
 internal sealed class CaptureDispatchers private constructor(
     threadName: String,
-) {
+) : IBackgroundThreadHandler {
     private var _executorService: ExecutorService =
         buildExecutorService(threadName)
             .also { register(this) }
@@ -32,7 +33,7 @@ internal sealed class CaptureDispatchers private constructor(
     /**
      * Run the specified task on the associated CaptureDispatcher
      */
-    fun launchAsync(task: () -> Unit) {
+    override fun runAsync(task: () -> Unit) {
         executorService.execute(task)
     }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/AppExitLoggerTest.kt
@@ -10,7 +10,6 @@ package io.bitdrift.capture
 import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo
 import android.app.ApplicationExitInfo
-import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argThat
@@ -23,10 +22,10 @@ import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.lifecycle.AppExitLogger
 import io.bitdrift.capture.events.lifecycle.CaptureUncaughtExceptionHandler
-import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider
-import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider.Companion.DEFAULT_MEMORY_ATTRIBUTES_MAP
+import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
+import io.bitdrift.capture.fakes.FakeMemoryMetricsProvider
+import io.bitdrift.capture.fakes.FakeMemoryMetricsProvider.Companion.DEFAULT_MEMORY_ATTRIBUTES_MAP
 import io.bitdrift.capture.providers.toFields
-import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.BuildVersionChecker
 import org.junit.Before
 import org.junit.Test
@@ -44,12 +43,12 @@ class AppExitLoggerTest {
     private val errorHandler: ErrorHandler = mock()
     private val crashHandler: CaptureUncaughtExceptionHandler = mock()
     private val versionChecker: BuildVersionChecker = mock()
-    private val memoryMetricsProvider = FakeIMemoryMetricsProvider()
+    private val memoryMetricsProvider = FakeMemoryMetricsProvider()
+    private val backgroundThreadHandler = FakeBackgroundThreadHandler()
     private lateinit var appExitLogger: AppExitLogger
 
     @Before
     fun setUp() {
-        CaptureDispatchers.setTestExecutorService(MoreExecutors.newDirectExecutorService())
         whenever(runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)).thenReturn(true)
         whenever(versionChecker.isAtLeast(anyInt())).thenReturn(true)
         appExitLogger =
@@ -61,6 +60,7 @@ class AppExitLoggerTest {
                 crashHandler,
                 versionChecker,
                 memoryMetricsProvider,
+                backgroundThreadHandler,
             )
     }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/AppExitLoggerTest.kt
@@ -10,6 +10,7 @@ package io.bitdrift.capture
 import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo
 import android.app.ApplicationExitInfo
+import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argThat
@@ -25,6 +26,7 @@ import io.bitdrift.capture.events.lifecycle.CaptureUncaughtExceptionHandler
 import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider
 import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider.Companion.DEFAULT_MEMORY_ATTRIBUTES_MAP
 import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.BuildVersionChecker
 import org.junit.Before
 import org.junit.Test
@@ -38,25 +40,28 @@ class AppExitLoggerTest {
     private val logger: LoggerImpl = mock()
     private val activityManager: ActivityManager = mock()
     private val runtime: Runtime = mock()
+
     private val errorHandler: ErrorHandler = mock()
     private val crashHandler: CaptureUncaughtExceptionHandler = mock()
     private val versionChecker: BuildVersionChecker = mock()
     private val memoryMetricsProvider = FakeIMemoryMetricsProvider()
-    private val appExitLogger =
-        AppExitLogger(
-            logger,
-            activityManager,
-            runtime,
-            errorHandler,
-            crashHandler,
-            versionChecker,
-            memoryMetricsProvider,
-        )
+    private lateinit var appExitLogger: AppExitLogger
 
     @Before
     fun setUp() {
+        CaptureDispatchers.setTestExecutorService(MoreExecutors.newDirectExecutorService())
         whenever(runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)).thenReturn(true)
         whenever(versionChecker.isAtLeast(anyInt())).thenReturn(true)
+        appExitLogger =
+            AppExitLogger(
+                logger,
+                activityManager,
+                runtime,
+                errorHandler,
+                crashHandler,
+                versionChecker,
+                memoryMetricsProvider,
+            )
     }
 
     @Test

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ResourceUtilizationTargetTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ResourceUtilizationTargetTest.kt
@@ -18,7 +18,7 @@ import io.bitdrift.capture.events.common.PowerMonitor
 import io.bitdrift.capture.events.performance.BatteryMonitor
 import io.bitdrift.capture.events.performance.DiskUsageMonitor
 import io.bitdrift.capture.events.performance.ResourceUtilizationTarget
-import io.bitdrift.capture.fakes.FakeIMemoryMetricsProvider
+import io.bitdrift.capture.fakes.FakeMemoryMetricsProvider
 import org.junit.After
 import org.junit.Test
 import java.util.concurrent.ExecutorService
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 
 class ResourceUtilizationTargetTest {
-    private val memoryMetricsProvider = FakeIMemoryMetricsProvider()
+    private val memoryMetricsProvider = FakeMemoryMetricsProvider()
     private val batteryMonitor: BatteryMonitor = mock()
     private val powerMonitor: PowerMonitor = mock()
     private val diskUsageMonitor: DiskUsageMonitor = mock()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeBackgroundThreadHandler.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeBackgroundThreadHandler.kt
@@ -1,0 +1,22 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.fakes
+
+import com.google.common.util.concurrent.MoreExecutors
+import io.bitdrift.capture.common.IBackgroundThreadHandler
+
+/**
+ * Fake [IBackgroundThreadHandler] that relies on newDirectExecutorService
+ */
+class FakeBackgroundThreadHandler : IBackgroundThreadHandler {
+    private val fakeExecutorService = MoreExecutors.newDirectExecutorService()
+
+    override fun runAsync(task: () -> Unit) {
+        fakeExecutorService.execute(task)
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeMemoryMetricsProvider.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeMemoryMetricsProvider.kt
@@ -12,7 +12,7 @@ import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
 /**
  * Fake [IMemoryMetricsProvider] with default memory attribute values
  */
-class FakeIMemoryMetricsProvider : IMemoryMetricsProvider {
+class FakeMemoryMetricsProvider : IMemoryMetricsProvider {
     private var exception: Exception? = null
 
     override fun getMemoryAttributes(): Map<String, String> {

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/IBackgroundThreadHandler.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/IBackgroundThreadHandler.kt
@@ -1,0 +1,18 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.common
+
+/**
+ * Runs the specified task on a background thread
+ */
+interface IBackgroundThreadHandler {
+    /**
+     * Runs the specified task off the main thread
+     */
+    fun runAsync(task: () -> Unit)
+}

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
@@ -25,4 +25,27 @@ class MainThreadHandler {
     fun run(run: () -> Unit) {
         mainHandler.post { run() }
     }
+
+    /**
+     * Common main thread checkers
+     */
+    companion object {
+        private const val CALLED_FROM_MAIN_THREAD = "Should not be called from the main thread"
+
+        /**
+         * Checks whether this call happens on the main thread
+         */
+        @JvmStatic
+        fun checkIsNotOnMainThread() {
+            if (isOnMainThread()) {
+                throw IllegalStateException(CALLED_FROM_MAIN_THREAD)
+            }
+        }
+
+        /**
+         * Checks whether this call happens on the main thread
+         */
+        @JvmStatic
+        fun isOnMainThread(): Boolean = Looper.myLooper() == Looper.getMainLooper()
+    }
 }

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
@@ -25,27 +25,4 @@ class MainThreadHandler {
     fun run(run: () -> Unit) {
         mainHandler.post { run() }
     }
-
-    /**
-     * Common main thread checkers
-     */
-    companion object {
-        private const val CALLED_FROM_MAIN_THREAD = "Should not be called from the main thread"
-
-        /**
-         * Checks whether this call happens on the main thread
-         */
-        @JvmStatic
-        fun checkIsNotOnMainThread() {
-            if (isOnMainThread()) {
-                throw IllegalStateException(CALLED_FROM_MAIN_THREAD)
-            }
-        }
-
-        /**
-         * Checks whether this call happens on the main thread
-         */
-        @JvmStatic
-        fun isOnMainThread(): Boolean = Looper.myLooper() == Looper.getMainLooper()
-    }
 }


### PR DESCRIPTION
## What

Following up on https://linear.app/bitdrift/issue/BIT-4410 proposing to make expensive AppExit methods a non-blocking call. This is given the potential impact on main thread as Capture.Logger.start() is going to be usually called on Application/Main activity onCreate

Local measurements shows that building and initializing AppExit is the main contributor to Capture.Logger.start() time.

# Verification

- Verified that crash/app exit terminations are reported successfully
- Verified that the session id is correct
- Validate improvements on main thread of Capture.Logger.start() call on low end device
- Modify existing microbenchmarks to measure with installAppExitLogger on main vs background

**NOTE: Please note that the whole method doesn't get executed given that there are no exit reasons so we early exit without appending app exit data and memory attributes

On current main
![image](https://github.com/user-attachments/assets/3a67fc5f-549e-4f04-bfd0-36fece18ad86)

On this diff
![image](https://github.com/user-attachments/assets/5dc0a4b8-5a58-4cf0-a28d-3c45ffa7106b)

Device used
![image](https://github.com/user-attachments/assets/0e5f292b-016a-42ce-be20-6f80681f0e11)
