### PR TITLE
[Android] Make Capture.Logger.start() return LoggerState

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -295,7 +295,7 @@ internal class LoggerImpl(
              *  `SharedPreferences`.
              */
             deviceCodeService.createTemporaryDeviceCode(deviceId, completion)
-        } ?: completion(Err(SdkNotStartedError))
+        } ?: completion(Err(SdkNotStartedError()))
     }
 
     private fun appExitSaveCurrentSessionId(sessionId: String? = null) {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Models.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Models.kt
@@ -57,4 +57,6 @@ sealed class ApiError(
 /**
  * Represents a failed operation due to the SDK not being started
  */
-data object SdkNotStartedError : Error("SDK not started")
+data class SdkNotStartedError(
+    override val message: String = "SDK not started",
+) : Error(message)

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
@@ -9,6 +9,7 @@ package io.bitdrift.gradletestapp;
 
 import io.bitdrift.capture.Capture;
 import io.bitdrift.capture.Configuration;
+import io.bitdrift.capture.LoggerState;
 import io.bitdrift.capture.providers.FieldProvider;
 import io.bitdrift.capture.providers.session.SessionStrategy;
 import io.bitdrift.capture.replay.SessionReplayConfiguration;
@@ -20,7 +21,7 @@ import java.util.UUID;
 import okhttp3.HttpUrl;
 
 public class BitdriftInit {
-    public static void initBitdriftCaptureInJava(HttpUrl apiUrl, String apiKey) {
+    public static LoggerState initBitdriftCaptureInJava(HttpUrl apiUrl, String apiKey) {
         String userID = UUID.randomUUID().toString();
         List<FieldProvider> fieldProviders = new ArrayList<>();
         fieldProviders.add(() -> {
@@ -29,7 +30,7 @@ public class BitdriftInit {
             return fields;
         });
 
-        Capture.Logger.start(
+        return Capture.Logger.start(
             apiKey,
             new SessionStrategy.ActivityBased(),
             new Configuration(),


### PR DESCRIPTION
Capture.Logger.start now returns current LoggerState. This could be useful in case of Logger.start initialization errors

See demo below on gradle test app

https://github.com/user-attachments/assets/fd6cfa27-2f76-47ee-b394-b1ef01df7b06
