### PR TITLE
[Android] Initial proposal for pre init crash reporting method

### DIFF
--- a/examples/android/HelloWorldApp.kt
+++ b/examples/android/HelloWorldApp.kt
@@ -17,6 +17,7 @@ import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import okhttp3.HttpUrl
 import java.util.UUID
+import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 
 private const val bitdriftAPIKey = "<YOUR API KEY GOES HERE>"
 private val BITDRIFT_URL = HttpUrl.Builder().scheme("https").host("api.bitdrift.io").build()
@@ -26,7 +27,10 @@ class HelloWorldApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
-
+        
+        @OptIn(ExperimentalBitdriftApi::class)
+        Logger.initCrashReporting()
+        
         setupExampleCrashHandler()
 
         val userID = UUID.randomUUID().toString();

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -20,7 +20,8 @@ import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.CrashReporter
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import okhttp3.HttpUrl
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
@@ -54,7 +55,7 @@ internal sealed class LoggerState {
  */
 object Capture {
     private val default: AtomicReference<LoggerState> = AtomicReference(LoggerState.NotStarted)
-    private var crashReporterState: CrashReporterState = CrashReporterState.NotInitialized
+    private var crashReporterStatus: CrashReporterStatus = CrashReporterStatus(NotInitialized)
 
     /**
      * Returns a handle to the underlying logger instance, if Capture has been started.
@@ -104,7 +105,7 @@ object Capture {
         @ExperimentalBitdriftApi
         fun initCrashReporting() {
             val crashReporter = CrashReporter()
-            crashReporterState = crashReporter.processCrashReportFile()
+            crashReporterStatus = crashReporter.processCrashReportFile()
         }
 
         /**
@@ -180,7 +181,7 @@ object Capture {
                             configuration = configuration,
                             sessionStrategy = sessionStrategy,
                             bridge = bridge,
-                            crashReporterState = crashReporterState,
+                            crashReporterStatus = crashReporterStatus,
                         )
                     default.set(LoggerState.Started(logger))
                 } catch (e: Throwable) {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -100,7 +100,7 @@ object Capture {
         /**
          * Initializes crash reporting mechanism.
          *
-         * This should be called priorly to Capture.Logger.start()
+         * This should be called prior to Capture.Logger.start()
          */
         @ExperimentalBitdriftApi
         @JvmStatic

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -20,8 +20,8 @@ import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.CrashReporter
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 import okhttp3.HttpUrl
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
@@ -55,7 +55,7 @@ internal sealed class LoggerState {
  */
 object Capture {
     private val default: AtomicReference<LoggerState> = AtomicReference(LoggerState.NotStarted)
-    private var crashReporterStatus: CrashReporterStatus = CrashReporterStatus(NotInitialized)
+    private var crashReporterStatus: CrashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized)
 
     /**
      * Returns a handle to the underlying logger instance, if Capture has been started.
@@ -106,7 +106,11 @@ object Capture {
         @JvmStatic
         fun initCrashReporting() {
             val crashReporter = CrashReporter()
-            crashReporterStatus = crashReporter.processCrashReportFile()
+            if (crashReporterStatus.state is CrashReporterState.NotInitialized) {
+                crashReporterStatus = crashReporter.processCrashReportFile()
+            } else {
+                Log.w("capture", "Crash reporting already being initialized")
+            }
         }
 
         /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -98,11 +98,12 @@ object Capture {
         private val mainThreadHandler by lazy { MainThreadHandler() }
 
         /**
-         * Initializes crash reporting mechanism. This should be the first call upon Application.onCreate()
+         * Initializes crash reporting mechanism.
+         *
+         * This should be called priorly to Capture.Logger.start()
          */
-        @Synchronized
-        @JvmStatic
         @ExperimentalBitdriftApi
+        @JvmStatic
         fun initCrashReporting() {
             val crashReporter = CrashReporter()
             crashReporterStatus = crashReporter.processCrashReportFile()

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -526,14 +526,6 @@ internal class LoggerImpl(
             errorHandler.handleError("Couldn't start JankStatsMonitor", IllegalArgumentException("Invalid application provided"))
         }
     }
-
-    private fun writeSDKStartLog(duration: Duration) {
-        CaptureJniLibrary.writeSDKStartLog(
-            loggerId,
-            crashReporterStatus.buildFieldsMap(),
-            duration.toDouble(DurationUnit.SECONDS),
-        )
-    }
 }
 
 internal data class LogAttributesOverrides(

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -269,7 +269,7 @@ internal class LoggerImpl(
                 CaptureJniLibrary.startLogger(this.loggerId)
             }
 
-        duration.writeSDKStartLog()
+        writeSDKStartLog(duration)
     }
 
     override val sessionId: String
@@ -529,7 +529,7 @@ internal class LoggerImpl(
         }
     }
 
-    private fun Duration.writeSDKStartLog() {
+    private fun writeSDKStartLog(duration: Duration) {
         val fields =
             if (runtime.isEnabled(RuntimeFeature.APPEND_INIT_CRASH_REPORTING_INFO)) {
                 crashReporterStatus.buildFieldsMap()
@@ -539,7 +539,7 @@ internal class LoggerImpl(
         CaptureJniLibrary.writeSDKStartLog(
             loggerId,
             fields,
-            toDouble(DurationUnit.SECONDS),
+            duration.toDouble(DurationUnit.SECONDS),
         )
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -50,7 +50,7 @@ import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFields
 import io.bitdrift.capture.reports.CrashReporter.Companion.buildFieldsMap
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterStatus
 import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import java.io.File
@@ -530,7 +530,7 @@ internal class LoggerImpl(
     }
 
     private fun writeSDKStartLog(duration: Duration) {
-        val fields =
+        val fields: Map<String, FieldValue> =
             if (runtime.isEnabled(RuntimeFeature.APPEND_INIT_CRASH_REPORTING_INFO)) {
                 crashReporterStatus.buildFieldsMap()
             } else {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -83,7 +83,8 @@ internal class LoggerImpl(
     private val bridge: IBridge = CaptureJniLibrary,
     private val eventListenerDispatcher: CaptureDispatchers.CommonBackground = CaptureDispatchers.CommonBackground,
     windowManager: IWindowManager = WindowManager(errorHandler),
-    private val crashReporterState: CrashReporter.CrashReporterState,
+    // TODO(FranAguilera): To remove default and update tests
+    private val crashReporterState: CrashReporter.CrashReporterState = CrashReporter.CrashReporterState.NotInitialized,
 ) : ILogger {
     private val metadataProvider: MetadataProvider
     private val memoryMetricsProvider = MemoryMetricsProvider(context)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/experimental/ExperimentalBitdriftApi.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/experimental/ExperimentalBitdriftApi.kt
@@ -1,0 +1,19 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.experimental
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This API is in experimental phase and may change in the future.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+/**
+ * Use it for APIs that are still under experimental phase
+ */
+annotation class ExperimentalBitdriftApi

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -37,26 +37,17 @@ internal class CrashReporter(
      */
     fun processCrashReportFile(): CrashReporterStatus =
         runCatching {
-            if (MainThreadHandler.isOnMainThread()) {
-                runVerifyDirectoriesAndCopyFiles()
-            } else {
-                mainThreadHandler.runAndReturnResult {
-                    runVerifyDirectoriesAndCopyFiles()
-                }
+            mainThreadHandler.runAndReturnResult {
+                var crashReporterState: CrashReporterState
+                val duration =
+                    measureTime {
+                        crashReporterState = verifyDirectoriesAndCopyFiles()
+                    }
+                CrashReporterStatus(crashReporterState, duration)
             }
         }.getOrElse {
             CrashReporterStatus(ProcessingFailure("Error while processCrashReportFile. ${it.message}"))
         }
-
-    @UiThread
-    private fun runVerifyDirectoriesAndCopyFiles(): CrashReporterStatus {
-        var crashReporterState: CrashReporterState
-        val duration =
-            measureTime {
-                crashReporterState = verifyDirectoriesAndCopyFiles()
-            }
-        return CrashReporterStatus(crashReporterState, duration)
-    }
 
     @UiThread
     private fun verifyDirectoriesAndCopyFiles(): CrashReporterState {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -100,7 +100,7 @@ internal class CrashReporter(
         crashFile.copyTo(destinationFile, overwrite = true)
 
         return if (destinationFile.exists()) {
-            Completed.CrashReportSent("File ${crashFile.name} copied successfully")
+            Completed.CrashReportSent("File ${destinationFile.absolutePath} copied successfully")
         } else {
             Completed.WithoutPriorCrash("No prior crashes found")
         }
@@ -122,7 +122,7 @@ internal class CrashReporter(
 
     private fun File.toFilenameWithTimeStamp(): String {
         val fileCreationEpochTime = getFileCreationTimeEpochInMillis(this)
-        return fileCreationEpochTime.toString() + DESTINATION_FILE_SEPARATOR + this.name
+        return fileCreationEpochTime.toString() + "." + this.extension
     }
 
     private fun getFileCreationTimeEpochInMillis(file: File): Long =
@@ -218,7 +218,6 @@ internal class CrashReporter(
         private const val CONFIGURATION_FILE_PATH = "/bitdrift_capture/reports/directories"
         private const val DESTINATION_FILE_PATH = "/bitdrift_capture/reports/new"
         private const val FILE_CREATION_TIME_ATTRIBUTE = "creationTime"
-        private const val DESTINATION_FILE_SEPARATOR = "_"
         private const val CRASH_REPORTING_STATE_KEY = "crash_reporting_state"
         private const val CRASH_REPORTING_DETAILS_KEY = "crash_reporting_details"
         private const val CRASH_REPORTING_DURATION_NANO_KEY = "crash_reporting_duration_nanos"

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -8,14 +8,17 @@
 package io.bitdrift.capture.reports
 
 import android.os.Build
-import android.util.Log
 import androidx.annotation.UiThread
+import androidx.annotation.VisibleForTesting
 import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.common.MainThreadHandler
+import io.bitdrift.capture.providers.FieldValue
+import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Completed
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
+import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.measureTime
 
@@ -32,9 +35,8 @@ internal class CrashReporter(
      *
      * @return The state of the crash reporting process
      */
-    fun processCrashReportFile(): CrashReporterState {
+    fun processCrashReportFile(): CrashReporterStatus {
         var crashReporterState: CrashReporterState = CrashReporterState.Initializing
-
         val duration =
             measureTime {
                 if (MainThreadHandler.isOnMainThread()) {
@@ -45,13 +47,7 @@ internal class CrashReporter(
                     }
                 }
             }
-
-        Log.i(
-            "CAPTURE_SDK",
-            "verifyDirectoriesAndCopyFiles completed with $crashReporterState " +
-                "and a duration of ${duration.toDouble(DurationUnit.NANOSECONDS)} ns",
-        )
-        return crashReporterState
+        return CrashReporterStatus(crashReporterState, duration)
     }
 
     @UiThread
@@ -78,22 +74,26 @@ internal class CrashReporter(
         }
 
         return runCatching {
-            copyFile(sourceDirectory, destinationDirectory, crashConfigDetails.extensionFileName)
+            findAndCopyCrashFile(
+                sourceDirectory,
+                destinationDirectory,
+                crashConfigDetails.extensionFileName,
+            )
         }.getOrElse {
             return Completed.ProcessingFailure("Couldn't process crash files", it)
         }
     }
 
     @UiThread
-    private fun copyFile(
+    private fun findAndCopyCrashFile(
         sourceDirectory: File,
         destinationDirectory: File,
         fileExtension: String,
     ): CrashReporterState {
         val crashFile =
-            getCrashFile(sourceDirectory, fileExtension)
+            findCrashFile(sourceDirectory, fileExtension)
                 ?: let {
-                    return Completed.WithoutPriorCrash("File with .$fileExtension not found in the source directory")
+                    return Completed.WithoutPriorCrash("Crash file with .$fileExtension extension not found in the source directory")
                 }
 
         val destinationFile = File(destinationDirectory, crashFile.toFilenameWithTimeStamp())
@@ -112,7 +112,7 @@ internal class CrashReporter(
             ConfigDetails(crashConfigDetails[0], crashConfigDetails[1])
         }.getOrNull()
 
-    private fun getCrashFile(
+    private fun findCrashFile(
         sourceFile: File,
         fileExtension: String,
     ): File? =
@@ -127,59 +127,71 @@ internal class CrashReporter(
 
     private fun getFileCreationTimeEpochInMillis(file: File): Long =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val fileTime = Files.getAttribute(file.toPath(), FILE_CREATION_TIME_ATTRIBUTE) as FileTime
+            val fileTime =
+                Files.getAttribute(file.toPath(), FILE_CREATION_TIME_ATTRIBUTE) as FileTime
             fileTime.toMillis()
         } else {
             file.lastModified()
         }
 
-    internal sealed class CrashReporterState {
+    internal sealed class CrashReporterState(
+        open val readableType: String,
+    ) {
+        /**
+         * Contains details of the state
+         */
+        abstract val message: String
+
         /**
          * Indicates that initial setup call is in progress
          */
-        data object Initializing : CrashReporterState()
+        data object Initializing : CrashReporterState("INITIALIZING") {
+            override val message: String
+                get() = "Initializing Crash Reporting"
+        }
 
         /**
          * State indicating that crash reporting has not been initialized
          */
-        data object NotInitialized : CrashReporterState()
+        data object NotInitialized : CrashReporterState("NOT_INITIALIZED") {
+            override val message: String
+                get() = "Crash reporting not initialized"
+        }
 
         /**
          * Sealed class representing all completed states
          */
-        sealed class Completed : CrashReporterState() {
+        sealed class Completed(
+            override val readableType: String,
+            override val message: String,
+        ) : CrashReporterState(readableType) {
             /**
-             * Contains details of the [Completed] state
-             */
-            abstract val message: String
-
-            /**
-             * State indicating that crash report file transfer succeeded
+             * State indicating that prior crash report was sent
              */
             data class CrashReportSent(
                 override val message: String,
-            ) : Completed()
+            ) : Completed("CRASH_REPORT_SENT", message)
 
             /**
              * State indicating that there are no prior crashes to report
              */
             data class WithoutPriorCrash(
                 override val message: String,
-            ) : Completed()
+            ) : Completed("NO_PRIOR_CRASHES", message)
 
             /**
              * State indicating that the crash report configuration file is missing
              */
             data class MissingConfigFile(
                 override val message: String,
-            ) : Completed()
+            ) : Completed("MISSING_CRASH_CONFIG_FILE", message)
 
             /**
              * State indicating that the crash report configuration file content is incorrect
              */
             data class MalformedConfigFile(
                 override val message: String,
-            ) : Completed()
+            ) : Completed("MALFORMED_CRASH_CONFIG_FILE", message)
 
             /**
              * State indicating that processing crash reports failed
@@ -187,20 +199,38 @@ internal class CrashReporter(
             data class ProcessingFailure(
                 override val message: String,
                 val throwable: Throwable,
-            ) : Completed()
+            ) : Completed("CRASH_PROCESSING_FAILURE", message)
         }
     }
+
+    data class CrashReporterStatus(
+        val state: CrashReporterState,
+        val duration: Duration? = null,
+    )
 
     private data class ConfigDetails(
         val rootPath: String,
         val extensionFileName: String,
     )
 
-    private companion object {
+    internal companion object {
         // TODO(FranAguilera): To rename to /bitdrift_capture/reports/config when shared-core is bumped
         private const val CONFIGURATION_FILE_PATH = "/bitdrift_capture/reports/directories"
         private const val DESTINATION_FILE_PATH = "/bitdrift_capture/reports/new"
         private const val FILE_CREATION_TIME_ATTRIBUTE = "creationTime"
         private const val DESTINATION_FILE_SEPARATOR = "_"
+        private const val CRASH_REPORTING_STATE_KEY = "crash_reporting_state"
+        private const val CRASH_REPORTING_DETAILS_KEY = "crash_reporting_details"
+        private const val CRASH_REPORTING_DURATION_NANO_KEY = "crash_reporting_duration_nanos"
+
+        fun CrashReporterStatus.buildFieldsMap(): Map<String, FieldValue> =
+            buildMap {
+                put(CRASH_REPORTING_STATE_KEY, state.readableType.toFieldValue())
+                put(CRASH_REPORTING_DETAILS_KEY, state.message.toFieldValue())
+                put(CRASH_REPORTING_DURATION_NANO_KEY, getDurationFieldValue().toFieldValue())
+            }
+
+        @VisibleForTesting
+        fun CrashReporterStatus.getDurationFieldValue(): String = duration?.toString(DurationUnit.NANOSECONDS) ?: "n/a"
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -160,7 +160,7 @@ internal class CrashReporter(
     )
 
     internal companion object {
-        // TODO(FranAguilera): To rename to /bitdrift_capture/reports/config when shared-core is bumped
+        // TODO(FranAguilera): BIT-4846. To rename to /bitdrift_capture/reports/config when shared-core is bumped
         private const val CONFIGURATION_FILE_PATH = "/reports/directories"
         private const val DESTINATION_FILE_PATH = "/reports/new"
         private const val LAST_MODIFIED_TIME_ATTRIBUTE = "lastModifiedTime"

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -1,0 +1,174 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.reports
+
+import android.util.Log
+import androidx.annotation.UiThread
+import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
+import io.bitdrift.capture.common.MainThreadHandler
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Completed
+import java.io.File
+import kotlin.system.measureNanoTime
+
+/**
+ * Handles internal reporting of crashes
+ */
+internal class CrashReporter(
+    private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
+) {
+    private val appContext by lazy { APP_CONTEXT }
+
+    /**
+     * Process existing crash report files.
+     *
+     * @return The state of the crash reporting process
+     */
+    fun processCrashReportFile(): CrashReporterState {
+        var crashReporterState: CrashReporterState = CrashReporterState.Initializing
+        mainThreadHandler.run {
+            val measuredTimeNano =
+                measureNanoTime {
+                    crashReporterState = verifyDirectoriesAndCopyFiles()
+                }
+            Log.i(
+                "CAPTURE_SDK",
+                "verifyDirectoriesAndCopyFiles completed with $crashReporterState and duration of $measuredTimeNano ns",
+            )
+        }
+        return crashReporterState
+    }
+
+    @UiThread
+    private fun verifyDirectoriesAndCopyFiles(): CrashReporterState {
+        val filesDir = appContext.filesDir.absolutePath
+        val crashConfigFile = File("$filesDir$REPORTS_DIRECTORY")
+
+        if (!crashConfigFile.exists()) {
+            return Completed.MissingConfigFile("$REPORTS_DIRECTORY does not exist")
+        }
+
+        val crashConfigDetails =
+            getConfigDetails(crashConfigFile) ?: let {
+                return Completed.MalformedConfigFile("Malformed content at $REPORTS_DIRECTORY")
+            }
+
+        val sourcePath = "${appContext.cacheDir.absolutePath}/${crashConfigDetails.rootPath}"
+        val destinationPath = "$filesDir$REPORTS_TO_BE_UPLOADED"
+
+        return runCatching {
+            copyFile(sourcePath, destinationPath, crashConfigDetails.extensionFileName)
+        }.getOrElse {
+            return Completed.ProcessingFailure("Couldn't process crash files", it)
+        }
+    }
+
+    @UiThread
+    private fun copyFile(
+        sourceBaseDir: String,
+        destDir: String,
+        fileExtension: String,
+    ): CrashReporterState {
+        val source = File(sourceBaseDir)
+        val destination = File(destDir).apply { if (!exists()) mkdirs() }
+
+        if (!source.exists() || !source.isDirectory) {
+            return Completed.WithoutPriorCrash("$sourceBaseDir directory does not exist or is not a directory")
+        }
+
+        val targetFile =
+            getCrashFile(source, fileExtension)
+                ?: let {
+                    return Completed.WithoutPriorCrash("File with .$fileExtension not found in the source directory")
+                }
+
+        val destFile =
+            File(destination, targetFile.name).apply { targetFile.copyTo(this, overwrite = true) }
+
+        return if (destFile.exists()) {
+            Completed.CrashReportSent("File ${targetFile.name} copied successfully")
+        } else {
+            Completed.WithoutPriorCrash("No prior crashes found")
+        }
+    }
+
+    private fun getConfigDetails(crashConfigFile: File): ConfigDetails? =
+        runCatching {
+            val crashConfigDetails = crashConfigFile.readText().split(",")
+            ConfigDetails(crashConfigDetails[0], crashConfigDetails[1])
+        }.getOrNull()
+
+    private fun getCrashFile(
+        sourceFile: File,
+        fileExtension: String,
+    ): File? =
+        sourceFile.walk().firstOrNull {
+            it.isFile && it.extension == fileExtension
+        }
+
+    internal sealed class CrashReporterState {
+        data object Initializing : CrashReporterState()
+
+        /**
+         * State indicating that crash reporting has not been initialized
+         */
+        data object NotInitialized : CrashReporterState()
+
+        /**
+         * Sealed class representing all completed states
+         */
+        sealed class Completed : CrashReporterState() {
+            abstract val message: String
+
+            /**
+             * State indicating that crash report file transfer succeeded
+             */
+            data class CrashReportSent(
+                override val message: String,
+            ) : Completed()
+
+            /**
+             * State indicating that there are no prior crashes to report
+             */
+            data class WithoutPriorCrash(
+                override val message: String,
+            ) : Completed()
+
+            /**
+             * State indicating that the crash report configuration file is missing
+             */
+            data class MissingConfigFile(
+                override val message: String,
+            ) : Completed()
+
+            /**
+             * State indicating that the crash report configuration file content is incorrect
+             */
+            data class MalformedConfigFile(
+                override val message: String,
+            ) : Completed()
+
+            /**
+             * State indicating that processing crash reports failed
+             */
+            data class ProcessingFailure(
+                override val message: String,
+                val throwable: Throwable,
+            ) : Completed()
+        }
+    }
+
+    private data class ConfigDetails(
+        val rootPath: String,
+        val extensionFileName: String,
+    )
+
+    private companion object {
+        private const val REPORTS_DIRECTORY = "/bitdrift_capture/reports/directories"
+        private const val REPORTS_TO_BE_UPLOADED = "/bitdrift_capture/reports/new"
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -216,9 +216,9 @@ internal class CrashReporter(
         private const val CONFIGURATION_FILE_PATH = "/bitdrift_capture/reports/directories"
         private const val DESTINATION_FILE_PATH = "/bitdrift_capture/reports/new"
         private const val FILE_CREATION_TIME_ATTRIBUTE = "creationTime"
-        private const val CRASH_REPORTING_STATE_KEY = "crash_reporting_state"
-        private const val CRASH_REPORTING_DETAILS_KEY = "crash_reporting_details"
-        private const val CRASH_REPORTING_DURATION_NANO_KEY = "crash_reporting_duration_nanos"
+        private const val CRASH_REPORTING_STATE_KEY = "_crash_reporting_state"
+        private const val CRASH_REPORTING_DETAILS_KEY = "_crash_reporting_details"
+        private const val CRASH_REPORTING_DURATION_NANO_KEY = "_crash_reporting_duration_nanos"
 
         fun CrashReporterStatus.buildFieldsMap(): Map<String, FieldValue> =
             buildMap {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -56,18 +56,18 @@ internal class CrashReporter(
         val crashConfigFile = File("$filesDir$CONFIGURATION_FILE_PATH")
 
         if (!crashConfigFile.exists()) {
-            return Initialized.MissingConfigFile("$CONFIGURATION_FILE_PATH does not exist")
+            return Initialized.MissingConfigFile("Configuration file does not exits")
         }
 
         val crashConfigFileContents = crashConfigFile.readText()
         val crashConfigDetails =
             getConfigDetails(crashConfigFileContents) ?: let {
-                return Initialized.MalformedConfigFile("Malformed content at $CONFIGURATION_FILE_PATH. Contents: $crashConfigFileContents")
+                return Initialized.MalformedConfigFile("Malformed content at configuration file")
             }
 
         val sourceDirectory = File("${appContext.cacheDir.absolutePath}/${crashConfigDetails.rootPath}")
         if (!sourceDirectory.exists() || !sourceDirectory.isDirectory) {
-            return Initialized.WithoutPriorCrash("$sourceDirectory directory does not exist or is not a directory")
+            return Initialized.WithoutPriorCrash("Prior crash not found")
         }
 
         val destinationDirectory = File("$filesDir$DESTINATION_FILE_PATH").apply { if (!exists()) mkdirs() }
@@ -92,14 +92,14 @@ internal class CrashReporter(
         val crashFile =
             findCrashFile(sourceDirectory, fileExtension)
                 ?: let {
-                    return Initialized.WithoutPriorCrash("Crash file with .$fileExtension extension not found in the source directory")
+                    return Initialized.WithoutPriorCrash("Crash file not found in the source directory")
                 }
 
         val destinationFile = File(destinationDirectory, crashFile.toFilenameWithTimeStamp())
         crashFile.copyTo(destinationFile, overwrite = true)
 
         return if (destinationFile.exists()) {
-            Initialized.CrashReportSent("File ${destinationFile.absolutePath} copied successfully")
+            Initialized.CrashReportSent("Crash file copied successfully")
         } else {
             Initialized.WithoutPriorCrash("No prior crashes found")
         }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -28,7 +28,7 @@ import kotlin.time.measureTime
 internal class CrashReporter(
     private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
 ) {
-    private val appContext by lazy { APP_CONTEXT }
+    private val appContext = APP_CONTEXT
 
     /**
      * Process existing crash report files.
@@ -224,10 +224,12 @@ internal class CrashReporter(
             buildMap {
                 put(CRASH_REPORTING_STATE_KEY, state.readableType.toFieldValue())
                 put(CRASH_REPORTING_DETAILS_KEY, state.message.toFieldValue())
-                put(CRASH_REPORTING_DURATION_NANO_KEY, getDurationFieldValue().toFieldValue())
+                put(CRASH_REPORTING_DURATION_NANO_KEY, getDuration().toFieldValue())
             }
 
         @VisibleForTesting
-        fun CrashReporterStatus.getDurationFieldValue(): String = duration?.toString(DurationUnit.NANOSECONDS) ?: "n/a"
+        fun CrashReporterStatus.getDuration(): String {
+            return duration?.toDouble(DurationUnit.MILLISECONDS)?.toString() ?: "n/a"
+        }
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporterState.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporterState.kt
@@ -1,0 +1,59 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.reports
+
+/**
+ * Represents all different states for [CrashReporter.processCrashReportFile]
+ */
+internal sealed class CrashReporterState(
+    open val readableType: String,
+) {
+    /**
+     * Indicates that initial setup call is in progress
+     */
+    data object Initializing : CrashReporterState("INITIALIZING")
+
+    /**
+     * State indicating that crash reporting has not been initialized
+     */
+    data object NotInitialized : CrashReporterState("NOT_INITIALIZED")
+
+    /**
+     * Sealed class representing all initialized states
+     */
+    sealed class Initialized(
+        override val readableType: String,
+    ) : CrashReporterState(readableType) {
+        /**
+         * State indicating that prior crash report was sent
+         */
+        data object CrashReportSent : Initialized("CRASH_REPORT_SENT")
+
+        /**
+         * State indicating that there are no prior crashes to report
+         */
+        data object WithoutPriorCrash : Initialized("NO_PRIOR_CRASHES")
+
+        /**
+         * State indicating that the crash report configuration file is missing
+         */
+        data object MissingConfigFile : Initialized("MISSING_CRASH_CONFIG_FILE")
+
+        /**
+         * State indicating that the crash report configuration file content is incorrect
+         */
+        data object MalformedConfigFile : Initialized("MALFORMED_CRASH_CONFIG_FILE")
+
+        /**
+         * State indicating that processing crash reports failed
+         */
+        data class ProcessingFailure(
+            val errorMessage: String,
+        ) : Initialized("CRASH_PROCESSING_FAILURE")
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporterStatus.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporterStatus.kt
@@ -1,0 +1,18 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.reports
+
+import kotlin.time.Duration
+
+/**
+ * Holds the latest [CrashReporter.processCrashReportFile] status
+ */
+internal data class CrashReporterStatus(
+    val state: CrashReporterState,
+    val duration: Duration? = null,
+)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/SdkDirectory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/SdkDirectory.kt
@@ -1,0 +1,27 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.utils
+
+import android.content.Context
+import java.io.File
+
+/**
+ * Specifies the SDK directory
+ */
+object SdkDirectory {
+    private const val BITDRIFT_ROOT_DIRECTORY: String = "bitdrift_capture"
+
+    /**
+     * Returns the SdkDirectory path
+     */
+    fun getPath(context: Context): String {
+        val directory = context.applicationContext.filesDir
+        val sdkDirectory = File(directory.absolutePath, BITDRIFT_ROOT_DIRECTORY)
+        return sdkDirectory.absolutePath
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerSessionOverrideTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerSessionOverrideTest.kt
@@ -19,8 +19,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
@@ -86,7 +86,7 @@ class CaptureLoggerSessionOverrideTest {
                 sessionStrategy = SessionStrategy.Fixed { "foo" },
                 configuration = Configuration(),
                 preferences = preferences,
-                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
             )
 
         CaptureTestJniLibrary.stopTestApiServer()
@@ -119,7 +119,7 @@ class CaptureLoggerSessionOverrideTest {
                 configuration = Configuration(),
                 preferences = preferences,
                 activityManager = activityManager,
-                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
             )
 
         val newStreamId = CaptureTestJniLibrary.awaitNextApiStream()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerSessionOverrideTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerSessionOverrideTest.kt
@@ -19,6 +19,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
@@ -84,6 +86,7 @@ class CaptureLoggerSessionOverrideTest {
                 sessionStrategy = SessionStrategy.Fixed { "foo" },
                 configuration = Configuration(),
                 preferences = preferences,
+                crashReporterStatus = CrashReporterStatus(NotInitialized),
             )
 
         CaptureTestJniLibrary.stopTestApiServer()
@@ -116,6 +119,7 @@ class CaptureLoggerSessionOverrideTest {
                 configuration = Configuration(),
                 preferences = preferences,
                 activityManager = activityManager,
+                crashReporterStatus = CrashReporterStatus(NotInitialized),
             )
 
         val newStreamId = CaptureTestJniLibrary.awaitNextApiStream()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -31,8 +31,8 @@ import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.providers.toFields
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
@@ -451,7 +451,7 @@ class CaptureLoggerTest {
         fieldProvider: FieldProvider? = null,
         dateProvider: DateProvider = mock<DateProvider>(),
         sessionStrategy: SessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
-        crashReporterStatus: CrashReporterStatus = CrashReporterStatus(NotInitialized),
+        crashReporterStatus: CrashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
     ): LoggerImpl {
         val fieldProviders = fieldProvider?.let { listOf(it) }.orEmpty()
         return LoggerImpl(

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -13,7 +13,7 @@ import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.reports.CrashReporter
 import io.bitdrift.capture.reports.CrashReporter.Companion.buildFieldsMap
-import io.bitdrift.capture.reports.CrashReporter.Companion.getDurationFieldValue
+import io.bitdrift.capture.reports.CrashReporter.Companion.getDuration
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.CrashReportSent
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.MalformedConfigFile
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.MissingConfigFile
@@ -126,7 +126,7 @@ class CrashReporterTest {
             buildMap {
                 put("_crash_reporting_state", state.readableType.toFieldValue())
                 put("_crash_reporting_details", state.message.toFieldValue())
-                put("_crash_reporting_duration_nanos", getDurationFieldValue().toFieldValue())
+                put("_crash_reporting_duration_nanos", getDuration().toFieldValue())
             }
         assertThat(buildFieldsMap()).isEqualTo(expectedMap)
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -124,9 +124,9 @@ class CrashReporterTest {
         assertThat(duration != null).isTrue()
         val expectedMap: Map<String, FieldValue> =
             buildMap {
-                put("crash_reporting_state", state.readableType.toFieldValue())
-                put("crash_reporting_details", state.message.toFieldValue())
-                put("crash_reporting_duration_nanos", getDurationFieldValue().toFieldValue())
+                put("_crash_reporting_state", state.readableType.toFieldValue())
+                put("_crash_reporting_details", state.message.toFieldValue())
+                put("_crash_reporting_duration_nanos", getDurationFieldValue().toFieldValue())
             }
         assertThat(buildFieldsMap()).isEqualTo(expectedMap)
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -14,9 +14,9 @@ import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.reports.CrashReporter
 import io.bitdrift.capture.reports.CrashReporter.Companion.buildFieldsMap
 import io.bitdrift.capture.reports.CrashReporter.Companion.getDurationFieldValue
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Completed.CrashReportSent
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Completed.MalformedConfigFile
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Completed.WithoutPriorCrash
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.CrashReportSent
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.MalformedConfigFile
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.WithoutPriorCrash
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -45,7 +45,7 @@ class CrashReporterTest {
         val crashReporterStatus = crashReporter.processCrashReportFile()
 
         crashReporterStatus.assert(
-            CrashReporter.CrashReporterState.Completed.MissingConfigFile::class.java,
+            CrashReporter.CrashReporterState.Initialized.MissingConfigFile::class.java,
             "/bitdrift_capture/reports/directories does not exist",
         )
     }
@@ -54,7 +54,7 @@ class CrashReporterTest {
     fun processCrashReportFile_withValidConfigFileAndNotReports_shouldReportWithoutPriorCrashState() {
         prepareFileDirectories(
             doesReportsDirectoryExist = true,
-            bitdriftConfig = "acme,json",
+            bitdriftConfigContent = "acme,json",
             crashFilePresent = false,
         )
 
@@ -70,7 +70,7 @@ class CrashReporterTest {
     fun processCrashReportFile_withValidConfigFileAndReports_shouldReportPriorCrash() {
         prepareFileDirectories(
             doesReportsDirectoryExist = true,
-            bitdriftConfig = "acme,json",
+            bitdriftConfigContent = "acme,json",
             crashFilePresent = true,
         )
 
@@ -86,7 +86,7 @@ class CrashReporterTest {
     fun processCrashReportFile_withInValidExtensionConfigAndReports_shouldReportPriorCrash() {
         prepareFileDirectories(
             doesReportsDirectoryExist = true,
-            bitdriftConfig = "acme,yaml",
+            bitdriftConfigContent = "acme,yaml",
             crashFilePresent = true,
         )
 
@@ -102,7 +102,7 @@ class CrashReporterTest {
     fun processCrashReportFile_withMalformedConfigFileAndPriorReport_shouldReportMalformedConfigFile() {
         prepareFileDirectories(
             doesReportsDirectoryExist = true,
-            bitdriftConfig = "/data/crashdemo/etc",
+            bitdriftConfigContent = "/data/crashdemo/etc",
             crashFilePresent = true,
         )
 
@@ -110,7 +110,7 @@ class CrashReporterTest {
 
         crashReporterStatus.assert(
             MalformedConfigFile::class.java,
-            "Malformed content at /bitdrift_capture/reports/directories",
+            "Malformed content at /bitdrift_capture/reports/directories. Contents: /data/crashdemo/etc",
         )
     }
 
@@ -132,7 +132,7 @@ class CrashReporterTest {
 
     private fun prepareFileDirectories(
         doesReportsDirectoryExist: Boolean,
-        bitdriftConfig: String? = null,
+        bitdriftConfigContent: String? = null,
         crashFilePresent: Boolean = false,
     ) {
         if (doesReportsDirectoryExist) {
@@ -140,7 +140,7 @@ class CrashReporterTest {
             val reportsDir = File(filesDir, "bitdrift_capture/reports/")
             reportsDir.mkdirs()
             val reportFile = File(reportsDir, "directories")
-            bitdriftConfig?.let {
+            bitdriftConfigContent?.let {
                 reportFile.writeText(it)
             }
         }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -78,7 +78,7 @@ class CrashReporterTest {
 
         crashReporterStatus.assert(
             CrashReportSent::class.java,
-            "File crash_info.json copied successfully",
+            ".json copied successfully",
         )
     }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -1,0 +1,144 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+import androidx.test.core.app.ApplicationProvider
+import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
+import io.bitdrift.capture.reports.CrashReporter
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Completed
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [21])
+class CrashReporterTest {
+    private lateinit var crashReporter: CrashReporter
+
+    @Before
+    fun setup() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+        crashReporter = CrashReporter(Mocks.sameThreadHandler)
+    }
+
+    @Test
+    fun processCrashReportFile_withMissingConfigFile_shouldReportMissingConfigState() {
+        prepareFileDirectories(doesReportsDirectoryExist = false)
+
+        val crashReporterState = crashReporter.processCrashReportFile()
+
+        crashReporterState.assertState(
+            Completed.MissingConfigFile::class.java,
+            "/bitdrift_capture/reports/directories does not exist",
+        )
+    }
+
+    @Test
+    fun processCrashReportFile_withValidConfigFileAndNotReports_shouldReportWithoutPriorCrashState() {
+        prepareFileDirectories(
+            doesReportsDirectoryExist = true,
+            bitdriftConfig = "acme,json",
+            crashFilePresent = false,
+        )
+
+        val crashReporterState = crashReporter.processCrashReportFile()
+
+        crashReporterState.assertState(
+            Completed.WithoutPriorCrash::class.java,
+            "io.bitdrift.capture-dataDir/cache/acme directory does not exist or is not a directory",
+        )
+    }
+
+    @Test
+    fun processCrashReportFile_withValidConfigFileAndReports_shouldReportPriorCrash() {
+        prepareFileDirectories(
+            doesReportsDirectoryExist = true,
+            bitdriftConfig = "acme,json",
+            crashFilePresent = true,
+        )
+
+        val crashReporterState = crashReporter.processCrashReportFile()
+
+        crashReporterState.assertState(
+            Completed.CrashReportSent::class.java,
+            "File crash_info.json copied successfully",
+        )
+    }
+
+    @Test
+    fun processCrashReportFile_withInValidExtensionConfigAndReports_shouldReportPriorCrash() {
+        prepareFileDirectories(
+            doesReportsDirectoryExist = true,
+            bitdriftConfig = "acme,yaml",
+            crashFilePresent = true,
+        )
+
+        val crashReporterState = crashReporter.processCrashReportFile()
+
+        crashReporterState.assertState(
+            Completed.WithoutPriorCrash::class.java,
+            "File with .yaml not found in the source directory",
+        )
+    }
+
+    @Test
+    fun processCrashReportFile_withMalformedConfigFileAndPriorReport_shouldReportMalformedConfigFile() {
+        prepareFileDirectories(
+            doesReportsDirectoryExist = true,
+            bitdriftConfig = "/data/crashdemo/etc",
+            crashFilePresent = true,
+        )
+
+        val crashReporterState = crashReporter.processCrashReportFile()
+
+        crashReporterState.assertState(
+            Completed.MalformedConfigFile::class.java,
+            "Malformed content at /bitdrift_capture/reports/directories",
+        )
+    }
+
+    private fun CrashReporterState.assertState(
+        expectedType: Class<*>,
+        expectedMessage: String,
+    ) {
+        assertThat(this).isInstanceOf(expectedType)
+        if (expectedType.isInstance(this)) {
+            assertThat((this as Completed).message).contains(expectedMessage)
+        }
+    }
+
+    private fun prepareFileDirectories(
+        doesReportsDirectoryExist: Boolean,
+        bitdriftConfig: String? = null,
+        crashFilePresent: Boolean = false,
+    ) {
+        if (doesReportsDirectoryExist) {
+            val filesDir = APP_CONTEXT.filesDir
+            val reportsDir = File(filesDir, "bitdrift_capture/reports/")
+            reportsDir.mkdirs()
+            val reportFile = File(reportsDir, "directories")
+            bitdriftConfig?.let {
+                reportFile.writeText(it)
+            }
+        }
+
+        if (crashFilePresent) {
+            val cacheDir = APP_CONTEXT.cacheDir
+            val sourceFileDir = File(cacheDir, "acme")
+            sourceFileDir.mkdirs()
+            val sourceFile = File(sourceFileDir, "crash_info.json")
+            sourceFile.createNewFile()
+        }
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -111,7 +111,7 @@ class CrashReporterTest {
         val expectedMap: Map<String, FieldValue> =
             buildMap {
                 put("_crash_reporting_state", state.readableType.toFieldValue())
-                put("_crash_reporting_duration_nanos", getDuration().toFieldValue())
+                put("_crash_reporting_duration_ms", getDuration().toFieldValue())
             }
         assertThat(buildFieldsMap()).isEqualTo(expectedMap)
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CrashReporterTest.kt
@@ -16,6 +16,7 @@ import io.bitdrift.capture.reports.CrashReporter.Companion.buildFieldsMap
 import io.bitdrift.capture.reports.CrashReporter.Companion.getDurationFieldValue
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.CrashReportSent
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.MalformedConfigFile
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.MissingConfigFile
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.Initialized.WithoutPriorCrash
 import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import org.assertj.core.api.Assertions.assertThat
@@ -45,8 +46,8 @@ class CrashReporterTest {
         val crashReporterStatus = crashReporter.processCrashReportFile()
 
         crashReporterStatus.assert(
-            CrashReporter.CrashReporterState.Initialized.MissingConfigFile::class.java,
-            "/bitdrift_capture/reports/directories does not exist",
+            MissingConfigFile::class.java,
+            "Configuration file does not exits",
         )
     }
 
@@ -62,7 +63,7 @@ class CrashReporterTest {
 
         crashReporterStatus.assert(
             WithoutPriorCrash::class.java,
-            "io.bitdrift.capture-dataDir/cache/acme directory does not exist or is not a directory",
+            "Prior crash not found",
         )
     }
 
@@ -78,7 +79,7 @@ class CrashReporterTest {
 
         crashReporterStatus.assert(
             CrashReportSent::class.java,
-            ".json copied successfully",
+            "Crash file copied successfully",
         )
     }
 
@@ -94,7 +95,7 @@ class CrashReporterTest {
 
         crashReporterStatus.assert(
             WithoutPriorCrash::class.java,
-            "Crash file with .yaml extension not found in the source directory",
+            "Crash file not found in the source directory",
         )
     }
 
@@ -110,7 +111,7 @@ class CrashReporterTest {
 
         crashReporterStatus.assert(
             MalformedConfigFile::class.java,
-            "Malformed content at /bitdrift_capture/reports/directories. Contents: /data/crashdemo/etc",
+            "Malformed content at configuration file",
         )
     }
 
@@ -119,7 +120,7 @@ class CrashReporterTest {
         expectedMessage: String,
     ) {
         assertThat(state).isInstanceOf(expectedType)
-        assertThat(state.message).contains(expectedMessage)
+        assertThat(state.message).isEqualTo(expectedMessage)
         assertThat(duration != null).isTrue()
         val expectedMap: Map<String, FieldValue> =
             buildMap {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
@@ -16,8 +16,8 @@ import io.bitdrift.capture.network.okhttp.OkHttpApiClient
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
@@ -108,7 +108,7 @@ class ErrorReporterTest {
                 sessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
                 configuration = Configuration(),
                 errorReporter = reporter,
-                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
             )
 
         val errorHandler = ErrorHandler()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
@@ -16,6 +16,8 @@ import io.bitdrift.capture.network.okhttp.OkHttpApiClient
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
@@ -106,6 +108,7 @@ class ErrorReporterTest {
                 sessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
                 configuration = Configuration(),
                 errorReporter = reporter,
+                crashReporterStatus = CrashReporterStatus(NotInitialized),
             )
 
         val errorHandler = ErrorHandler()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/Mocks.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/Mocks.kt
@@ -17,6 +17,7 @@ object Mocks {
     val sameThreadHandler: MainThreadHandler by lazy {
         mock {
             on { run(any()) } doAnswer { (it.arguments[0] as Function0<Unit>).invoke() }
+            on { runAndReturnResult<Any>(any()) } doAnswer { (it.arguments[0] as Function0<Any>).invoke() }
         }
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
@@ -10,8 +10,8 @@ package io.bitdrift.capture
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.providers.session.SessionStrategy
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -48,7 +48,7 @@ class SessionStrategyTest {
                         sessionId
                     },
                 configuration = Configuration(),
-                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
             )
 
         val sessionId = logger.sessionId
@@ -82,7 +82,7 @@ class SessionStrategyTest {
                     },
                 configuration = Configuration(),
                 preferences = mock(),
-                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
             )
 
         val sessionId = logger.sessionId

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
@@ -10,6 +10,8 @@ package io.bitdrift.capture
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -46,6 +48,7 @@ class SessionStrategyTest {
                         sessionId
                     },
                 configuration = Configuration(),
+                crashReporterStatus = CrashReporterStatus(NotInitialized),
             )
 
         val sessionId = logger.sessionId
@@ -79,6 +82,7 @@ class SessionStrategyTest {
                     },
                 configuration = Configuration(),
                 preferences = mock(),
+                crashReporterStatus = CrashReporterStatus(NotInitialized),
             )
 
         val sessionId = logger.sessionId

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
@@ -10,8 +10,8 @@ package io.bitdrift.capture
 import androidx.test.core.app.ApplicationProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -73,6 +73,6 @@ class SessionUrlTest {
             fieldProviders = listOf(),
             dateProvider = SystemDateProvider(),
             sessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
-            crashReporterStatus = CrashReporterStatus(NotInitialized),
+            crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
         )
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
@@ -10,6 +10,8 @@ package io.bitdrift.capture
 import androidx.test.core.app.ApplicationProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -71,5 +73,6 @@ class SessionUrlTest {
             fieldProviders = listOf(),
             dateProvider = SystemDateProvider(),
             sessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
+            crashReporterStatus = CrashReporterStatus(NotInitialized),
         )
 }

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
@@ -25,4 +25,14 @@ class MainThreadHandler {
     fun run(run: () -> Unit) {
         mainHandler.post { run() }
     }
+
+    /**
+     * Wraps utilities for main thread operations
+     */
+    companion object {
+        /**
+         * Returns true when current call is happening on the main thread
+         */
+        fun isOnMainThread(): Boolean = Looper.getMainLooper() == Looper.myLooper()
+    }
 }

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
@@ -24,6 +24,9 @@ class MainThreadHandler {
      * Schedule the given code to run on the main thread
      */
     fun run(run: () -> Unit) {
+        if (isOnMainThread()) {
+            return run()
+        }
         mainHandler.post { run() }
     }
 

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MainThreadHandler.kt
@@ -9,6 +9,7 @@ package io.bitdrift.capture.common
 
 import android.os.Handler
 import android.os.Looper
+import java.util.concurrent.CountDownLatch
 
 /**
  * Helper class to run code on the main thread
@@ -24,6 +25,27 @@ class MainThreadHandler {
      */
     fun run(run: () -> Unit) {
         mainHandler.post { run() }
+    }
+
+    /**
+     * Runs the specific action on main thread and return its results.
+     */
+    fun <T> runAndReturnResult(action: () -> T): T {
+        if (isOnMainThread()) {
+            return action()
+        }
+        var actionResult: T? = null
+        val countDownLatch = CountDownLatch(1)
+        mainHandler.post {
+            try {
+                actionResult = action()
+            } finally {
+                countDownLatch.countDown()
+            }
+        }
+        countDownLatch.await()
+        @Suppress("UNCHECKED_CAST")
+        return actionResult as T
     }
 
     /**

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -72,6 +72,14 @@ sealed class RuntimeFeature(
      * Whether we should send crash artifact data via AppExit
      */
     data object SEND_CRASH_ARTIFACT : RuntimeFeature("client_feature.android.send_crash_artifact")
+
+    /**
+     * Whether we should send crash artifact data via AppExit
+     */
+    data object APPEND_INIT_CRASH_REPORTING_INFO : RuntimeFeature(
+        "client_feature.android.append_init_crash_reporting",
+        defaultValue = false,
+    )
 }
 
 /**

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -72,14 +72,6 @@ sealed class RuntimeFeature(
      * Whether we should send crash artifact data via AppExit
      */
     data object SEND_CRASH_ARTIFACT : RuntimeFeature("client_feature.android.send_crash_artifact")
-
-    /**
-     * If enabled will append init crash reporting metadata into 'SDKConfigured'
-     */
-    data object APPEND_INIT_CRASH_REPORTING_INFO : RuntimeFeature(
-        "client_feature.android.append_init_crash_reporting_to_sdk_start_log",
-        defaultValue = false,
-    )
 }
 
 /**

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -74,10 +74,10 @@ sealed class RuntimeFeature(
     data object SEND_CRASH_ARTIFACT : RuntimeFeature("client_feature.android.send_crash_artifact")
 
     /**
-     * Whether we should send crash artifact data via AppExit
+     * If enabled will append init crash reporting metadata into 'SDKConfigured'
      */
     data object APPEND_INIT_CRASH_REPORTING_INFO : RuntimeFeature(
-        "client_feature.android.append_init_crash_reporting",
+        "client_feature.android.append_init_crash_reporting_to_sdk_start_log",
         defaultValue = false,
     )
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -10,7 +10,6 @@ package io.bitdrift.gradletestapp
 import android.app.Activity
 import android.app.ActivityManager
 import android.app.Application
-import android.app.ApplicationExitInfo
 import android.app.ApplicationStartInfo.LAUNCH_MODE_SINGLE_INSTANCE
 import android.app.ApplicationStartInfo.LAUNCH_MODE_SINGLE_INSTANCE_PER_TASK
 import android.app.ApplicationStartInfo.LAUNCH_MODE_SINGLE_TASK
@@ -45,7 +44,6 @@ import android.app.ApplicationStartInfo.START_TYPE_UNSET
 import android.app.ApplicationStartInfo.START_TYPE_WARM
 import android.content.Context
 import android.content.SharedPreferences
-import android.graphics.Paint.Cap
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -59,6 +57,13 @@ import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.timber.CaptureTree
+import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.Companion.SESSION_STRATEGY_PREFS_KEY
+import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.SessionStrategyPreferences.FIXED
+import io.bitdrift.gradletestapp.SettingsApiKeysDialogFragment.Companion.BITDRIFT_API_KEY
+import io.bitdrift.gradletestapp.SettingsApiKeysDialogFragment.Companion.BUG_SNAG_SDK_API_KEY
+import io.bitdrift.gradletestapp.SettingsApiKeysDialogFragment.Companion.SENTRY_SDK_DSN_KEY
+import io.sentry.android.core.SentryAndroid
+import io.sentry.android.core.SentryAndroidOptions
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import papa.AppLaunchType
 import papa.PapaEvent
@@ -67,13 +72,6 @@ import timber.log.Timber
 import kotlin.random.Random
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
-import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.Companion.SESSION_STRATEGY_PREFS_KEY
-import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.SessionStrategyPreferences.FIXED
-import io.bitdrift.gradletestapp.SettingsApiKeysDialogFragment.Companion.BITDRIFT_API_KEY
-import io.bitdrift.gradletestapp.SettingsApiKeysDialogFragment.Companion.BUG_SNAG_SDK_API_KEY
-import io.bitdrift.gradletestapp.SettingsApiKeysDialogFragment.Companion.SENTRY_SDK_DSN_KEY
-import io.sentry.android.core.SentryAndroid
-import io.sentry.android.core.SentryAndroidOptions
 
 /**
  * A Java app entry point that initializes the Bitdrift Logger.

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -45,6 +45,7 @@ import android.app.ApplicationStartInfo.START_TYPE_UNSET
 import android.app.ApplicationStartInfo.START_TYPE_WARM
 import android.content.Context
 import android.content.SharedPreferences
+import android.graphics.Paint.Cap
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -56,6 +57,7 @@ import io.bitdrift.capture.Capture.Logger.sessionUrl
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.events.span.SpanResult
+import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.timber.CaptureTree
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import papa.AppLaunchType
@@ -84,6 +86,10 @@ class GradleTestApp : Application() {
     override fun onCreate() {
         super.onCreate()
         Timber.i("Hello World!")
+
+        @OptIn(ExperimentalBitdriftApi::class)
+        Capture.Logger.initCrashReporting()
+
         initLogging()
         trackAppLaunch()
         trackAppLifecycle()

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/ClockTimeProfiler.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/ClockTimeProfiler.kt
@@ -17,12 +17,12 @@ import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
-import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import io.bitdrift.capture.reports.CrashReporterState
+import io.bitdrift.capture.reports.CrashReporterStatus
 
 private const val LOG_MESSAGE = "50 characters long test message - 0123456789012345"
 
@@ -56,7 +56,7 @@ class ClockTimeProfiler {
                 dateProvider = SystemDateProvider(),
                 configuration = Configuration(),
                 sessionStrategy = SessionStrategy.Fixed(),
-                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                crashReporterStatus = CrashReporterStatus(CrashReporterState.NotInitialized),
                 )
         }
     }

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/ClockTimeProfiler.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/ClockTimeProfiler.kt
@@ -17,6 +17,8 @@ import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterState.NotInitialized
+import io.bitdrift.capture.reports.CrashReporter.CrashReporterStatus
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Rule
 import org.junit.Test
@@ -54,7 +56,8 @@ class ClockTimeProfiler {
                 dateProvider = SystemDateProvider(),
                 configuration = Configuration(),
                 sessionStrategy = SessionStrategy.Fixed(),
-            )
+                crashReporterStatus = CrashReporterStatus(NotInitialized),
+                )
         }
     }
 


### PR DESCRIPTION
- Introduce "experimental" `Capture.Logger.initCrashReporting` API.
- Status of that init function is passed to LoggerImpl (called upon first Capture.Logger.start), there will append additional map values to existing SDKConfigured . This contains the status of crash reporter and its duration when applicable
- For now opting for a config format such as 'root_directory_path,file_extension'. 
- Appended the epoch time of the original crash file that will be moved under reports/new
- Demo sessions [bazel sample app](https://timeline.bitdrift.dev/session/f150649a-1da8-4732-bf20-4b3b61226272?pages=1&utilization=0&expanded=4568865902884925366), [gradle sample app](https://timeline.bitdrift.dev/s/dddb3ced-0bc6-4078-9044-b90ef98c4022?utm_source=sdk)