### PR TITLE
More metrics to our network responses captures

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpRequestMetrics.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpRequestMetrics.kt
@@ -34,4 +34,31 @@ data class HttpRequestMetrics
          * of a given HTTP request.
          */
         internal var dnsResolutionDurationMs: Long? = null,
+
+        /**
+         * The cumulative duration of all TLS handshakes performed during the execution of a given
+         * HTTP request. Due to retries of different routes or redirects a single pair of
+         * `callStart` and `callEnd`/`callFailed` may include multiple TLS handshakes.
+         */
+        internal var tlsDurationMs: Long? = null,
+
+        /**
+         * The cumulative duration of all TCP handshakes performed during the execution of a given
+         * HTTP request. Due to retries of different routes or redirects a single pair of
+         * `callStart` and `callEnd`/`callFailed` may include multiple TCP handshakes.
+         */
+        internal var tcpDurationMs: Long? = null,
+
+        /**
+         * The duration between the `callStart` and the first DNS resolution.
+         */
+        internal var fetchInitializationMs: Long? = null,
+
+        /**
+         * The cumulative duration of all responses from the time the request is sent to the time we
+         * get the first byte from the server. Due to retries of different routes or redirects a
+         * single pair of `callStart` and `callEnd`/`callFailed` may include multiple
+         * request/responses.
+         */
+        internal var responseLatencyMs: Long? = null,
     )

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpRequestMetrics.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpRequestMetrics.kt
@@ -34,26 +34,22 @@ data class HttpRequestMetrics
          * of a given HTTP request.
          */
         internal var dnsResolutionDurationMs: Long? = null,
-
         /**
          * The cumulative duration of all TLS handshakes performed during the execution of a given
          * HTTP request. Due to retries of different routes or redirects a single pair of
          * `callStart` and `callEnd`/`callFailed` may include multiple TLS handshakes.
          */
         internal var tlsDurationMs: Long? = null,
-
         /**
          * The cumulative duration of all TCP handshakes performed during the execution of a given
          * HTTP request. Due to retries of different routes or redirects a single pair of
          * `callStart` and `callEnd`/`callFailed` may include multiple TCP handshakes.
          */
         internal var tcpDurationMs: Long? = null,
-
         /**
          * The duration between the `callStart` and the first DNS resolution.
          */
         internal var fetchInitializationMs: Long? = null,
-
         /**
          * The cumulative duration of all responses from the time the request is sent to the time we
          * get the first byte from the server. Due to retries of different routes or redirects a

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpResponseInfo.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpResponseInfo.kt
@@ -100,6 +100,10 @@ data class HttpResponseInfo
                                 FieldValue.StringField(it.responseHeadersBytesCount.toString()),
                             )
                             putOptional("_dns_resolution_duration_ms", it.dnsResolutionDurationMs)
+                            putOptional("_tls_duration_ms", it.tlsDurationMs)
+                            putOptional("_tcp_duration_ms", it.tcpDurationMs)
+                            putOptional("_fetch_init_duration_ms", it.fetchInitializationMs)
+                            putOptional("_response_latency_ms", it.responseLatencyMs)
                         }
                     }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
@@ -154,7 +154,7 @@ internal class CaptureOkHttpEventListener internal constructor(
         val elapsed = clock.elapsedRealtime()
 
         // Calculate initialization time as the first dnsStart - callStart
-        if (fetchInitializationMs == null ) {
+        if (fetchInitializationMs == null) {
             fetchInitializationMs = (elapsed - callStartTimeMs)
         }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
@@ -56,9 +56,17 @@ class CaptureOkHttpEventListenerFactoryTest {
         val fetchInitDurationMs = dnsStartTimeMs - callStartTimeMs
         val responseLatencyMs = responseHeadersStartTimeMs - requestBodyEndTimeMs
         whenever(clock.elapsedRealtime()).thenReturn(
-            callStartTimeMs, dnsStartTimeMs, dnsEndTimeMs, connectStartTimeMs,  tlsStartTimeMs,
-            tlsEndTimeMs, connectEndTimeMs, requestHeadersEndTimeMs, requestBodyEndTimeMs,
-            responseHeadersStartTimeMs, callEndtimeMs
+            callStartTimeMs,
+            dnsStartTimeMs,
+            dnsEndTimeMs,
+            connectStartTimeMs,
+            tlsStartTimeMs,
+            tlsEndTimeMs,
+            connectEndTimeMs,
+            requestHeadersEndTimeMs,
+            requestBodyEndTimeMs,
+            responseHeadersStartTimeMs,
+            callEndtimeMs,
         )
 
         val request =

--- a/platform/swift/source/logging/HTTPRequestMetrics.swift
+++ b/platform/swift/source/logging/HTTPRequestMetrics.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 /// Metrics collected for the execution of an HTTP request.
+/// 
+/// See https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics for
+/// the flow of these events.
 public struct HTTPRequestMetrics {
     /// The number of body bytes sent over-the-wire.
     let requestBodyBytesSentCount: Int64?

--- a/platform/swift/source/logging/HTTPRequestMetrics.swift
+++ b/platform/swift/source/logging/HTTPRequestMetrics.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Metrics collected for the execution of an HTTP request.
-/// 
+///
 /// See https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics for
 /// the flow of these events.
 public struct HTTPRequestMetrics {
@@ -121,7 +121,6 @@ extension HTTPRequestMetrics {
                 {
                     return nil
                 }
-                
 
                 return endDate.timeIntervalSince(startDate)
             }
@@ -131,7 +130,6 @@ extension HTTPRequestMetrics {
         } else {
             return nil
         }
-
     }
 
     private static func getResponseLatency(metrics: URLSessionTaskMetrics) -> TimeInterval? {

--- a/platform/swift/source/logging/HTTPResponseInfo.swift
+++ b/platform/swift/source/logging/HTTPResponseInfo.swift
@@ -127,9 +127,18 @@ public struct HTTPResponseInfo {
                     .flatMap(String.init)
                 fields["_response_headers_bytes_count"] = metrics.responseHeadersBytesCount
                     .flatMap(String.init)
-                fields["_dns_resolution_duration_ms"] = metrics.dnsResolutionDuration
-                    .flatMap { "\($0.toMilliseconds())" }
             }
+
+            fields["_dns_resolution_duration_ms"] = metrics.dnsResolutionDuration
+                .flatMap { "\($0.toMilliseconds())" }
+            fields["_tls_duration_ms"] = metrics.tlsDuration
+                .flatMap { "\($0.toMilliseconds())" }
+            fields["_tcp_duration_ms"] = metrics.tcpDuration
+                .flatMap { "\($0.toMilliseconds())" }
+            fields["_fetch_init_duration_ms"] = metrics.fetchInitializationDuration
+                .flatMap { "\($0.toMilliseconds())" }
+            fields["_response_latency_ms"] = metrics.responseLatency
+                .flatMap { "\($0.toMilliseconds())" }
         }
 
         return fields

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -818,6 +818,10 @@ final class URLSessionIntegrationTests: XCTestCase {
 
         let expectedOptionalFields = [
             "_dns_resolution_duration_ms",
+            "_tls_duration_ms",
+            "_tcp_duration_ms",
+            "_fetch_init_duration_ms",
+            "_response_latency_ms",
         ]
 
         for field in expectedOptionalFields {


### PR DESCRIPTION
android example session: https://timeline.bitdrift.dev/session/d492111c-651f-4c2b-b1c7-4ccc5a94e851?pages=1&utilization=0&h=6442453973147137303