### PR TITLE
[Android] [Dropped Frames] Adding Runtime.ConfigValue

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/JniRuntime.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/JniRuntime.kt
@@ -8,12 +8,15 @@
 package io.bitdrift.capture
 
 import io.bitdrift.capture.common.Runtime
+import io.bitdrift.capture.common.RuntimeConfig
 import io.bitdrift.capture.common.RuntimeFeature
 
 internal class JniRuntime(
     private val logger: LoggerId,
 ) : Runtime {
     override fun isEnabled(feature: RuntimeFeature): Boolean = Jni.isRuntimeEnabled(logger, feature.featureName, feature.defaultValue)
+
+    override fun getConfigValue(config: RuntimeConfig): Int = Jni.captureRuntimeIntValue(logger, config.configName, config.defaultValue)
 }
 
 internal object Jni {
@@ -22,4 +25,10 @@ internal object Jni {
         feature: String,
         defaultValue: Boolean,
     ): Boolean
+
+    external fun captureRuntimeIntValue(
+        logger: LoggerId,
+        variableName: String,
+        defaultValue: Int,
+    ): Int
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
@@ -21,6 +21,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.common.IWindowManager
 import io.bitdrift.capture.common.Runtime
+import io.bitdrift.capture.common.RuntimeConfig
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.performance.JankStatsMonitor
 import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
@@ -58,7 +59,10 @@ class JankStatsMonitorTest {
 
         whenever(processLifecycleOwner.lifecycle).thenReturn(lifecycle)
         whenever(windowManager.getCurrentWindow()).thenReturn(window)
+
         whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)
+        whenever(runtime.getConfigValue(RuntimeConfig.FROZEN_FRAME_THRESHOLD_IN_MILLI_SECONDS)).thenReturn(700)
+        whenever(runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS)).thenReturn(5000)
 
         jankStatsMonitor =
             JankStatsMonitor(
@@ -101,6 +105,20 @@ class JankStatsMonitorTest {
     @Test
     fun onStateChanged_withOnResumeAndAnrFrame_shouldLogWithErrorAndAnrMessage() {
         val jankDurationInMilli = 5000L
+
+        triggerLifecycleEvent(
+            lifecycleEvent = Lifecycle.Event.ON_RESUME,
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        assertLogDetails(jankDurationInMilli, LogLevel.ERROR, "ANR")
+    }
+
+    @Test
+    fun onStateChanged_withOnResumeAndUpdatedConfigAnrValueAndAnrFrame_shouldLogWithErrorAndAnrMessage() {
+        whenever(runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS)).thenReturn(2000)
+        val jankDurationInMilli = 2000L
 
         triggerLifecycleEvent(
             lifecycleEvent = Lifecycle.Event.ON_RESUME,

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -70,6 +70,43 @@ sealed class RuntimeFeature(
 }
 
 /**
+ * Known runtime config values.
+ * @param configName the runtime key to use for this config value
+ * @param defaultValue The value
+ */
+sealed class RuntimeConfig(
+    val configName: String,
+    val defaultValue: Int,
+) {
+    /**
+     * The configured value for [jankHeuristicMultiplier] from [JankStatsMonitoring]. More info at https://developer.android.com/topic/performance/jankstats#jank-heuristics
+     */
+    data object JANK_FRAME_HEURISTICS_MULTIPLIER : RuntimeConfig("client_feature.android.jank_frame_heuristics", 2)
+
+    /**
+     * The upper bound threshold that defines what constitutes a FROZEN frame reported via [JankStats]
+     *
+     * The default value is 700ms
+     *
+     * Slow Frame: >=16ms to < FROZEN_FRAME_THRESHOLD_IN_MILLI_SECONDS
+     * Frozen Frame: >=FROZEN_FRAME_THRESHOLD_IN_MILLI_SECONDS to <ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS
+     * ANR Frame: >=ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS
+     */
+    data object FROZEN_FRAME_THRESHOLD_IN_MILLI_SECONDS : RuntimeConfig("client_feature.android.frozen_frame_threshold", 700)
+
+    /**
+     * The upper bound threshold that defines what constitutes an ANR frame reported via [JankStats]
+     *
+     * The default value is 5000ms
+     *
+     * Slow Frame: >=16ms to < FROZEN_FRAME_THRESHOLD_IN_MILLI_SECONDS
+     * Frozen Frame: >=FROZEN_FRAME_THRESHOLD_IN_MILLI_SECONDS to <ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS
+     * ANR Frame: >=ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS
+     */
+    data object ANR_FRAME_THRESHOLD_IN_MILLI_SECONDS : RuntimeConfig("client_feature.android.anr_frame_threshold", 5000)
+}
+
+/**
  * Allows checking whether a runtime feature is enabled. Features may be remotely disabled via the a runtime flag, making it possible to
  * disable features that are known to be problematic with certain SDK versions.
  */
@@ -79,4 +116,10 @@ interface Runtime {
      * @param feature the feature flag to check
      */
     fun isEnabled(feature: RuntimeFeature): Boolean
+
+    /**
+     * Returns the configured Int value
+     * @param config the configuration value to check
+     */
+    fun getConfigValue(config: RuntimeConfig): Int
 }

--- a/platform/jvm/src/jni.rs
+++ b/platform/jvm/src/jni.rs
@@ -1181,6 +1181,31 @@ pub extern "system" fn Java_io_bitdrift_capture_Jni_isRuntimeEnabled(
   .into()
 }
 
+#[no_mangle]
+pub extern "system" fn Java_io_bitdrift_capture_Jni_captureRuntimeIntValue(
+  env: JNIEnv<'_>,
+  _class: JClass<'_>,
+  logger_id: jlong,
+  variable_name: JString<'_>,
+  default_value: jint,
+) -> jint {
+  bd_client_common::error::with_handle_unexpected_or(
+    || {
+      let logger = unsafe { LoggerId::from_raw(logger_id) };
+      let binding = unsafe { env.get_string_unchecked(&variable_name) }?;
+      let variable_name = binding.to_str()?;
+      Ok(
+        logger
+          .runtime_snapshot()
+          .get_integer(variable_name, default_value as u32) as jint,
+      )
+    },
+    default_value,
+    "jni captureRuntimeIntValue",
+  )
+  .into()
+}
+
 fn unix_milliseconds_to_date(millis_since_utc_epoch: i64) -> anyhow::Result<OffsetDateTime> {
   let seconds = millis_since_utc_epoch / 1000;
   let nano = (millis_since_utc_epoch % 1000) * 10_i64.pow(6);


### PR DESCRIPTION
## What

Tech spec https://docs.google.com/document/d/1KPu7DZEl6qzI8P4s5WNr-yqg4DJQkzLcHg9RPWAJVTQ/edit?tab=t.t6ha7ymkk1n2

Follow up from https://github.com/bitdriftlabs/capture-sdk/pull/222 where now these fields are controlled by RuntimeConfig as listed on the proposal doc

- `android.jank_frame_heuristics_multiplier` with default of 2
- `android.frozen_frame_threshold` with default of 700ms
- `android.anr_frame_threshold` with default of 5000ms