### PR TITLE
Confirm explicit support for URLSessionTask(s)

### DIFF
--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -29,18 +29,20 @@ final class URLSessionTaskTracker {
 
     static let shared = URLSessionTaskTracker()
 
+    private func supports(task: URLSessionTask) -> Bool {
+        // TODO(fz): Add supports for other types of tasks (stream, download, avdownload, etc).
+        return (
+            task is URLSessionDataTask ||
+            task is URLSessionDownloadTask ||
+            task is URLSessionUploadTask
+        )
+    }
+    
     func taskWillStart(_ task: URLSessionTask) {
-        // TODO(Augustyniak): Add supports for the these two types of tasks.
-        if task is URLSessionStreamTask {
+        if !self.supports(task: task) {
             return
         }
-
-        if #available(iOS 13.0, *) {
-            if task is URLSessionWebSocketTask {
-                return
-            }
-        }
-
+        
         self.lock.withLock {
             guard task.cap_requestInfo == nil else {
                 // Defensive check in case we've logged a request for a given task already.

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -60,6 +60,10 @@ final class URLSessionTaskTracker {
 
     // Observation: This method is called on `URLSession` delegate queue.
     func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        if !self.supports(task: task) {
+            return
+        }
+
         self.lock.withLock {
             guard let requestInfo = task.cap_requestInfo else {
                 return

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -14,7 +14,9 @@ extension URLSessionTask {
     @objc
     func cap_resume() {
         defer { self.cap_resume() }
-        if self.state == .completed || self.state == .canceling {
+        if self.state == .completed || self.state == .canceling ||
+            !URLSessionTaskTracker.supports(task: self)
+        {
             return
         }
 

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -5,8 +5,8 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-@testable import Capture
 import AVFoundation
+@testable import Capture
 import CaptureMocks
 import Foundation
 import XCTest

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -6,6 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 @testable import Capture
+import AVFoundation
 import CaptureMocks
 import Foundation
 import XCTest
@@ -130,6 +131,32 @@ final class URLSessionIntegrationTests: XCTestCase {
             self.customTearDown()
             session.finishTasksAndInvalidate()
         }
+    }
+
+    @available(iOS 15.0, *)
+    func testCreateInvalidTask() throws {
+        self.customSetUp(swizzle: true)
+
+        let requestExpectation = self.expectation(description: "request not logged")
+        requestExpectation.isInverted = true
+        let responseExpectation = self.expectation(description: "response not logged")
+        responseExpectation.isInverted = true
+
+        let session = AVAssetDownloadURLSession(configuration: .background(withIdentifier: "w00t"),
+                                                assetDownloadDelegate: nil,
+                                                delegateQueue: nil)
+
+        let task = session
+            .makeAssetDownloadTask(downloadConfiguration: .init(asset: .init(url: self.makeURL()),
+                                                                title: "we"))
+        task.resume()
+
+        XCTAssertEqual(
+            .completed,
+            XCTWaiter().wait(for: [requestExpectation, responseExpectation], timeout: 2)
+        )
+
+        XCTAssertTrue(self.logger.logs.isEmpty)
     }
 
     func testBackgroundSessionTasks() throws {


### PR DESCRIPTION
Before we were checking for specific unsupported task types, flipping it around because we keep finding Task's types iOS throws ObjC runtime exceptions when accessing certain properties.
