### PR TITLE
[Android] [JankStats] Add error reporting for cases where JankStats API returns unexpected duration

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -93,7 +93,7 @@ internal class JankStatsMonitor(
                 val errorMessage =
                     "Unexpected frame duration. durationInNano: $durationNano." +
                         " durationMillis: $durationMillis"
-                errorHandler.handleError(errorMessage, IllegalStateException())
+                errorHandler.handleError(errorMessage, null)
                 return
             }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -89,7 +89,7 @@ internal class JankStatsMonitor(
 
             val durationNano = volatileFrameData.toDurationNano()
             val durationMillis = volatileFrameData.toDurationMillis()
-            if (durationNano < 0 || durationMillis > ANR_DURATION_MAX_THRESHOLD_MS) {
+            if (durationNano < 0 || durationMillis > ERROR_DURATION_THRESHOLD_MILLIS) {
                 val errorMessage =
                     "Unexpected frame duration. durationInNano: $durationNano." +
                         " durationMillis: $durationMillis"
@@ -289,7 +289,7 @@ internal class JankStatsMonitor(
     )
 
     private companion object {
-        private const val ANR_DURATION_MAX_THRESHOLD_MS = 1_000_000L
+        private const val ERROR_DURATION_THRESHOLD_MILLIS = 100_000_000L
         private const val DROPPED_FRAME_MESSAGE_ID = "DroppedFrame"
         private const val ANR_MESSAGE_ID = "ANR"
         private const val SCREEN_NAME_KEY = "_screen_name"

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
@@ -337,9 +337,8 @@ class JankStatsMonitorTest {
         verify(logger, never()).log(any(), any(), any(), any())
         verify(errorHandler).handleError(
             errorMessageCaptor.capture(),
-            illegalStateExceptionCaptor.capture(),
+            eq(null),
         )
         assertThat(errorMessageCaptor.lastValue).isEqualTo(expectedMessage)
-        assertThat(illegalStateExceptionCaptor.lastValue).isInstanceOf(IllegalStateException::class.java)
     }
 }


### PR DESCRIPTION
Looks like there are reports with an overflown ms duration (more details on BIT-4813), on this PR the goal is to check for any potential incorrect duration on JankStats and log an error if that's the case
