### PR TITLE
[Android] Memory Leak fix on JankStatsMonitor

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -51,7 +51,6 @@ internal class JankStatsMonitor(
 ) : IEventListenerLogger,
     LifecycleEventObserver,
     JankStats.OnFrameListener {
-
     private var jankStatsWeakRef: WeakReference<JankStats>? = null
 
     override fun start() {
@@ -122,7 +121,7 @@ internal class JankStatsMonitor(
         }
     }
 
-    private fun getJankStats():JankStats? = jankStatsWeakRef?.get()
+    private fun getJankStats(): JankStats? = jankStatsWeakRef?.get()
 
     private fun stopCollection() {
         getJankStats()?.isTrackingEnabled = false

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -32,6 +32,7 @@ import io.bitdrift.capture.events.IEventListenerLogger
 import io.bitdrift.capture.events.span.SpanField
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.threading.CaptureDispatchers
+import java.lang.ref.WeakReference
 
 /**
  * Reports Jank Frames and its duration in ms
@@ -50,7 +51,8 @@ internal class JankStatsMonitor(
 ) : IEventListenerLogger,
     LifecycleEventObserver,
     JankStats.OnFrameListener {
-    private var jankStats: JankStats? = null
+
+    private var jankStatsWeakRef: WeakReference<JankStats>? = null
 
     override fun start() {
         mainThreadHandler.run {
@@ -69,7 +71,9 @@ internal class JankStatsMonitor(
         event: Lifecycle.Event,
     ) {
         if (event == Lifecycle.Event.ON_RESUME) {
-            windowManager.getCurrentWindow()?.let { setJankStatsForCurrentWindow(it) }
+            windowManager.getCurrentWindow()?.let {
+                setJankStatsForCurrentWindow(it)
+            }
         } else if (event == Lifecycle.Event.ON_STOP) {
             stopCollection()
         }
@@ -108,8 +112,8 @@ internal class JankStatsMonitor(
                 return
             }
 
-            jankStats = JankStats.createAndTrack(window, this)
-            jankStats?.jankHeuristicMultiplier = runtime.getConfigValue(RuntimeConfig.JANK_FRAME_HEURISTICS_MULTIPLIER).toFloat()
+            jankStatsWeakRef = WeakReference(JankStats.createAndTrack(window, this))
+            getJankStats()?.jankHeuristicMultiplier = runtime.getConfigValue(RuntimeConfig.JANK_FRAME_HEURISTICS_MULTIPLIER).toFloat()
         } catch (illegalStateException: IllegalStateException) {
             errorHandler.handleError(
                 "Couldn't create JankStats instance",
@@ -118,9 +122,11 @@ internal class JankStatsMonitor(
         }
     }
 
+    private fun getJankStats():JankStats? = jankStatsWeakRef?.get()
+
     private fun stopCollection() {
-        jankStats?.isTrackingEnabled = false
-        jankStats = null
+        getJankStats()?.isTrackingEnabled = false
+        jankStatsWeakRef?.clear()
     }
 
     @WorkerThread


### PR DESCRIPTION
Verified with leakcanary enabled on debug build and that dropped frames are still being send upon configuration changes

https://timeline.bitdrift.dev/session/1d4ca361-3037-43d0-b449-3085fbb06b90?pages=1&utilization=0&expanded=1070970770558996757