### PR TITLE
[Android] [Dropped Frames] Adding another config value for min threshold

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -52,8 +52,6 @@ internal class JankStatsMonitor(
     JankStats.OnFrameListener {
     private var jankStats: JankStats? = null
 
-    private val minJankFrameThresholdMs by lazy { runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS) }
-
     override fun start() {
         mainThreadHandler.run {
             processLifecycleOwner.lifecycle.addObserver(this)
@@ -78,7 +76,20 @@ internal class JankStatsMonitor(
     }
 
     override fun onFrame(volatileFrameData: FrameData) {
-        if (volatileFrameData.isJankAndMinDurationReached()) {
+        if (volatileFrameData.isJank) {
+            if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+                stopCollection()
+                return
+            }
+
+            if (volatileFrameData.durationToMilli()
+                < runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)
+            ) {
+                // The Frame is considered as Jank but it didn't reached the min
+                // threshold defined by MIN_JANK_FRAME_THRESHOLD_MS config
+                return
+            }
+
             // Below API 24 [onFrame(volatileFrameData)] call happens on the main thread
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
                 backgroundThreadHandler.runAsync { volatileFrameData.sendJankFrameData() }
@@ -88,15 +99,6 @@ internal class JankStatsMonitor(
             }
         }
     }
-
-    /**
-     * Will only report frames as Jank if duration is at least the configured value at
-     * `MIN_JANK_FRAME_THRESHOLD_MS` (which is a default of 16 ms).
-     * This is given that depending on device characteristics, frame can be reported as Jank
-     * even the duration is below 16 ms
-     */
-    private fun FrameData.isJankAndMinDurationReached(): Boolean =
-        isJank && minJankFrameThresholdMs > this.durationToMilli()
 
     @UiThread
     private fun setJankStatsForCurrentWindow(window: Window) {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -90,10 +90,13 @@ internal class JankStatsMonitor(
     }
 
     /**
-     * Will only report frames as Jank if duration is at least the configured value at `MIN_JANK_FRAME_THRESHOLD_MS` (which is a default of 16 ms)
-     * This is given that depending on device characteristics, frame can be reported as Jank even the duration is below 16 ms
+     * Will only report frames as Jank if duration is at least the configured value at
+     * `MIN_JANK_FRAME_THRESHOLD_MS` (which is a default of 16 ms).
+     * This is given that depending on device characteristics, frame can be reported as Jank
+     * even the duration is below 16 ms
      */
-    private fun FrameData.isJankAndMinDurationReached(): Boolean = isJank && minJankFrameThresholdMs > this.durationToMilli()
+    private fun FrameData.isJankAndMinDurationReached(): Boolean =
+        isJank && minJankFrameThresholdMs > this.durationToMilli()
 
     @UiThread
     private fun setJankStatsForCurrentWindow(window: Window) {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
@@ -63,7 +63,6 @@ class JankStatsMonitorTest {
         whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)
         whenever(runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)).thenReturn(16)
         whenever(runtime.getConfigValue(RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS)).thenReturn(700)
-        whenever(runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)).thenReturn(16)
         whenever(runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_MS)).thenReturn(5000)
 
         jankStatsMonitor =

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
@@ -61,6 +61,7 @@ class JankStatsMonitorTest {
         whenever(windowManager.getCurrentWindow()).thenReturn(window)
 
         whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)
+        whenever(runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)).thenReturn(16)
         whenever(runtime.getConfigValue(RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS)).thenReturn(700)
         whenever(runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_MS)).thenReturn(5000)
 
@@ -127,6 +128,17 @@ class JankStatsMonitorTest {
         )
 
         assertLogDetails(jankDurationInMilli, LogLevel.ERROR, "ANR")
+    }
+
+    @Test
+    fun onStateChanged_withJankyFrameBelowMinThreshold_shouldNotLogAnyMessage() {
+        triggerLifecycleEvent(
+            lifecycleEvent = Lifecycle.Event.ON_RESUME,
+            isJankyFrame = true,
+            durationInMilli = 4L,
+        )
+
+        verify(logger, never()).log(any(), any(), any(), any())
     }
 
     @Test

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -84,11 +84,22 @@ sealed class RuntimeConfig(
     data object JANK_FRAME_HEURISTICS_MULTIPLIER : RuntimeConfig("client_feature.android.jank_frame_heuristics_multiplier", 2)
 
     /**
+     * The lower bound threshold on what it defines a Jank Frame by its duration [JankStats]
+     *
+     * The default value is 16 ms
+     *
+     * Slow Frame: >= MIN_JANK_FRAME_THRESHOLD_MS to < FROZEN_FRAME_THRESHOLD_MS
+     * Frozen Frame: >= FROZEN_FRAME_THRESHOLD_MS to < ANR_FRAME_THRESHOLD_MS
+     * ANR Frame: >= ANR_FRAME_THRESHOLD_MS
+     */
+    data object MIN_JANK_FRAME_THRESHOLD_MS : RuntimeConfig("client_feature.android.min_jank_frame.threshold_ms", 16)
+
+    /**
      * The upper bound threshold that defines what constitutes a FROZEN frame reported via [JankStats]
      *
      * The default value is 700ms
      *
-     * Slow Frame: >= 16ms to < FROZEN_FRAME_THRESHOLD_MS
+     * Slow Frame: >= MIN_JANK_FRAME_THRESHOLD_MS to < FROZEN_FRAME_THRESHOLD_MS
      * Frozen Frame: >= FROZEN_FRAME_THRESHOLD_MS to < ANR_FRAME_THRESHOLD_MS
      * ANR Frame: >= ANR_FRAME_THRESHOLD_MS
      */
@@ -99,7 +110,7 @@ sealed class RuntimeConfig(
      *
      * The default value is 5000ms
      *
-     * Slow Frame: >= 16ms to < FROZEN_FRAME_THRESHOLD_MS
+     * Slow Frame: >= MIN_JANK_FRAME_THRESHOLD_MS to < FROZEN_FRAME_THRESHOLD_MS
      * Frozen Frame: >= FROZEN_FRAME_THRESHOLD_MS to < ANR_FRAME_THRESHOLD_MS
      * ANR Frame: >= ANR_FRAME_THRESHOLD_MS
      */


### PR DESCRIPTION
Tech spec https://docs.google.com/document/d/1KPu7DZEl6qzI8P4s5WNr-yqg4DJQkzLcHg9RPWAJVTQ/edit?tab=t.t6ha7ymkk1n2

Adding another config threshold for what is considered Jank.

On local testing and changing to more strict heuristics value was still getting frames reported as janks below 16 ms (e.g. 4 ms)

In this manner we can also control a bit more the lower threshold in case this becomes super noisy