### PR TITLE
[Bazel common] Update to latest sha with fixes on main

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -78,7 +78,7 @@ new_git_repository(
 
 git_override(
     module_name = "google_bazel_common",
-    commit = "05f53f68ecec6aec44b54751306af0e7b6552682",
+    commit = "c35b0339ae7d7ac95761f69f4a0eed033163cc80",
     remote = "https://github.com/google/bazel-common",
 )
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/CrashReporter.kt
@@ -151,9 +151,9 @@ internal class CrashReporter(
     )
 
     internal companion object {
-        private const val CRASH_REPORTING_STATE_KEY = "_crash_reporting_state"
-        private const val CRASH_REPORTING_DURATION_MILLI_KEY = "_crash_reporting_duration_ms"
         private const val CONFIGURATION_FILE_PATH = "/reports/config"
+        private const val CRASH_REPORTING_DURATION_MILLI_KEY = "_crash_reporting_duration_ms"
+        private const val CRASH_REPORTING_STATE_KEY = "_crash_reporting_state"
         private const val DESTINATION_FILE_PATH = "/reports/new"
         private const val LAST_MODIFIED_TIME_ATTRIBUTE = "lastModifiedTime"
 


### PR DESCRIPTION
Related to https://github.com/bitdriftlabs/capture-sdk/pull/256

Updating to latest sha on main, now that https://github.com/google/bazel-common/pull/217 is landed