### PR TITLE
[sdk][ios] enable anr runtime flag

### DIFF
--- a/platform/swift/source/RuntimeVariable.swift
+++ b/platform/swift/source/RuntimeVariable.swift
@@ -61,8 +61,7 @@ extension RuntimeVariable<Bool> {
 
     static let applicationANRReporting = RuntimeVariable(
         name: "client_feature.ios.application_anr_reporting",
-        // TODO(Augustyniak): Flip default to `true` once we verify that the feature doesn't cause any issues.
-        defaultValue: false
+        defaultValue: true
     )
 
     static let applicationLifecycleReporting = RuntimeVariable(


### PR DESCRIPTION
Tenants have it enabled and have been running with it for months so it should be safe to default-enable it in the sdk to avoid flip-flopping