### PR TITLE
[Android][Dropped Frames] Add API level checks for duration

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -165,7 +165,7 @@ internal class JankStatsMonitor(
                 is FrameDataApi31 -> this.frameDurationTotalNanos
                 is FrameDataApi24 -> this.frameDurationCpuNanos
                 else -> {
-                    frameDurationUiNanos
+                    this.frameDurationUiNanos
                 }
             }
         return durationInNano / TO_MILLI

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -15,6 +15,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.metrics.performance.FrameData
+import androidx.metrics.performance.FrameDataApi24
+import androidx.metrics.performance.FrameDataApi31
 import androidx.metrics.performance.JankStats
 import io.bitdrift.capture.ErrorHandler
 import io.bitdrift.capture.LogLevel
@@ -157,7 +159,17 @@ internal class JankStatsMonitor(
             JankFrameType.ANR
         }
 
-    private fun FrameData.durationToMilli(): Long = this.frameDurationUiNanos / TO_MILLI
+    private fun FrameData.durationToMilli(): Long {
+        val durationInNano =
+            when (this) {
+                is FrameDataApi31 -> this.frameDurationTotalNanos
+                is FrameDataApi24 -> this.frameDurationCpuNanos
+                else -> {
+                    frameDurationUiNanos
+                }
+            }
+        return durationInNano / TO_MILLI
+    }
 
     /**
      * The different type of Janks according to Play Vitals

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -77,6 +77,11 @@ internal class JankStatsMonitor(
 
     override fun onFrame(volatileFrameData: FrameData) {
         if (volatileFrameData.isJank) {
+            if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+                stopCollection()
+                return
+            }
+
             // Below API 24 [onFrame(volatileFrameData)] call happens on the main thread
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
                 backgroundThreadHandler.runAsync { volatileFrameData.sendJankFrameData() }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -76,11 +76,6 @@ internal class JankStatsMonitor(
     }
 
     override fun onFrame(volatileFrameData: FrameData) {
-        if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
-            stopCollection()
-            return
-        }
-
         if (volatileFrameData.isJank) {
             // Below API 24 [onFrame(volatileFrameData)] call happens on the main thread
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
@@ -162,10 +157,10 @@ internal class JankStatsMonitor(
     private fun FrameData.durationToMilli(): Long {
         val durationInNano =
             when (this) {
-                is FrameDataApi31 -> this.frameDurationTotalNanos
-                is FrameDataApi24 -> this.frameDurationCpuNanos
+                is FrameDataApi31 -> frameDurationTotalNanos
+                is FrameDataApi24 -> frameDurationCpuNanos
                 else -> {
-                    this.frameDurationUiNanos
+                    frameDurationUiNanos
                 }
             }
         return durationInNano / TO_MILLI


### PR DESCRIPTION
Kudos to @murki for the investigation

In order to retrieve more accurate total jank frame duration, adding API level check