### PR TITLE
[Android] [GradleTestApp] Add session strategy configuration option

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
@@ -11,7 +11,7 @@ import io.bitdrift.capture.Capture;
 import io.bitdrift.capture.Configuration;
 import io.bitdrift.capture.providers.FieldProvider;
 import io.bitdrift.capture.providers.session.SessionStrategy;
-import io.bitdrift.capture.replay.SessionReplayConfiguration;
+import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.SessionStrategyPreferences;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -20,7 +20,10 @@ import java.util.UUID;
 import okhttp3.HttpUrl;
 
 public class BitdriftInit {
-    public static void initBitdriftCaptureInJava(HttpUrl apiUrl, String apiKey) {
+    public static void initBitdriftCaptureInJava(
+            HttpUrl apiUrl,
+            String apiKey,
+            String sessionStrategyName) {
         String userID = UUID.randomUUID().toString();
         List<FieldProvider> fieldProviders = new ArrayList<>();
         fieldProviders.add(() -> {
@@ -31,11 +34,19 @@ public class BitdriftInit {
 
         Capture.Logger.start(
             apiKey,
-            new SessionStrategy.Fixed(),
+            mapToSessionStrategy(sessionStrategyName),
             new Configuration(),
             fieldProviders,
             null,
             apiUrl
         );
+    }
+
+    private static SessionStrategy mapToSessionStrategy(String sessionStrategyName) {
+        if(sessionStrategyName.equals(SessionStrategyPreferences.ACTIVITY_BASED.getDisplayName())){
+            return new SessionStrategy.ActivityBased();
+        }else{
+            return new SessionStrategy.Fixed();
+        }
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ConfigurationSettingsFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ConfigurationSettingsFragment.kt
@@ -7,13 +7,15 @@
 
 package io.bitdrift.gradletestapp
 
+import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import io.bitdrift.capture.providers.session.SessionStrategy
 import kotlin.system.exitProcess
 
 class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
@@ -30,14 +32,14 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         val apiUrlPref = EditTextPreference(context)
         apiUrlPref.key = "apiUrl"
         apiUrlPref.title = "API URL"
-        apiUrlPref.summary = "App needs to be restarted for changes to take effect"
+        apiUrlPref.summary = SELECTION_SUMMARY
 
         backendCategory.addPreference(apiUrlPref)
 
         val apiKeyPref = EditTextPreference(context)
         apiKeyPref.key = "apiKey"
         apiKeyPref.title = "API Key"
-        apiKeyPref.summary = "App needs to be restarted for changes to take effect"
+        apiKeyPref.summary = SELECTION_SUMMARY
 
         backendCategory.addPreference(apiKeyPref)
 
@@ -54,8 +56,35 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
             exitProcess(0)
         }
 
+        val sessionStrategyPref = buildSessionStrategyOption(context)
+        backendCategory.addPreference(sessionStrategyPref)
+
         screen.addPreference(restartPreference)
 
         preferenceScreen = screen
+    }
+
+    private fun buildSessionStrategyOption(context: Context): ListPreference {
+        val sessionStrategyPref = ListPreference(context)
+        sessionStrategyPref.key = SESSION_STRATEGY_PREFS_KEY
+        sessionStrategyPref.title = SESSION_STRATEGY_TITLE
+        sessionStrategyPref.entries = SESSION_STRATEGY_ENTRIES
+        sessionStrategyPref.entryValues = SESSION_STRATEGY_ENTRIES
+        sessionStrategyPref.summary = SELECTION_SUMMARY
+        sessionStrategyPref.setDefaultValue(SessionStrategyPreferences.FIXED.displayName)
+        return sessionStrategyPref
+    }
+
+    enum class SessionStrategyPreferences(val displayName: String) {
+        FIXED("Fixed"),
+        ACTIVITY_BASED("Activity Based")
+    }
+
+    companion object {
+        const val SESSION_STRATEGY_PREFS_KEY = "sessionStrategy"
+        private const val SELECTION_SUMMARY = "App needs to be restarted for changes to take effect"
+        private const val SESSION_STRATEGY_TITLE = "Session Strategy"
+        private val SESSION_STRATEGY_ENTRIES =
+            arrayOf(SessionStrategyPreferences.FIXED.displayName, SessionStrategyPreferences.ACTIVITY_BASED.displayName)
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -66,6 +66,9 @@ import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
+import io.bitdrift.gradletestapp.ConfigurationSettingsFragment
+import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.Companion.SESSION_STRATEGY_PREFS_KEY
+import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.SessionStrategyPreferences.FIXED
 
 /**
  * A Java app entry point that initializes the Bitdrift Logger.
@@ -90,7 +93,11 @@ class GradleTestApp : Application() {
             Log.e("GradleTestApp", "Failed to initialize bitdrift logger due to invalid API URL: $stringApiUrl")
             return
         }
-        BitdriftInit.initBitdriftCaptureInJava(apiUrl, prefs.getString("apiKey", ""))
+        BitdriftInit.initBitdriftCaptureInJava(
+            apiUrl,
+            prefs.getString("apiKey", ""),
+            prefs.getString(SESSION_STRATEGY_PREFS_KEY, FIXED.displayName),
+        )
         // Timber
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())


### PR DESCRIPTION
Just small tweak on the gradle test app in order to easy tweak SessionStrategy type without having to hardcode it locally (default still remains as Fixed)

![config_fragment](https://github.com/user-attachments/assets/d8934e60-30a9-4c94-b7c5-81594d5639f7)

![session_strategy_options](https://github.com/user-attachments/assets/aac9e5bb-4129-4a41-9d03-ba8da47b1ee8)


