### PR TITLE
include build-id in release android builds

### DIFF
--- a/platform/jvm/BUILD.bazel
+++ b/platform/jvm/BUILD.bazel
@@ -14,6 +14,7 @@ cc_binary(
     linkopts = [
         "-lm",  # Required to avoid dlopen runtime failures unrelated to rust
         "-lz",  # Link against system zlib library
+        "-Wl,--build-id", # Include build id in the binary
     ] + select({
         "@platforms//os:android": [
             "-Wl,-z,max-page-size=16384",  # enable 16 KB ELF alignment on Android to support API 35+
@@ -30,9 +31,6 @@ cc_binary(
             "-Wl,-framework,Security",
         ],
         "//conditions:default": ["@platforms//:incompatible"],
-    }) + select({
-        "//bazel:dbg_build": ["-Wl,--build-id"],
-        "//conditions:default": [],
     }),
     linkshared = True,
     tags = [

--- a/platform/jvm/BUILD.bazel
+++ b/platform/jvm/BUILD.bazel
@@ -14,11 +14,11 @@ cc_binary(
     linkopts = [
         "-lm",  # Required to avoid dlopen runtime failures unrelated to rust
         "-lz",  # Link against system zlib library
-        "-Wl,--build-id", # Include build id in the binary
     ] + select({
         "@platforms//os:android": [
             "-Wl,-z,max-page-size=16384",  # enable 16 KB ELF alignment on Android to support API 35+
             "-Wl,--retain-symbols-file=$(location :jni_symbols.lds)",
+            "-Wl,--build-id",  # Include build id in the binary
         ],
         "@platforms//os:linux": ["-Wl,--retain-symbols-file=$(location :jni_symbols.lds)"],
         # The linker on macos doesn't support the same options or file formats as linux, so use a pattern match here (not availabile on linux).


### PR DESCRIPTION
This passes -Wl,--build-id during linking for the release build which should make it easier to symbolicate frames coming from the libcapture.so binary