### PR TITLE
Bump shared core

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4569345dfba5d7380ed55c3c6f1cac7406c06f7712bfcb12e963af9130ff6181",
+  "checksum": "63af841a51c5f1c47c024c120795702f8e6f0bd8df90e767d355c83f356d2d83",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -88,6 +88,116 @@
         "MIT"
       ],
       "license_file": "LICENSE-0BSD"
+    },
+    "ahash 0.8.11": {
+      "name": "ahash",
+      "version": "0.8.11",
+      "package_url": "https://github.com/tkaitchuck/ahash",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/ahash/0.8.11/download",
+          "sha256": "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ahash",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "ahash",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "getrandom",
+            "runtime-rng",
+            "serde",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ahash 0.8.11",
+              "target": "build_script_build"
+            },
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "getrandom 0.2.15",
+              "target": "getrandom"
+            },
+            {
+              "id": "serde 1.0.219",
+              "target": "serde"
+            },
+            {
+              "id": "zerocopy 0.7.35",
+              "target": "zerocopy"
+            }
+          ],
+          "selects": {
+            "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
+              {
+                "id": "once_cell 1.21.1",
+                "target": "once_cell"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.8.11"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "version_check 0.9.5",
+              "target": "version_check"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
     },
     "aho-corasick 1.1.3": {
       "name": "aho-corasick",
@@ -183,14 +293,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "android_log-sys 0.3.1": {
+    "android_log-sys 0.3.2": {
       "name": "android_log-sys",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "package_url": "https://github.com/rust-mobile/android_log-sys-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/android_log-sys/0.3.1/download",
-          "sha256": "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+          "url": "https://static.crates.io/crates/android_log-sys/0.3.2/download",
+          "sha256": "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
         }
       },
       "targets": [
@@ -213,7 +323,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "0.3.1"
+        "version": "0.3.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -254,7 +364,7 @@
         "deps": {
           "common": [
             {
-              "id": "android_log-sys 0.3.1",
+              "id": "android_log-sys 0.3.2",
               "target": "android_log_sys"
             },
             {
@@ -262,7 +372,7 @@
               "target": "env_filter"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             }
           ],
@@ -310,7 +420,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "libc"
             }
           ],
@@ -417,14 +527,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "anyhow 1.0.95": {
+    "anyhow 1.0.97": {
       "name": "anyhow",
-      "version": "1.0.95",
+      "version": "1.0.97",
       "package_url": "https://github.com/dtolnay/anyhow",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/anyhow/1.0.95/download",
-          "sha256": "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+          "url": "https://static.crates.io/crates/anyhow/1.0.97/download",
+          "sha256": "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
         }
       },
       "targets": [
@@ -468,14 +578,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.95"
+        "version": "1.0.97"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -570,14 +680,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async-compression 0.4.18": {
+    "async-compression 0.4.20": {
       "name": "async-compression",
-      "version": "0.4.18",
+      "version": "0.4.20",
       "package_url": "https://github.com/Nullus157/async-compression",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async-compression/0.4.18/download",
-          "sha256": "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+          "url": "https://static.crates.io/crates/async-compression/0.4.20/download",
+          "sha256": "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
         }
       },
       "targets": [
@@ -610,7 +720,7 @@
         "deps": {
           "common": [
             {
-              "id": "flate2 1.0.35",
+              "id": "flate2 1.1.0",
               "target": "flate2"
             },
             {
@@ -626,14 +736,14 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.18"
+        "version": "0.4.20"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -642,14 +752,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "async-trait 0.1.86": {
+    "async-trait 0.1.87": {
       "name": "async-trait",
-      "version": "0.1.86",
+      "version": "0.1.87",
       "package_url": "https://github.com/dtolnay/async-trait",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/async-trait/0.1.86/download",
-          "sha256": "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+          "url": "https://static.crates.io/crates/async-trait/0.1.87/download",
+          "sha256": "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
         }
       },
       "targets": [
@@ -674,22 +784,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.86"
+        "version": "0.1.87"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -829,7 +939,7 @@
               "target": "axum_core"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -841,7 +951,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -849,7 +959,7 @@
               "target": "http_body"
             },
             {
-              "id": "http-body-util 0.1.2",
+              "id": "http-body-util 0.1.3",
               "target": "http_body_util"
             },
             {
@@ -861,7 +971,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
@@ -885,15 +995,15 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "serde_json"
             },
             {
-              "id": "serde_path_to_error 0.1.16",
+              "id": "serde_path_to_error 0.1.17",
               "target": "serde_path_to_error"
             },
             {
@@ -905,7 +1015,7 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -935,7 +1045,7 @@
               "target": "axum_macros"
             },
             {
-              "id": "rustversion 1.0.19",
+              "id": "rustversion 1.0.20",
               "target": "rustversion"
             }
           ],
@@ -987,7 +1097,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -995,7 +1105,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -1003,7 +1113,7 @@
               "target": "http_body"
             },
             {
-              "id": "http-body-util 0.1.2",
+              "id": "http-body-util 0.1.3",
               "target": "http_body_util"
             },
             {
@@ -1037,7 +1147,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "rustversion 1.0.19",
+              "id": "rustversion 1.0.20",
               "target": "rustversion"
             }
           ],
@@ -1089,15 +1199,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -1160,7 +1270,7 @@
               "target": "arc_swap"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -1168,7 +1278,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -1176,7 +1286,7 @@
               "target": "http_body"
             },
             {
-              "id": "http-body-util 0.1.2",
+              "id": "http-body-util 0.1.3",
               "target": "http_body_util"
             },
             {
@@ -1192,7 +1302,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "rustls 0.23.20",
+              "id": "rustls 0.23.23",
               "target": "rustls"
             },
             {
@@ -1200,15 +1310,15 @@
               "target": "rustls_pemfile"
             },
             {
-              "id": "rustls-pki-types 1.10.1",
+              "id": "rustls-pki-types 1.11.0",
               "target": "rustls_pki_types"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
-              "id": "tokio-rustls 0.26.1",
+              "id": "tokio-rustls 0.26.2",
               "target": "tokio_rustls"
             },
             {
@@ -1322,6 +1432,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -1340,11 +1457,11 @@
                 "target": "addr2line"
               },
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               },
               {
-                "id": "miniz_oxide 0.8.3",
+                "id": "miniz_oxide 0.8.5",
                 "target": "miniz_oxide"
               },
               {
@@ -1417,14 +1534,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "base64ct 1.6.0": {
+    "base64ct 1.7.2": {
       "name": "base64ct",
-      "version": "1.6.0",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/base64ct",
+      "version": "1.7.2",
+      "package_url": "https://github.com/RustCrypto/formats",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/base64ct/1.6.0/download",
-          "sha256": "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+          "url": "https://static.crates.io/crates/base64ct/1.7.2/download",
+          "sha256": "8faa168b8c4ffca39c2699e772943af41ec2b75fb1683dda07b28a6d285c53dc"
         }
       },
       "targets": [
@@ -1454,7 +1571,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.6.0"
+        "version": "1.7.2"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -1471,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-api"
         }
@@ -1498,7 +1615,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -1554,7 +1671,7 @@
               "target": "bd_time"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -1566,11 +1683,11 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -1578,7 +1695,7 @@
               "target": "tracing"
             },
             {
-              "id": "uuid 1.13.1",
+              "id": "uuid 1.15.1",
               "target": "uuid"
             }
           ],
@@ -1588,7 +1705,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -1608,7 +1725,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -1635,7 +1752,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -1679,7 +1796,7 @@
               "target": "intrusive_collections"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -1695,15 +1812,15 @@
               "target": "static_assertions"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -1717,7 +1834,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -1737,7 +1854,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -1764,7 +1881,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -1792,11 +1909,11 @@
               "target": "flatbuffers"
             },
             {
-              "id": "flate2 1.0.35",
+              "id": "flate2 1.1.0",
               "target": "flate2"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -1808,19 +1925,19 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
-              "id": "uuid 1.13.1",
+              "id": "uuid 1.15.1",
               "target": "uuid"
             }
           ],
@@ -1841,7 +1958,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -1868,7 +1985,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -1912,7 +2029,7 @@
               "target": "bd_time"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -1924,11 +2041,11 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -1938,7 +2055,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -1958,7 +2075,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -1993,7 +2110,7 @@
               "target": "bd_stats_common"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -2005,11 +2122,11 @@
               "target": "sketches_rust"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -2030,7 +2147,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2057,15 +2174,15 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -2086,7 +2203,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2113,7 +2230,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2129,11 +2246,27 @@
               "target": "bd_shutdown"
             },
             {
-              "id": "log 0.4.25",
+              "id": "itertools 0.14.0",
+              "target": "itertools"
+            },
+            {
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "regex 1.11.1",
+              "target": "regex"
+            },
+            {
+              "id": "time 0.3.39",
+              "target": "time"
+            },
+            {
+              "id": "tinyjson 2.5.1",
+              "target": "tinyjson"
+            },
+            {
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -2143,7 +2276,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -2163,7 +2296,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-device"
         }
@@ -2190,7 +2323,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2206,7 +2339,7 @@
               "target": "bd_time"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -2214,7 +2347,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
@@ -2222,11 +2355,11 @@
               "target": "serde_yaml"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "uuid 1.13.1",
+              "id": "uuid 1.15.1",
               "target": "uuid"
             }
           ],
@@ -2247,7 +2380,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-events"
         }
@@ -2282,15 +2415,15 @@
               "target": "bd_shutdown"
             },
             {
-              "id": "ctor 0.3.6",
+              "id": "ctor 0.4.1",
               "target": "ctor"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -2311,7 +2444,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -2350,7 +2483,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2362,7 +2495,7 @@
               "target": "axum"
             },
             {
-              "id": "base64ct 1.6.0",
+              "id": "base64ct 1.7.2",
               "target": "base64ct"
             },
             {
@@ -2398,7 +2531,7 @@
               "target": "bd_time"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -2406,7 +2539,7 @@
               "target": "futures"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -2414,7 +2547,7 @@
               "target": "http_body"
             },
             {
-              "id": "http-body-util 0.1.2",
+              "id": "http-body-util 0.1.3",
               "target": "http_body_util"
             },
             {
@@ -2426,7 +2559,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -2438,11 +2571,11 @@
               "target": "protobuf"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "serde_json"
             },
             {
@@ -2450,15 +2583,15 @@
               "target": "snap"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -2488,7 +2621,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -2531,7 +2664,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -2565,7 +2698,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2577,15 +2710,15 @@
               "target": "bd_stats_common"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
-              "id": "flate2 1.0.35",
+              "id": "flate2 1.1.0",
               "target": "flate2"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -2593,7 +2726,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -2614,7 +2747,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -2648,7 +2781,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2664,11 +2797,11 @@
               "target": "bd_shutdown"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -2676,7 +2809,7 @@
               "target": "http_body"
             },
             {
-              "id": "http-body-util 0.1.2",
+              "id": "http-body-util 0.1.3",
               "target": "http_body_util"
             },
             {
@@ -2692,19 +2825,19 @@
               "target": "hyper_util"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -2718,7 +2851,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -2738,7 +2871,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -2765,7 +2898,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2781,7 +2914,7 @@
               "target": "bd_runtime"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -2802,7 +2935,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -2829,7 +2962,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2841,23 +2974,23 @@
               "target": "bd_log"
             },
             {
-              "id": "bincode 1.3.3",
+              "id": "bincode 2.0.1",
               "target": "bincode"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -2878,7 +3011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-log"
         }
@@ -2905,7 +3038,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -2913,7 +3046,7 @@
               "target": "bd_time"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -2921,11 +3054,11 @@
               "target": "parking_lot"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -2962,7 +3095,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -2989,7 +3122,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3013,7 +3146,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -3021,7 +3154,7 @@
               "target": "regex"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -3042,7 +3175,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -3069,7 +3202,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3114,7 +3247,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -3141,7 +3274,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3149,7 +3282,7 @@
               "target": "bd_log_primitives"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -3170,7 +3303,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -3197,7 +3330,11 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "ahash 0.8.11",
+              "target": "ahash"
+            },
+            {
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3205,7 +3342,11 @@
               "target": "bd_proto"
             },
             {
-              "id": "time 0.3.37",
+              "id": "serde 1.0.219",
+              "target": "serde"
+            },
+            {
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -3226,7 +3367,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-logger"
         }
@@ -3253,7 +3394,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3381,7 +3522,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -3393,19 +3534,19 @@
               "target": "protobuf"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -3427,7 +3568,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -3447,7 +3588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-matcher"
         }
@@ -3474,7 +3615,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3494,7 +3635,7 @@
               "target": "regex"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -3515,7 +3656,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -3542,7 +3683,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3554,23 +3695,23 @@
               "target": "bd_log"
             },
             {
-              "id": "bincode 1.3.3",
+              "id": "bincode 2.0.1",
               "target": "bincode"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -3591,7 +3732,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -3630,7 +3771,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -3657,7 +3798,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3675,12 +3816,68 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
           "selects": {}
         },
+        "version": "1.0.0"
+      },
+      "license": null,
+      "license_ids": [],
+      "license_file": "../LICENSE"
+    },
+    "bd-panic 1.0.0": {
+      "name": "bd-panic",
+      "version": "1.0.0",
+      "package_url": null,
+      "repository": {
+        "Git": {
+          "remote": "https://github.com/bitdriftlabs/shared-core.git",
+          "commitish": {
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+          },
+          "strip_prefix": "bd-panic"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bd_panic",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "bd_panic",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "color-backtrace 0.7.0",
+              "target": "color_backtrace"
+            },
+            {
+              "id": "log 0.4.26",
+              "target": "log"
+            },
+            {
+              "id": "termcolor 1.4.1",
+              "target": "termcolor"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
         "version": "1.0.0"
       },
       "license": null,
@@ -3695,7 +3892,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -3738,7 +3935,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -3746,7 +3943,7 @@
               "target": "protobuf"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             }
           ],
@@ -3790,7 +3987,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-proto"
         }
@@ -3837,7 +4034,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -3893,7 +4090,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -3920,7 +4117,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -3944,19 +4141,19 @@
               "target": "bd_time"
             },
             {
-              "id": "ctor 0.3.6",
+              "id": "ctor 0.4.1",
               "target": "ctor"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -3977,7 +4174,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -4004,7 +4201,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -4016,7 +4213,7 @@
               "target": "bd_proto"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -4024,11 +4221,11 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -4049,7 +4246,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -4096,7 +4293,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -4112,15 +4309,15 @@
               "target": "regex"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -4141,7 +4338,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-session"
         }
@@ -4168,7 +4365,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -4188,7 +4385,7 @@
               "target": "bd_time"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -4196,7 +4393,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
@@ -4208,15 +4405,15 @@
               "target": "thread_local"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
-              "id": "uuid 1.13.1",
+              "id": "uuid 1.15.1",
               "target": "uuid"
             }
           ],
@@ -4237,7 +4434,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -4264,7 +4461,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -4300,11 +4497,11 @@
               "target": "bd_time"
             },
             {
-              "id": "ctor 0.3.6",
+              "id": "ctor 0.4.1",
               "target": "ctor"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -4312,11 +4509,11 @@
               "target": "parking_lot"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -4337,7 +4534,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -4364,11 +4561,11 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -4389,7 +4586,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -4428,7 +4625,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -4455,7 +4652,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -4507,6 +4704,10 @@
               "target": "bd_metadata"
             },
             {
+              "id": "bd-panic 1.0.0",
+              "target": "bd_panic"
+            },
+            {
               "id": "bd-proto 1.0.0",
               "target": "bd_proto"
             },
@@ -4531,11 +4732,11 @@
               "target": "futures_core"
             },
             {
-              "id": "http-body-util 0.1.2",
+              "id": "http-body-util 0.1.3",
               "target": "http_body_util"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -4551,15 +4752,15 @@
               "target": "protobuf"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -4577,7 +4778,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -4597,7 +4798,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-time"
         }
@@ -4636,11 +4837,11 @@
               "target": "rand"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -4650,7 +4851,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -4670,7 +4871,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "090996dddec2fda608c19a43263e2fedce428351"
+            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
           },
           "strip_prefix": "bd-workflows"
         }
@@ -4697,7 +4898,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -4753,7 +4954,7 @@
               "target": "bd_time"
             },
             {
-              "id": "bincode 1.3.3",
+              "id": "bincode 2.0.1",
               "target": "bincode"
             },
             {
@@ -4761,7 +4962,7 @@
               "target": "itertools"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -4773,7 +4974,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
@@ -4781,15 +4982,15 @@
               "target": "sha2"
             },
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -4799,7 +5000,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -4811,14 +5012,14 @@
       "license_ids": [],
       "license_file": "../LICENSE"
     },
-    "bincode 1.3.3": {
+    "bincode 2.0.1": {
       "name": "bincode",
-      "version": "1.3.3",
-      "package_url": "https://github.com/servo/bincode",
+      "version": "2.0.1",
+      "package_url": "https://github.com/bincode-org/bincode",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bincode/1.3.3/download",
-          "sha256": "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+          "url": "https://static.crates.io/crates/bincode/2.0.1/download",
+          "sha256": "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
         }
       },
       "targets": [
@@ -4840,17 +5041,41 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "bincode_derive",
+            "default",
+            "derive",
+            "serde",
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
+            },
+            {
+              "id": "unty 0.0.4",
+              "target": "unty"
             }
           ],
           "selects": {}
         },
-        "edition": "2015",
-        "version": "1.3.3"
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "bincode_derive 2.0.1",
+              "target": "bincode_derive"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "2.0.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -4858,14 +5083,61 @@
       ],
       "license_file": "LICENSE.md"
     },
-    "bitflags 2.8.0": {
+    "bincode_derive 2.0.1": {
+      "name": "bincode_derive",
+      "version": "2.0.1",
+      "package_url": "https://github.com/bincode-org/bincode",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/bincode_derive/2.0.1/download",
+          "sha256": "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "bincode_derive",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "bincode_derive",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "virtue 0.0.18",
+              "target": "virtue"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.0.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.md"
+    },
+    "bitflags 2.9.0": {
       "name": "bitflags",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "package_url": "https://github.com/bitflags/bitflags",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bitflags/2.8.0/download",
-          "sha256": "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+          "url": "https://static.crates.io/crates/bitflags/2.9.0/download",
+          "sha256": "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
         }
       },
       "targets": [
@@ -4899,7 +5171,7 @@
           }
         },
         "edition": "2021",
-        "version": "2.8.0"
+        "version": "2.9.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -4994,14 +5266,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "bumpalo 3.16.0": {
+    "bumpalo 3.17.0": {
       "name": "bumpalo",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "package_url": "https://github.com/fitzgen/bumpalo",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bumpalo/3.16.0/download",
-          "sha256": "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+          "url": "https://static.crates.io/crates/bumpalo/3.17.0/download",
+          "sha256": "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
         }
       },
       "targets": [
@@ -5030,7 +5302,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "3.16.0"
+        "version": "3.17.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5039,53 +5311,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "byteorder 1.5.0": {
-      "name": "byteorder",
-      "version": "1.5.0",
-      "package_url": "https://github.com/BurntSushi/byteorder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/byteorder/1.5.0/download",
-          "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "byteorder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "byteorder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "1.5.0"
-      },
-      "license": "Unlicense OR MIT",
-      "license_ids": [
-        "MIT",
-        "Unlicense"
-      ],
-      "license_file": "LICENSE-MIT"
-    },
-    "bytes 1.10.0": {
+    "bytes 1.10.1": {
       "name": "bytes",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "package_url": "https://github.com/tokio-rs/bytes",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/bytes/1.10.0/download",
-          "sha256": "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+          "url": "https://static.crates.io/crates/bytes/1.10.1/download",
+          "sha256": "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
         }
       },
       "targets": [
@@ -5115,7 +5348,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.10.0"
+        "version": "1.10.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -5154,7 +5387,7 @@
               "target": "android_logger"
             },
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -5198,11 +5431,11 @@
               "target": "jni"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
@@ -5210,7 +5443,7 @@
               "target": "tracing_subscriber"
             },
             {
-              "id": "uuid 1.13.1",
+              "id": "uuid 1.15.1",
               "target": "uuid"
             }
           ],
@@ -5220,7 +5453,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -5271,14 +5504,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cc 1.2.7": {
+    "cc 1.2.16": {
       "name": "cc",
-      "version": "1.2.7",
+      "version": "1.2.16",
       "package_url": "https://github.com/rust-lang/cc-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cc/1.2.7/download",
-          "sha256": "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+          "url": "https://static.crates.io/crates/cc/1.2.16/download",
+          "sha256": "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
         }
       },
       "targets": [
@@ -5310,7 +5543,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.7"
+        "version": "1.2.16"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5397,14 +5630,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "chrono 0.4.39": {
+    "chrono 0.4.40": {
       "name": "chrono",
-      "version": "0.4.39",
+      "version": "0.4.40",
       "package_url": "https://github.com/chronotope/chrono",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/chrono/0.4.39/download",
-          "sha256": "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+          "url": "https://static.crates.io/crates/chrono/0.4.40/download",
+          "sha256": "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
         }
       },
       "targets": [
@@ -5440,7 +5673,7 @@
             "wasm-bindgen",
             "wasmbind",
             "winapi",
-            "windows-targets"
+            "windows-link"
           ],
           "selects": {}
         },
@@ -5483,7 +5716,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.4.39"
+        "version": "0.4.40"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5539,7 +5772,7 @@
               "target": "ciborium_ll"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             }
           ],
@@ -5650,14 +5883,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "clap 4.5.28": {
+    "clap 4.5.32": {
       "name": "clap",
-      "version": "4.5.28",
+      "version": "4.5.32",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/4.5.28/download",
-          "sha256": "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+          "url": "https://static.crates.io/crates/clap/4.5.32/download",
+          "sha256": "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
         }
       },
       "targets": [
@@ -5688,14 +5921,14 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.5.27",
+              "id": "clap_builder 4.5.32",
               "target": "clap_builder"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.28"
+        "version": "4.5.32"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5704,14 +5937,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_builder 4.5.27": {
+    "clap_builder 4.5.32": {
       "name": "clap_builder",
-      "version": "4.5.27",
+      "version": "4.5.32",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.5.27/download",
-          "sha256": "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+          "url": "https://static.crates.io/crates/clap_builder/4.5.32/download",
+          "sha256": "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
         }
       },
       "targets": [
@@ -5753,7 +5986,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.27"
+        "version": "4.5.32"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5793,6 +6026,65 @@
         ],
         "edition": "2021",
         "version": "0.7.4"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "color-backtrace 0.7.0": {
+      "name": "color-backtrace",
+      "version": "0.7.0",
+      "package_url": "https://github.com/athre0z/color-backtrace",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/color-backtrace/0.7.0/download",
+          "sha256": "2123a5984bd52ca861c66f66a9ab9883b27115c607f801f86c1bc2a84eb69f0f"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "color_backtrace",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "color_backtrace",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "use-backtrace-crate"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "backtrace 0.3.74",
+              "target": "backtrace"
+            },
+            {
+              "id": "termcolor 1.4.1",
+              "target": "termcolor"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.7.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5842,7 +6134,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -5946,14 +6238,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cpufeatures 0.2.16": {
+    "cpufeatures 0.2.17": {
       "name": "cpufeatures",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "package_url": "https://github.com/RustCrypto/utils",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cpufeatures/0.2.16/download",
-          "sha256": "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+          "url": "https://static.crates.io/crates/cpufeatures/0.2.17/download",
+          "sha256": "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
         }
       },
       "targets": [
@@ -5980,32 +6272,32 @@
           "selects": {
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.2.16"
+        "version": "0.2.17"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -6122,7 +6414,7 @@
               "target": "ciborium"
             },
             {
-              "id": "clap 4.5.28",
+              "id": "clap 4.5.32",
               "target": "clap"
             },
             {
@@ -6130,7 +6422,7 @@
               "target": "criterion_plot"
             },
             {
-              "id": "is-terminal 0.4.13",
+              "id": "is-terminal 0.4.16",
               "target": "is_terminal"
             },
             {
@@ -6142,11 +6434,11 @@
               "target": "num_traits"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
-              "id": "oorandom 11.1.4",
+              "id": "oorandom 11.1.5",
               "target": "oorandom"
             },
             {
@@ -6162,11 +6454,11 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "serde_json"
             },
             {
@@ -6184,7 +6476,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.217",
+              "id": "serde_derive 1.0.219",
               "target": "serde_derive"
             }
           ],
@@ -6440,14 +6732,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "crunchy 0.2.2": {
+    "crunchy 0.2.3": {
       "name": "crunchy",
-      "version": "0.2.2",
-      "package_url": null,
+      "version": "0.2.3",
+      "package_url": "https://github.com/eira-fransham/crunchy",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/crunchy/0.2.2/download",
-          "sha256": "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+          "url": "https://static.crates.io/crates/crunchy/0.2.3/download",
+          "sha256": "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
         }
       },
       "targets": [
@@ -6484,14 +6776,14 @@
         "deps": {
           "common": [
             {
-              "id": "crunchy 0.2.2",
+              "id": "crunchy 0.2.3",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2015",
-        "version": "0.2.2"
+        "edition": "2021",
+        "version": "0.2.3"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -6505,7 +6797,7 @@
       "license_ids": [
         "MIT"
       ],
-      "license_file": null
+      "license_file": "LICENSE"
     },
     "crypto-common 0.1.6": {
       "name": "crypto-common",
@@ -6549,7 +6841,7 @@
               "target": "generic_array"
             },
             {
-              "id": "typenum 1.17.0",
+              "id": "typenum 1.18.0",
               "target": "typenum"
             }
           ],
@@ -6597,11 +6889,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -6617,14 +6909,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "ctor 0.3.6": {
+    "ctor 0.4.1": {
       "name": "ctor",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "package_url": "https://github.com/mmastrac/rust-ctor",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ctor/0.3.6/download",
-          "sha256": "21d960ecacd0a1bf55e73144b72de745e7bf275c7952c50e36e8af0a0cb7ab1f"
+          "url": "https://static.crates.io/crates/ctor/0.4.1/download",
+          "sha256": "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
         }
       },
       "targets": [
@@ -6648,7 +6940,19 @@
         ],
         "crate_features": {
           "common": [
-            "default"
+            "__no_warn_on_missing_unsafe",
+            "default",
+            "dtor",
+            "proc_macro"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "dtor 0.0.5",
+              "target": "dtor"
+            }
           ],
           "selects": {}
         },
@@ -6656,13 +6960,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "ctor-proc-macro 0.0.4",
+              "id": "ctor-proc-macro 0.0.5",
               "target": "ctor_proc_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.6"
+        "version": "0.4.1"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -6671,14 +6975,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "ctor-proc-macro 0.0.4": {
+    "ctor-proc-macro 0.0.5": {
       "name": "ctor-proc-macro",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "package_url": "https://github.com/mmastrac/rust-ctor",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ctor-proc-macro/0.0.4/download",
-          "sha256": "c426d2ba3e525b39c1f0a9ba41b9fe61878dee11fa4e4a76b6ab440f46c5db5d"
+          "url": "https://static.crates.io/crates/ctor-proc-macro/0.0.5/download",
+          "sha256": "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
         }
       },
       "targets": [
@@ -6706,8 +7010,8 @@
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.0.4"
+        "edition": "2021",
+        "version": "0.0.5"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -6764,7 +7068,7 @@
               "target": "lock_api"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
@@ -6828,7 +7132,7 @@
               "target": "powerfmt"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             }
           ],
@@ -6945,14 +7249,114 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "either 1.13.0": {
+    "dtor 0.0.5": {
+      "name": "dtor",
+      "version": "0.0.5",
+      "package_url": "https://github.com/mmastrac/rust-ctor",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/dtor/0.0.5/download",
+          "sha256": "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "dtor",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "dtor",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "__no_warn_on_missing_unsafe",
+            "proc_macro"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "dtor-proc-macro 0.0.5",
+              "target": "dtor_proc_macro"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "0.0.5"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "dtor-proc-macro 0.0.5": {
+      "name": "dtor-proc-macro",
+      "version": "0.0.5",
+      "package_url": "https://github.com/mmastrac/rust-ctor",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/dtor-proc-macro/0.0.5/download",
+          "sha256": "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+        }
+      },
+      "targets": [
+        {
+          "ProcMacro": {
+            "crate_name": "dtor_proc_macro",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "dtor_proc_macro",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.0.5"
+      },
+      "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": null
+    },
+    "either 1.15.0": {
       "name": "either",
-      "version": "1.13.0",
+      "version": "1.15.0",
       "package_url": "https://github.com/rayon-rs/either",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/either/1.13.0/download",
-          "sha256": "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+          "url": "https://static.crates.io/crates/either/1.15.0/download",
+          "sha256": "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
         }
       },
       "targets": [
@@ -6976,6 +7380,7 @@
         ],
         "crate_features": {
           "common": [
+            "std",
             "use_std"
           ],
           "selects": {
@@ -6987,8 +7392,8 @@
             ]
           }
         },
-        "edition": "2018",
-        "version": "1.13.0"
+        "edition": "2021",
+        "version": "1.15.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7029,7 +7434,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             }
           ],
@@ -7045,14 +7450,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "equivalent 1.0.1": {
+    "equivalent 1.0.2": {
       "name": "equivalent",
-      "version": "1.0.1",
-      "package_url": "https://github.com/cuviper/equivalent",
+      "version": "1.0.2",
+      "package_url": "https://github.com/indexmap-rs/equivalent",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/equivalent/1.0.1/download",
-          "sha256": "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+          "url": "https://static.crates.io/crates/equivalent/1.0.2/download",
+          "sha256": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
         }
       },
       "targets": [
@@ -7075,7 +7480,7 @@
           "**"
         ],
         "edition": "2015",
-        "version": "1.0.1"
+        "version": "1.0.2"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -7124,19 +7529,19 @@
           "selects": {
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -7256,7 +7661,7 @@
         "deps": {
           "common": [
             {
-              "id": "bitflags 2.8.0",
+              "id": "bitflags 2.9.0",
               "target": "bitflags"
             },
             {
@@ -7324,7 +7729,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             }
           ],
@@ -7340,14 +7745,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "flate2 1.0.35": {
+    "flate2 1.1.0": {
       "name": "flate2",
-      "version": "1.0.35",
+      "version": "1.1.0",
       "package_url": "https://github.com/rust-lang/flate2-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/flate2/1.0.35/download",
-          "sha256": "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+          "url": "https://static.crates.io/crates/flate2/1.1.0/download",
+          "sha256": "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
         }
       },
       "targets": [
@@ -7388,18 +7793,18 @@
               "target": "crc32fast"
             },
             {
-              "id": "libz-sys 1.1.20",
+              "id": "libz-sys 1.1.21",
               "target": "libz_sys"
             },
             {
-              "id": "miniz_oxide 0.8.3",
+              "id": "miniz_oxide 0.8.5",
               "target": "miniz_oxide"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.35"
+        "version": "1.1.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7544,7 +7949,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -7933,15 +8338,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -8212,7 +8617,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "typenum 1.17.0",
+              "id": "typenum 1.18.0",
               "target": "typenum"
             }
           ],
@@ -8295,7 +8700,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ]
@@ -8372,7 +8777,7 @@
           "selects": {
             "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(getrandom_backend = \"custom\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -8390,43 +8795,43 @@
             ],
             "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"hurd\", target_os = \"illumos\", all(target_os = \"horizon\", target_arch = \"arm\")))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"haiku\", target_os = \"redox\", target_os = \"nto\", target_os = \"aix\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"ios\", target_os = \"visionos\", target_os = \"watchos\", target_os = \"tvos\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"macos\", target_os = \"openbsd\", target_os = \"vita\", target_os = \"emscripten\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"netbsd\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"solaris\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"vxworks\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ]
@@ -8479,6 +8884,13 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "read",
+            "read-core"
+          ],
+          "selects": {}
+        },
         "edition": "2018",
         "version": "0.31.1"
       },
@@ -8489,14 +8901,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "h2 0.4.7": {
+    "h2 0.4.8": {
       "name": "h2",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "package_url": "https://github.com/hyperium/h2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/h2/0.4.7/download",
-          "sha256": "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+          "url": "https://static.crates.io/crates/h2/0.4.8/download",
+          "sha256": "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
         }
       },
       "targets": [
@@ -8525,7 +8937,7 @@
               "target": "atomic_waker"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -8541,11 +8953,11 @@
               "target": "futures_sink"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
-              "id": "indexmap 2.7.0",
+              "id": "indexmap 2.8.0",
               "target": "indexmap"
             },
             {
@@ -8553,11 +8965,11 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.7.13",
+              "id": "tokio-util 0.7.14",
               "target": "tokio_util"
             },
             {
@@ -8568,7 +8980,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.7"
+        "version": "0.4.8"
       },
       "license": "MIT",
       "license_ids": [
@@ -8615,7 +9027,7 @@
           "selects": {
             "cfg(target_arch = \"spirv\")": [
               {
-                "id": "crunchy 0.2.2",
+                "id": "crunchy 0.2.3",
                 "target": "crunchy"
               }
             ]
@@ -8715,14 +9127,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "hermit-abi 0.4.0": {
+    "hermit-abi 0.5.0": {
       "name": "hermit-abi",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "package_url": "https://github.com/hermit-os/hermit-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/hermit-abi/0.4.0/download",
-          "sha256": "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+          "url": "https://static.crates.io/crates/hermit-abi/0.5.0/download",
+          "sha256": "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
         }
       },
       "targets": [
@@ -8745,7 +9157,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.4.0"
+        "version": "0.5.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -8804,14 +9216,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "http 1.2.0": {
+    "http 1.3.1": {
       "name": "http",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "package_url": "https://github.com/hyperium/http",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http/1.2.0/download",
-          "sha256": "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+          "url": "https://static.crates.io/crates/http/1.3.1/download",
+          "sha256": "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
         }
       },
       "targets": [
@@ -8843,7 +9255,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -8851,14 +9263,14 @@
               "target": "fnv"
             },
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.0"
+        "version": "1.3.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -8899,11 +9311,11 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             }
           ],
@@ -8918,14 +9330,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "http-body-util 0.1.2": {
+    "http-body-util 0.1.3": {
       "name": "http-body-util",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "package_url": "https://github.com/hyperium/http-body",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http-body-util/0.1.2/download",
-          "sha256": "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+          "url": "https://static.crates.io/crates/http-body-util/0.1.3/download",
+          "sha256": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
         }
       },
       "targets": [
@@ -8947,18 +9359,24 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
-              "id": "futures-util 0.3.31",
-              "target": "futures_util"
+              "id": "futures-core 0.3.31",
+              "target": "futures_core"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -8973,7 +9391,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.2"
+        "version": "0.1.3"
       },
       "license": "MIT",
       "license_ids": [
@@ -8981,14 +9399,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "httparse 1.9.5": {
+    "httparse 1.10.1": {
       "name": "httparse",
-      "version": "1.9.5",
+      "version": "1.10.1",
       "package_url": "https://github.com/seanmonstar/httparse",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/httparse/1.9.5/download",
-          "sha256": "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+          "url": "https://static.crates.io/crates/httparse/1.10.1/download",
+          "sha256": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
         }
       },
       "targets": [
@@ -9032,14 +9450,14 @@
         "deps": {
           "common": [
             {
-              "id": "httparse 1.9.5",
+              "id": "httparse 1.10.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.9.5"
+        "version": "1.10.1"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -9137,7 +9555,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -9149,11 +9567,11 @@
               "target": "futures_util"
             },
             {
-              "id": "h2 0.4.7",
+              "id": "h2 0.4.8",
               "target": "h2"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -9161,7 +9579,7 @@
               "target": "http_body"
             },
             {
-              "id": "httparse 1.9.5",
+              "id": "httparse 1.10.1",
               "target": "httparse"
             },
             {
@@ -9169,7 +9587,7 @@
               "target": "httpdate"
             },
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
@@ -9177,11 +9595,11 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "smallvec 1.13.2",
+              "id": "smallvec 1.14.0",
               "target": "smallvec"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -9246,7 +9664,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -9258,20 +9676,20 @@
               "target": "hyper_util"
             },
             {
-              "id": "rustls 0.23.20",
+              "id": "rustls 0.23.23",
               "target": "rustls"
             },
             {
-              "id": "rustls-pki-types 1.10.1",
+              "id": "rustls-pki-types 1.11.0",
               "target": "rustls_pki_types",
               "alias": "pki_types"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
-              "id": "tokio-rustls 0.26.1",
+              "id": "tokio-rustls 0.26.2",
               "target": "tokio_rustls"
             },
             {
@@ -9279,7 +9697,7 @@
               "target": "tower_service"
             },
             {
-              "id": "webpki-roots 0.26.7",
+              "id": "webpki-roots 0.26.8",
               "target": "webpki_roots"
             }
           ],
@@ -9342,7 +9760,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -9354,7 +9772,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -9374,7 +9792,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -9437,11 +9855,11 @@
           "selects": {
             "cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))": [
               {
-                "id": "js-sys 0.3.76",
+                "id": "js-sys 0.3.77",
                 "target": "js_sys"
               },
               {
-                "id": "wasm-bindgen 0.2.99",
+                "id": "wasm-bindgen 0.2.100",
                 "target": "wasm_bindgen"
               }
             ],
@@ -9544,7 +9962,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.7",
+              "id": "cc 1.2.16",
               "target": "cc"
             }
           ],
@@ -9558,14 +9976,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "indexmap 2.7.0": {
+    "indexmap 2.8.0": {
       "name": "indexmap",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "package_url": "https://github.com/indexmap-rs/indexmap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/indexmap/2.7.0/download",
-          "sha256": "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+          "url": "https://static.crates.io/crates/indexmap/2.8.0/download",
+          "sha256": "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
         }
       },
       "targets": [
@@ -9597,7 +10015,7 @@
         "deps": {
           "common": [
             {
-              "id": "equivalent 1.0.1",
+              "id": "equivalent 1.0.2",
               "target": "equivalent"
             },
             {
@@ -9608,7 +10026,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.7.0"
+        "version": "2.8.0"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -9719,14 +10137,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "is-terminal 0.4.13": {
+    "is-terminal 0.4.16": {
       "name": "is-terminal",
-      "version": "0.4.13",
+      "version": "0.4.16",
       "package_url": "https://github.com/sunfishcode/is-terminal",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/is-terminal/0.4.13/download",
-          "sha256": "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+          "url": "https://static.crates.io/crates/is-terminal/0.4.16/download",
+          "sha256": "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
         }
       },
       "targets": [
@@ -9753,26 +10171,26 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "hermit-abi 0.4.0",
+                "id": "hermit-abi 0.5.0",
                 "target": "hermit_abi"
               }
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.59.0",
                 "target": "windows_sys"
               }
             ]
           }
         },
         "edition": "2018",
-        "version": "0.4.13"
+        "version": "0.4.16"
       },
       "license": "MIT",
       "license_ids": [
@@ -9820,7 +10238,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.13.0",
+              "id": "either 1.15.0",
               "target": "either"
             }
           ],
@@ -9876,7 +10294,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.13.0",
+              "id": "either 1.15.0",
               "target": "either"
             }
           ],
@@ -9892,14 +10310,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "itoa 1.0.14": {
+    "itoa 1.0.15": {
       "name": "itoa",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "package_url": "https://github.com/dtolnay/itoa",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/itoa/1.0.14/download",
-          "sha256": "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+          "url": "https://static.crates.io/crates/itoa/1.0.15/download",
+          "sha256": "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
         }
       },
       "targets": [
@@ -9922,7 +10340,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.14"
+        "version": "1.0.15"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -9985,7 +10403,7 @@
               "target": "jni_sys"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -10051,14 +10469,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "js-sys 0.3.76": {
+    "js-sys 0.3.77": {
       "name": "js-sys",
-      "version": "0.3.76",
+      "version": "0.3.77",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/js-sys/0.3.76/download",
-          "sha256": "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+          "url": "https://static.crates.io/crates/js-sys/0.3.77/download",
+          "sha256": "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
         }
       },
       "targets": [
@@ -10083,18 +10501,18 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
-              "id": "wasm-bindgen 0.2.99",
+              "id": "wasm-bindgen 0.2.100",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.76"
+        "version": "0.3.77"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10142,14 +10560,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "libc 0.2.169": {
+    "libc 0.2.171": {
       "name": "libc",
-      "version": "0.2.169",
+      "version": "0.2.171",
       "package_url": "https://github.com/rust-lang/libc",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libc/0.2.169/download",
-          "sha256": "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+          "url": "https://static.crates.io/crates/libc/0.2.171/download",
+          "sha256": "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
         }
       },
       "targets": [
@@ -10197,14 +10615,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.169"
+        "version": "0.2.171"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -10221,14 +10639,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "libz-sys 1.1.20": {
+    "libz-sys 1.1.21": {
       "name": "libz-sys",
-      "version": "1.1.20",
+      "version": "1.1.21",
       "package_url": "https://github.com/rust-lang/libz-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libz-sys/1.1.20/download",
-          "sha256": "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+          "url": "https://static.crates.io/crates/libz-sys/1.1.21/download",
+          "sha256": "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
         }
       },
       "targets": [
@@ -10265,14 +10683,14 @@
         "deps": {
           "common": [
             {
-              "id": "libz-sys 1.1.20",
+              "id": "libz-sys 1.1.21",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.1.20"
+        "version": "1.1.21"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -10284,11 +10702,11 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.7",
+              "id": "cc 1.2.16",
               "target": "cc"
             },
             {
-              "id": "pkg-config 0.3.31",
+              "id": "pkg-config 0.3.32",
               "target": "pkg_config"
             },
             {
@@ -10307,14 +10725,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "linux-raw-sys 0.4.14": {
+    "linux-raw-sys 0.4.15": {
       "name": "linux-raw-sys",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "package_url": "https://github.com/sunfishcode/linux-raw-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.14/download",
-          "sha256": "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+          "url": "https://static.crates.io/crates/linux-raw-sys/0.4.15/download",
+          "sha256": "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
         }
       },
       "targets": [
@@ -10348,7 +10766,57 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.14"
+        "version": "0.4.15"
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "linux-raw-sys 0.9.2": {
+      "name": "linux-raw-sys",
+      "version": "0.9.2",
+      "package_url": "https://github.com/sunfishcode/linux-raw-sys",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/linux-raw-sys/0.9.2/download",
+          "sha256": "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "linux_raw_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "linux_raw_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "elf",
+            "errno",
+            "general",
+            "ioctl",
+            "no_std",
+            "std"
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.9.2"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -10445,14 +10913,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "log 0.4.25": {
+    "log 0.4.26": {
       "name": "log",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "package_url": "https://github.com/rust-lang/log",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/log/0.4.25/download",
-          "sha256": "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+          "url": "https://static.crates.io/crates/log/0.4.26/download",
+          "sha256": "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
         }
       },
       "targets": [
@@ -10483,7 +10951,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.25"
+        "version": "0.4.26"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10558,7 +11026,7 @@
               "target": "tempdir"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -10603,7 +11071,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "libc"
             }
           ],
@@ -10791,7 +11259,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ]
@@ -10928,14 +11396,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "miniz_oxide 0.8.3": {
+    "miniz_oxide 0.8.5": {
       "name": "miniz_oxide",
-      "version": "0.8.3",
+      "version": "0.8.5",
       "package_url": "https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/miniz_oxide/0.8.3/download",
-          "sha256": "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+          "url": "https://static.crates.io/crates/miniz_oxide/0.8.5/download",
+          "sha256": "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
         }
       },
       "targets": [
@@ -10973,7 +11441,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.3"
+        "version": "0.8.5"
       },
       "license": "MIT OR Zlib OR Apache-2.0",
       "license_ids": [
@@ -11025,13 +11493,13 @@
           "selects": {
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               },
               {
@@ -11041,7 +11509,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -11429,6 +11897,19 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "archive",
+            "coff",
+            "elf",
+            "macho",
+            "pe",
+            "read_core",
+            "unaligned",
+            "xcoff"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -11460,14 +11941,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "once_cell 1.20.2": {
+    "once_cell 1.21.1": {
       "name": "once_cell",
-      "version": "1.20.2",
+      "version": "1.21.1",
       "package_url": "https://github.com/matklad/once_cell",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/once_cell/1.20.2/download",
-          "sha256": "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+          "url": "https://static.crates.io/crates/once_cell/1.21.1/download",
+          "sha256": "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
         }
       },
       "targets": [
@@ -11499,7 +11980,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.20.2"
+        "version": "1.21.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11508,14 +11989,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "oorandom 11.1.4": {
+    "oorandom 11.1.5": {
       "name": "oorandom",
-      "version": "11.1.4",
+      "version": "11.1.5",
       "package_url": "https://hg.sr.ht/~icefox/oorandom",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/oorandom/11.1.4/download",
-          "sha256": "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+          "url": "https://static.crates.io/crates/oorandom/11.1.5/download",
+          "sha256": "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
         }
       },
       "targets": [
@@ -11538,7 +12019,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "11.1.4"
+        "version": "11.1.5"
       },
       "license": "MIT",
       "license_ids": [
@@ -11694,20 +12175,20 @@
               "target": "build_script_build"
             },
             {
-              "id": "smallvec 1.13.2",
+              "id": "smallvec 1.14.0",
               "target": "smallvec"
             }
           ],
           "selects": {
             "cfg(target_os = \"redox\")": [
               {
-                "id": "redox_syscall 0.5.8",
+                "id": "redox_syscall 0.5.10",
                 "target": "syscall"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -11784,14 +12265,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pin-project 1.1.8": {
+    "pin-project 1.1.10": {
       "name": "pin-project",
-      "version": "1.1.8",
+      "version": "1.1.10",
       "package_url": "https://github.com/taiki-e/pin-project",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pin-project/1.1.8/download",
-          "sha256": "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+          "url": "https://static.crates.io/crates/pin-project/1.1.10/download",
+          "sha256": "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
         }
       },
       "targets": [
@@ -11817,13 +12298,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pin-project-internal 1.1.8",
+              "id": "pin-project-internal 1.1.10",
               "target": "pin_project_internal"
             }
           ],
           "selects": {}
         },
-        "version": "1.1.8"
+        "version": "1.1.10"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -11832,14 +12313,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pin-project-internal 1.1.8": {
+    "pin-project-internal 1.1.10": {
       "name": "pin-project-internal",
-      "version": "1.1.8",
+      "version": "1.1.10",
       "package_url": "https://github.com/taiki-e/pin-project",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pin-project-internal/1.1.8/download",
-          "sha256": "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+          "url": "https://static.crates.io/crates/pin-project-internal/1.1.10/download",
+          "sha256": "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
         }
       },
       "targets": [
@@ -11864,22 +12345,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.1.8"
+        "version": "1.1.10"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -11966,14 +12447,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "pkg-config 0.3.31": {
+    "pkg-config 0.3.32": {
       "name": "pkg-config",
-      "version": "0.3.31",
+      "version": "0.3.32",
       "package_url": "https://github.com/rust-lang/pkg-config-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/pkg-config/0.3.31/download",
-          "sha256": "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+          "url": "https://static.crates.io/crates/pkg-config/0.3.32/download",
+          "sha256": "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
         }
       },
       "targets": [
@@ -11996,7 +12477,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.3.31"
+        "version": "0.3.32"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -12044,7 +12525,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -12076,7 +12557,7 @@
               "target": "bd_session"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -12092,11 +12573,11 @@
               "target": "regex"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -12153,7 +12634,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -12189,7 +12670,7 @@
               "target": "bd_test_helpers"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -12258,11 +12739,11 @@
           "selects": {
             "cfg(all(target_arch = \"wasm32\", not(target_os = \"wasi\")))": [
               {
-                "id": "wasm-bindgen 0.2.99",
+                "id": "wasm-bindgen 0.2.100",
                 "target": "wasm_bindgen"
               },
               {
-                "id": "web-sys 0.3.76",
+                "id": "web-sys 0.3.77",
                 "target": "web_sys"
               }
             ]
@@ -12441,14 +12922,14 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "ppv-lite86 0.2.20": {
+    "ppv-lite86 0.2.21": {
       "name": "ppv-lite86",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "package_url": "https://github.com/cryptocorrosion/cryptocorrosion",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ppv-lite86/0.2.20/download",
-          "sha256": "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+          "url": "https://static.crates.io/crates/ppv-lite86/0.2.21/download",
+          "sha256": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
         }
       },
       "targets": [
@@ -12480,16 +12961,16 @@
         "deps": {
           "common": [
             {
-              "id": "zerocopy 0.7.35",
+              "id": "zerocopy 0.8.23",
               "target": "zerocopy"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.20"
+        "version": "0.2.21"
       },
-      "license": "MIT/Apache-2.0",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -12555,14 +13036,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "proc-macro2 1.0.93": {
+    "proc-macro2 1.0.94": {
       "name": "proc-macro2",
-      "version": "1.0.93",
+      "version": "1.0.94",
       "package_url": "https://github.com/dtolnay/proc-macro2",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/proc-macro2/1.0.93/download",
-          "sha256": "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+          "url": "https://static.crates.io/crates/proc-macro2/1.0.94/download",
+          "sha256": "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
         }
       },
       "targets": [
@@ -12606,18 +13087,18 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "build_script_build"
             },
             {
-              "id": "unicode-ident 1.0.16",
+              "id": "unicode-ident 1.0.18",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.93"
+        "version": "1.0.94"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -12739,11 +13220,11 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "serde_json"
             }
           ],
@@ -12811,11 +13292,11 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
@@ -12885,11 +13366,11 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
@@ -12905,7 +13386,7 @@
               "target": "regex"
             },
             {
-              "id": "tempfile 3.15.0",
+              "id": "tempfile 3.18.0",
               "target": "tempfile"
             },
             {
@@ -12959,15 +13440,15 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
-              "id": "indexmap 2.7.0",
+              "id": "indexmap 2.8.0",
               "target": "indexmap"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -12979,7 +13460,7 @@
               "target": "protobuf_support"
             },
             {
-              "id": "tempfile 3.15.0",
+              "id": "tempfile 3.18.0",
               "target": "tempfile"
             },
             {
@@ -13052,14 +13533,14 @@
       ],
       "license_file": "LICENSE.txt"
     },
-    "quote 1.0.38": {
+    "quote 1.0.40": {
       "name": "quote",
-      "version": "1.0.38",
+      "version": "1.0.40",
       "package_url": "https://github.com/dtolnay/quote",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/quote/1.0.38/download",
-          "sha256": "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+          "url": "https://static.crates.io/crates/quote/1.0.40/download",
+          "sha256": "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
         }
       },
       "targets": [
@@ -13091,14 +13572,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.38"
+        "version": "1.0.40"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13147,7 +13628,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "libc"
             }
           ],
@@ -13230,7 +13711,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "libc"
             },
             {
@@ -13302,11 +13783,11 @@
               "target": "rand_chacha"
             },
             {
-              "id": "rand_core 0.9.0",
+              "id": "rand_core 0.9.3",
               "target": "rand_core"
             },
             {
-              "id": "zerocopy 0.8.16",
+              "id": "zerocopy 0.8.23",
               "target": "zerocopy"
             }
           ],
@@ -13360,7 +13841,7 @@
         "deps": {
           "common": [
             {
-              "id": "ppv-lite86 0.2.20",
+              "id": "ppv-lite86 0.2.21",
               "target": "ppv_lite86"
             },
             {
@@ -13418,11 +13899,11 @@
         "deps": {
           "common": [
             {
-              "id": "ppv-lite86 0.2.20",
+              "id": "ppv-lite86 0.2.21",
               "target": "ppv_lite86"
             },
             {
-              "id": "rand_core 0.9.0",
+              "id": "rand_core 0.9.3",
               "target": "rand_core"
             }
           ],
@@ -13581,14 +14062,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rand_core 0.9.0": {
+    "rand_core 0.9.3": {
       "name": "rand_core",
-      "version": "0.9.0",
+      "version": "0.9.3",
       "package_url": "https://github.com/rust-random/rand",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rand_core/0.9.0/download",
-          "sha256": "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+          "url": "https://static.crates.io/crates/rand_core/0.9.3/download",
+          "sha256": "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
         }
       },
       "targets": [
@@ -13622,16 +14103,12 @@
             {
               "id": "getrandom 0.3.1",
               "target": "getrandom"
-            },
-            {
-              "id": "zerocopy 0.8.16",
-              "target": "zerocopy"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.9.0"
+        "version": "0.9.3"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -13672,7 +14149,7 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.13.0",
+              "id": "either 1.15.0",
               "target": "either"
             },
             {
@@ -13816,14 +14293,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "redox_syscall 0.5.8": {
+    "redox_syscall 0.5.10": {
       "name": "redox_syscall",
-      "version": "0.5.8",
+      "version": "0.5.10",
       "package_url": "https://gitlab.redox-os.org/redox-os/syscall",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/redox_syscall/0.5.8/download",
-          "sha256": "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+          "url": "https://static.crates.io/crates/redox_syscall/0.5.10/download",
+          "sha256": "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
         }
       },
       "targets": [
@@ -13848,14 +14325,14 @@
         "deps": {
           "common": [
             {
-              "id": "bitflags 2.8.0",
+              "id": "bitflags 2.9.0",
               "target": "bitflags"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.8"
+        "version": "0.5.10"
       },
       "license": "MIT",
       "license_ids": [
@@ -14241,14 +14718,14 @@
       ],
       "license_file": null
     },
-    "ring 0.17.8": {
+    "ring 0.17.14": {
       "name": "ring",
-      "version": "0.17.8",
+      "version": "0.17.14",
       "package_url": "https://github.com/briansmith/ring",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ring/0.17.8/download",
-          "sha256": "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+          "url": "https://static.crates.io/crates/ring/0.17.14/download",
+          "sha256": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
         }
       },
       "targets": [
@@ -14301,7 +14778,7 @@
               "target": "getrandom"
             },
             {
-              "id": "ring 0.17.8",
+              "id": "ring 0.17.14",
               "target": "build_script_build"
             },
             {
@@ -14310,28 +14787,28 @@
             }
           ],
           "selects": {
-            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
-              {
-                "id": "libc 0.2.169",
-                "target": "libc"
-              }
-            ],
-            "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
+            "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_os = \"windows\"))": [
               {
                 "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ],
-            "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
+            "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_vendor = \"apple\", any(target_os = \"ios\", target_os = \"macos\", target_os = \"tvos\", target_os = \"visionos\", target_os = \"watchos\")))": [
               {
-                "id": "spin 0.9.8",
-                "target": "spin"
+                "id": "libc 0.2.171",
+                "target": "libc"
+              }
+            ],
+            "cfg(all(any(all(target_arch = \"aarch64\", target_endian = \"little\"), all(target_arch = \"arm\", target_endian = \"little\")), any(target_os = \"android\", target_os = \"linux\")))": [
+              {
+                "id": "libc 0.2.171",
+                "target": "libc"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.17.8"
+        "version": "0.17.14"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14343,16 +14820,19 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.7",
+              "id": "cc 1.2.16",
               "target": "cc"
             }
           ],
           "selects": {}
         },
-        "links": "ring_core_0_17_8"
+        "links": "ring_core_0_17_14_"
       },
-      "license": null,
-      "license_ids": [],
+      "license": "Apache-2.0 AND ISC",
+      "license_ids": [
+        "Apache-2.0",
+        "ISC"
+      ],
       "license_file": "LICENSE"
     },
     "rustc-demangle 0.1.24": {
@@ -14426,7 +14906,7 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.24",
+              "id": "semver 1.0.26",
               "target": "semver"
             }
           ],
@@ -14442,14 +14922,141 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustix 0.38.42": {
+    "rustix 0.38.44": {
       "name": "rustix",
-      "version": "0.38.42",
+      "version": "0.38.44",
       "package_url": "https://github.com/bytecodealliance/rustix",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustix/0.38.42/download",
-          "sha256": "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+          "url": "https://static.crates.io/crates/rustix/0.38.44/download",
+          "sha256": "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustix",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustix",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "fs",
+            "libc-extra-traits",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "bitflags 2.9.0",
+              "target": "bitflags"
+            },
+            {
+              "id": "rustix 0.38.44",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "errno 0.3.10",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.171",
+                "target": "libc"
+              }
+            ],
+            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+              {
+                "id": "linux-raw-sys 0.4.15",
+                "target": "linux_raw_sys"
+              }
+            ],
+            "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
+              {
+                "id": "linux-raw-sys 0.4.15",
+                "target": "linux_raw_sys"
+              }
+            ],
+            "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+              {
+                "id": "errno 0.3.10",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "libc 0.2.171",
+                "target": "libc"
+              }
+            ],
+            "cfg(windows)": [
+              {
+                "id": "errno 0.3.10",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "windows-sys 0.59.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.38.44"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "rustix 1.0.2": {
+      "name": "rustix",
+      "version": "1.0.2",
+      "package_url": "https://github.com/bytecodealliance/rustix",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/rustix/1.0.2/download",
+          "sha256": "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
         }
       },
       "targets": [
@@ -14488,20 +15095,18 @@
             "alloc",
             "default",
             "fs",
-            "libc-extra-traits",
-            "std",
-            "use-libc-auxv"
+            "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
             {
-              "id": "bitflags 2.8.0",
+              "id": "bitflags 2.9.0",
               "target": "bitflags"
             },
             {
-              "id": "rustix 0.38.42",
+              "id": "rustix 1.0.2",
               "target": "build_script_build"
             }
           ],
@@ -14513,30 +15118,30 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
-            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+            "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "linux-raw-sys 0.4.14",
+                "id": "linux-raw-sys 0.9.2",
                 "target": "linux_raw_sys"
               }
             ],
-            "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
+            "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
               {
-                "id": "linux-raw-sys 0.4.14",
+                "id": "linux-raw-sys 0.9.2",
                 "target": "linux_raw_sys"
               }
             ],
-            "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+            "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
                 "id": "errno 0.3.10",
                 "target": "errno",
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -14554,7 +15159,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.38.42"
+        "version": "1.0.2"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14571,14 +15176,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls 0.23.20": {
+    "rustls 0.23.23": {
       "name": "rustls",
-      "version": "0.23.20",
+      "version": "0.23.23",
       "package_url": "https://github.com/rustls/rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls/0.23.20/download",
-          "sha256": "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+          "url": "https://static.crates.io/crates/rustls/0.23.23/download",
+          "sha256": "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
         }
       },
       "targets": [
@@ -14622,19 +15227,19 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
-              "id": "ring 0.17.8",
+              "id": "ring 0.17.14",
               "target": "ring"
             },
             {
-              "id": "rustls 0.23.20",
+              "id": "rustls 0.23.23",
               "target": "build_script_build"
             },
             {
-              "id": "rustls-pki-types 1.10.1",
+              "id": "rustls-pki-types 1.11.0",
               "target": "rustls_pki_types",
               "alias": "pki_types"
             },
@@ -14654,7 +15259,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.23.20"
+        "version": "0.23.23"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14666,7 +15271,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "ring 0.17.8",
+              "id": "ring 0.17.14",
               "target": "ring"
             }
           ],
@@ -14720,7 +15325,7 @@
         "deps": {
           "common": [
             {
-              "id": "rustls-pki-types 1.10.1",
+              "id": "rustls-pki-types 1.11.0",
               "target": "rustls_pki_types",
               "alias": "pki_types"
             }
@@ -14738,14 +15343,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "rustls-pki-types 1.10.1": {
+    "rustls-pki-types 1.11.0": {
       "name": "rustls-pki-types",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "package_url": "https://github.com/rustls/pki-types",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls-pki-types/1.10.1/download",
-          "sha256": "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+          "url": "https://static.crates.io/crates/rustls-pki-types/1.11.0/download",
+          "sha256": "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
         }
       },
       "targets": [
@@ -14776,7 +15381,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.10.1"
+        "version": "1.11.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -14825,11 +15430,11 @@
         "deps": {
           "common": [
             {
-              "id": "ring 0.17.8",
+              "id": "ring 0.17.14",
               "target": "ring"
             },
             {
-              "id": "rustls-pki-types 1.10.1",
+              "id": "rustls-pki-types 1.11.0",
               "target": "rustls_pki_types",
               "alias": "pki_types"
             },
@@ -14849,14 +15454,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "rustversion 1.0.19": {
+    "rustversion 1.0.20": {
       "name": "rustversion",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "package_url": "https://github.com/dtolnay/rustversion",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustversion/1.0.19/download",
-          "sha256": "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+          "url": "https://static.crates.io/crates/rustversion/1.0.20/download",
+          "sha256": "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
         }
       },
       "targets": [
@@ -14893,14 +15498,14 @@
         "deps": {
           "common": [
             {
-              "id": "rustversion 1.0.19",
+              "id": "rustversion 1.0.20",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.19"
+        "version": "1.0.20"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -14917,14 +15522,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "ryu 1.0.19": {
+    "ryu 1.0.20": {
       "name": "ryu",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "package_url": "https://github.com/dtolnay/ryu",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ryu/1.0.19/download",
-          "sha256": "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+          "url": "https://static.crates.io/crates/ryu/1.0.20/download",
+          "sha256": "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
         }
       },
       "targets": [
@@ -14947,7 +15552,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.19"
+        "version": "1.0.20"
       },
       "license": "Apache-2.0 OR BSL-1.0",
       "license_ids": [
@@ -15045,14 +15650,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "semver 1.0.24": {
+    "semver 1.0.26": {
       "name": "semver",
-      "version": "1.0.24",
+      "version": "1.0.26",
       "package_url": "https://github.com/dtolnay/semver",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/semver/1.0.24/download",
-          "sha256": "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+          "url": "https://static.crates.io/crates/semver/1.0.26/download",
+          "sha256": "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
         }
       },
       "targets": [
@@ -15096,14 +15701,14 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.24",
+              "id": "semver 1.0.26",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.24"
+        "version": "1.0.26"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -15120,14 +15725,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde 1.0.217": {
+    "serde 1.0.219": {
       "name": "serde",
-      "version": "1.0.217",
+      "version": "1.0.219",
       "package_url": "https://github.com/serde-rs/serde",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde/1.0.217/download",
-          "sha256": "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+          "url": "https://static.crates.io/crates/serde/1.0.219/download",
+          "sha256": "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
         }
       },
       "targets": [
@@ -15175,7 +15780,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "build_script_build"
             }
           ],
@@ -15185,13 +15790,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.217",
+              "id": "serde_derive 1.0.219",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.217"
+        "version": "1.0.219"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -15208,14 +15813,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_derive 1.0.217": {
+    "serde_derive 1.0.219": {
       "name": "serde_derive",
-      "version": "1.0.217",
+      "version": "1.0.219",
       "package_url": "https://github.com/serde-rs/serde",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_derive/1.0.217/download",
-          "sha256": "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+          "url": "https://static.crates.io/crates/serde_derive/1.0.219/download",
+          "sha256": "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
         }
       },
       "targets": [
@@ -15246,22 +15851,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.217"
+        "version": "1.0.219"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -15270,14 +15875,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_json 1.0.138": {
+    "serde_json 1.0.140": {
       "name": "serde_json",
-      "version": "1.0.138",
+      "version": "1.0.140",
       "package_url": "https://github.com/serde-rs/json",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_json/1.0.138/download",
-          "sha256": "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+          "url": "https://static.crates.io/crates/serde_json/1.0.140/download",
+          "sha256": "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
         }
       },
       "targets": [
@@ -15322,7 +15927,7 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
@@ -15330,22 +15935,22 @@
               "target": "memchr"
             },
             {
-              "id": "ryu 1.0.19",
+              "id": "ryu 1.0.20",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.138"
+        "version": "1.0.140"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -15362,14 +15967,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "serde_path_to_error 0.1.16": {
+    "serde_path_to_error 0.1.17": {
       "name": "serde_path_to_error",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "package_url": "https://github.com/dtolnay/path-to-error",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/serde_path_to_error/0.1.16/download",
-          "sha256": "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+          "url": "https://static.crates.io/crates/serde_path_to_error/0.1.17/download",
+          "sha256": "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
         }
       },
       "targets": [
@@ -15394,18 +15999,18 @@
         "deps": {
           "common": [
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.1.16"
+        "version": "0.1.17"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -15450,15 +16055,15 @@
               "target": "form_urlencoded"
             },
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.19",
+              "id": "ryu 1.0.20",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             }
           ],
@@ -15506,19 +16111,19 @@
         "deps": {
           "common": [
             {
-              "id": "indexmap 2.7.0",
+              "id": "indexmap 2.8.0",
               "target": "indexmap"
             },
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.19",
+              "id": "ryu 1.0.20",
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
@@ -15588,7 +16193,7 @@
           "selects": {
             "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
               {
-                "id": "cpufeatures 0.2.16",
+                "id": "cpufeatures 0.2.17",
                 "target": "cpufeatures"
               }
             ]
@@ -15729,7 +16334,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "libc"
             }
           ],
@@ -15913,14 +16518,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "smallvec 1.13.2": {
+    "smallvec 1.14.0": {
       "name": "smallvec",
-      "version": "1.13.2",
+      "version": "1.14.0",
       "package_url": "https://github.com/servo/rust-smallvec",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/smallvec/1.13.2/download",
-          "sha256": "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+          "url": "https://static.crates.io/crates/smallvec/1.14.0/download",
+          "sha256": "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
         }
       },
       "targets": [
@@ -15950,7 +16555,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.13.2"
+        "version": "1.14.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -16066,7 +16671,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.169",
+                "id": "libc 0.2.171",
                 "target": "libc"
               }
             ],
@@ -16087,50 +16692,6 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "spin 0.9.8": {
-      "name": "spin",
-      "version": "0.9.8",
-      "package_url": "https://github.com/mvdnes/spin-rs.git",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/spin/0.9.8/download",
-          "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "spin",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "spin",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "once"
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.9.8"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
     },
     "static_assertions 1.1.0": {
       "name": "static_assertions",
@@ -16236,7 +16797,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -16280,7 +16841,7 @@
               "target": "bd_time"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -16292,11 +16853,11 @@
               "target": "parking_lot"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -16304,7 +16865,7 @@
               "target": "tracing_subscriber"
             },
             {
-              "id": "uuid 1.13.1",
+              "id": "uuid 1.15.1",
               "target": "uuid"
             }
           ],
@@ -16327,7 +16888,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "async-trait 0.1.86",
+              "id": "async-trait 0.1.87",
               "target": "async_trait"
             }
           ],
@@ -16339,14 +16900,14 @@
       "license_ids": [],
       "license_file": "LICENSE"
     },
-    "syn 2.0.98": {
+    "syn 2.0.100": {
       "name": "syn",
-      "version": "2.0.98",
+      "version": "2.0.100",
       "package_url": "https://github.com/dtolnay/syn",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/syn/2.0.98/download",
-          "sha256": "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+          "url": "https://static.crates.io/crates/syn/2.0.100/download",
+          "sha256": "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
         }
       },
       "targets": [
@@ -16386,22 +16947,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "unicode-ident 1.0.16",
+              "id": "unicode-ident 1.0.18",
               "target": "unicode_ident"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.98"
+        "version": "2.0.100"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -16500,14 +17061,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "tempfile 3.15.0": {
+    "tempfile 3.18.0": {
       "name": "tempfile",
-      "version": "3.15.0",
+      "version": "3.18.0",
       "package_url": "https://github.com/Stebalien/tempfile",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tempfile/3.15.0/download",
-          "sha256": "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+          "url": "https://static.crates.io/crates/tempfile/3.18.0/download",
+          "sha256": "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
         }
       },
       "targets": [
@@ -16547,18 +17108,18 @@
               "target": "fastrand"
             },
             {
-              "id": "getrandom 0.2.15",
+              "id": "getrandom 0.3.1",
               "target": "getrandom"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             }
           ],
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "rustix 0.38.42",
+                "id": "rustix 1.0.2",
                 "target": "rustix"
               }
             ],
@@ -16571,7 +17132,7 @@
           }
         },
         "edition": "2021",
-        "version": "3.15.0"
+        "version": "3.18.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -16579,6 +17140,56 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "termcolor 1.4.1": {
+      "name": "termcolor",
+      "version": "1.4.1",
+      "package_url": "https://github.com/BurntSushi/termcolor",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/termcolor/1.4.1/download",
+          "sha256": "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "termcolor",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "termcolor",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "winapi-util 0.1.9",
+                "target": "winapi_util"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "1.4.1"
+      },
+      "license": "Unlicense OR MIT",
+      "license_ids": [
+        "MIT",
+        "Unlicense"
+      ],
+      "license_file": "LICENSE-MIT"
     },
     "test_jni 1.0.0": {
       "name": "test_jni",
@@ -16607,7 +17218,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.95",
+              "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
             {
@@ -16635,7 +17246,7 @@
               "target": "bd_test_helpers"
             },
             {
-              "id": "chrono 0.4.39",
+              "id": "chrono 0.4.40",
               "target": "chrono"
             },
             {
@@ -16643,7 +17254,7 @@
               "target": "jni"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -16724,7 +17335,7 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.37",
+              "id": "time 0.3.39",
               "target": "time"
             }
           ],
@@ -16823,14 +17434,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror 2.0.11": {
+    "thiserror 2.0.12": {
       "name": "thiserror",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror/2.0.11/download",
-          "sha256": "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+          "url": "https://static.crates.io/crates/thiserror/2.0.12/download",
+          "sha256": "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
         }
       },
       "targets": [
@@ -16874,7 +17485,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 2.0.11",
+              "id": "thiserror 2.0.12",
               "target": "build_script_build"
             }
           ],
@@ -16884,13 +17495,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 2.0.11",
+              "id": "thiserror-impl 2.0.12",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "2.0.11"
+        "version": "2.0.12"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -16939,15 +17550,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -16963,14 +17574,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "thiserror-impl 2.0.11": {
+    "thiserror-impl 2.0.12": {
       "name": "thiserror-impl",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "package_url": "https://github.com/dtolnay/thiserror",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/thiserror-impl/2.0.11/download",
-          "sha256": "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+          "url": "https://static.crates.io/crates/thiserror-impl/2.0.12/download",
+          "sha256": "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
         }
       },
       "targets": [
@@ -16995,22 +17606,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.11"
+        "version": "2.0.12"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17055,7 +17666,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             }
           ],
@@ -17071,14 +17682,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "time 0.3.37": {
+    "time 0.3.39": {
       "name": "time",
-      "version": "0.3.37",
+      "version": "0.3.39",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time/0.3.37/download",
-          "sha256": "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+          "url": "https://static.crates.io/crates/time/0.3.39/download",
+          "sha256": "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
         }
       },
       "targets": [
@@ -17120,7 +17731,7 @@
               "target": "deranged"
             },
             {
-              "id": "itoa 1.0.14",
+              "id": "itoa 1.0.15",
               "target": "itoa"
             },
             {
@@ -17132,11 +17743,11 @@
               "target": "powerfmt"
             },
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "time-core 0.1.2",
+              "id": "time-core 0.1.3",
               "target": "time_core"
             }
           ],
@@ -17146,13 +17757,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "time-macros 0.2.19",
+              "id": "time-macros 0.2.20",
               "target": "time_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.37"
+        "version": "0.3.39"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17161,14 +17772,14 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "time-core 0.1.2": {
+    "time-core 0.1.3": {
       "name": "time-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time-core/0.1.2/download",
-          "sha256": "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+          "url": "https://static.crates.io/crates/time-core/0.1.3/download",
+          "sha256": "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
         }
       },
       "targets": [
@@ -17191,7 +17802,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.1.2"
+        "version": "0.1.3"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17200,14 +17811,14 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "time-macros 0.2.19": {
+    "time-macros 0.2.20": {
       "name": "time-macros",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time-macros/0.2.19/download",
-          "sha256": "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+          "url": "https://static.crates.io/crates/time-macros/0.2.20/download",
+          "sha256": "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
         }
       },
       "targets": [
@@ -17244,14 +17855,14 @@
               "target": "num_conv"
             },
             {
-              "id": "time-core 0.1.2",
+              "id": "time-core 0.1.3",
               "target": "time_core"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.19"
+        "version": "0.2.20"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17259,6 +17870,44 @@
         "MIT"
       ],
       "license_file": "LICENSE-Apache"
+    },
+    "tinyjson 2.5.1": {
+      "name": "tinyjson",
+      "version": "2.5.1",
+      "package_url": "https://github.com/rhysd/tinyjson",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tinyjson/2.5.1/download",
+          "sha256": "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tinyjson",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tinyjson",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "2.5.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.txt"
     },
     "tinytemplate 1.2.1": {
       "name": "tinytemplate",
@@ -17292,11 +17941,11 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.217",
+              "id": "serde 1.0.219",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.138",
+              "id": "serde_json 1.0.140",
               "target": "serde_json"
             }
           ],
@@ -17312,14 +17961,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "tokio 1.43.0": {
+    "tokio 1.44.1": {
       "name": "tokio",
-      "version": "1.43.0",
+      "version": "1.44.1",
       "package_url": "https://github.com/tokio-rs/tokio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio/1.43.0/download",
-          "sha256": "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+          "url": "https://static.crates.io/crates/tokio/1.44.1/download",
+          "sha256": "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
         }
       },
       "targets": [
@@ -17370,11 +18019,11 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
-              "id": "libc 0.2.169",
+              "id": "libc 0.2.171",
               "target": "libc"
             },
             {
@@ -17417,7 +18066,7 @@
           ],
           "selects": {}
         },
-        "version": "1.43.0"
+        "version": "1.44.1"
       },
       "license": "MIT",
       "license_ids": [
@@ -17457,15 +18106,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -17480,14 +18129,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tokio-rustls 0.26.1": {
+    "tokio-rustls 0.26.2": {
       "name": "tokio-rustls",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "package_url": "https://github.com/rustls/tokio-rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio-rustls/0.26.1/download",
-          "sha256": "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+          "url": "https://static.crates.io/crates/tokio-rustls/0.26.2/download",
+          "sha256": "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
         }
       },
       "targets": [
@@ -17512,18 +18161,18 @@
         "deps": {
           "common": [
             {
-              "id": "rustls 0.23.20",
+              "id": "rustls 0.23.23",
               "target": "rustls"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.26.1"
+        "version": "0.26.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -17579,7 +18228,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
@@ -17594,14 +18243,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "tokio-util 0.7.13": {
+    "tokio-util 0.7.14": {
       "name": "tokio-util",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "package_url": "https://github.com/tokio-rs/tokio",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/tokio-util/0.7.13/download",
-          "sha256": "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+          "url": "https://static.crates.io/crates/tokio-util/0.7.14/download",
+          "sha256": "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
         }
       },
       "targets": [
@@ -17634,7 +18283,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -17650,14 +18299,14 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.13"
+        "version": "0.7.14"
       },
       "license": "MIT",
       "license_ids": [
@@ -17719,7 +18368,7 @@
               "target": "futures_util"
             },
             {
-              "id": "pin-project 1.1.8",
+              "id": "pin-project 1.1.10",
               "target": "pin_project"
             },
             {
@@ -17814,7 +18463,7 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
@@ -17887,15 +18536,15 @@
         "deps": {
           "common": [
             {
-              "id": "async-compression 0.4.18",
+              "id": "async-compression 0.4.20",
               "target": "async_compression"
             },
             {
-              "id": "bitflags 2.8.0",
+              "id": "bitflags 2.9.0",
               "target": "bitflags"
             },
             {
-              "id": "bytes 1.10.0",
+              "id": "bytes 1.10.1",
               "target": "bytes"
             },
             {
@@ -17903,7 +18552,7 @@
               "target": "futures_core"
             },
             {
-              "id": "http 1.2.0",
+              "id": "http 1.3.1",
               "target": "http"
             },
             {
@@ -17915,11 +18564,11 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.43.0",
+              "id": "tokio 1.44.1",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.7.13",
+              "id": "tokio-util 0.7.14",
               "target": "tokio_util"
             },
             {
@@ -18060,7 +18709,7 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
@@ -18124,15 +18773,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -18187,7 +18836,7 @@
         "deps": {
           "common": [
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             }
           ],
@@ -18300,11 +18949,11 @@
         "deps": {
           "common": [
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
@@ -18384,7 +19033,7 @@
               "target": "nu_ansi_term"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
@@ -18396,7 +19045,7 @@
               "target": "sharded_slab"
             },
             {
-              "id": "smallvec 1.13.2",
+              "id": "smallvec 1.14.0",
               "target": "smallvec"
             },
             {
@@ -18465,14 +19114,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "typenum 1.17.0": {
+    "typenum 1.18.0": {
       "name": "typenum",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "package_url": "https://github.com/paholg/typenum",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/typenum/1.17.0/download",
-          "sha256": "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+          "url": "https://static.crates.io/crates/typenum/1.18.0/download",
+          "sha256": "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
         }
       },
       "targets": [
@@ -18490,8 +19139,8 @@
         },
         {
           "BuildScript": {
-            "crate_name": "build_script_main",
-            "crate_root": "build/main.rs",
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
             "srcs": {
               "allow_empty": true,
               "include": [
@@ -18509,14 +19158,14 @@
         "deps": {
           "common": [
             {
-              "id": "typenum 1.17.0",
-              "target": "build_script_main"
+              "id": "typenum 1.18.0",
+              "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.17.0"
+        "version": "1.18.0"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -18533,14 +19182,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "unicode-ident 1.0.16": {
+    "unicode-ident 1.0.18": {
       "name": "unicode-ident",
-      "version": "1.0.16",
+      "version": "1.0.18",
       "package_url": "https://github.com/dtolnay/unicode-ident",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/unicode-ident/1.0.16/download",
-          "sha256": "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+          "url": "https://static.crates.io/crates/unicode-ident/1.0.18/download",
+          "sha256": "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
         }
       },
       "targets": [
@@ -18563,7 +19212,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "1.0.16"
+        "version": "1.0.18"
       },
       "license": "(MIT OR Apache-2.0) AND Unicode-3.0",
       "license_ids": [
@@ -18649,6 +19298,45 @@
       ],
       "license_file": "LICENSE.txt"
     },
+    "unty 0.0.4": {
+      "name": "unty",
+      "version": "0.0.4",
+      "package_url": "https://github.com/bincode-org/unty",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/unty/0.0.4/download",
+          "sha256": "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "unty",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "unty",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.0.4"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "unwrap-infallible 0.1.5": {
       "name": "unwrap-infallible",
       "version": "0.1.5",
@@ -18732,14 +19420,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "uuid 1.13.1": {
+    "uuid 1.15.1": {
       "name": "uuid",
-      "version": "1.13.1",
+      "version": "1.15.1",
       "package_url": "https://github.com/uuid-rs/uuid",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/uuid/1.13.1/download",
-          "sha256": "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+          "url": "https://static.crates.io/crates/uuid/1.15.1/download",
+          "sha256": "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
         }
       },
       "targets": [
@@ -18780,7 +19468,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.13.1"
+        "version": "1.15.1"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -18789,14 +19477,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "valuable 0.1.0": {
+    "valuable 0.1.1": {
       "name": "valuable",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "package_url": "https://github.com/tokio-rs/valuable",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/valuable/0.1.0/download",
-          "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+          "url": "https://static.crates.io/crates/valuable/0.1.1/download",
+          "sha256": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
         }
       },
       "targets": [
@@ -18833,14 +19521,14 @@
         "deps": {
           "common": [
             {
-              "id": "valuable 0.1.0",
+              "id": "valuable 0.1.1",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
-        "edition": "2018",
-        "version": "0.1.0"
+        "edition": "2021",
+        "version": "0.1.1"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -18933,6 +19621,44 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "virtue 0.0.18": {
+      "name": "virtue",
+      "version": "0.0.18",
+      "package_url": "https://github.com/bincode-org/virtue",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/virtue/0.0.18/download",
+          "sha256": "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "virtue",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "virtue",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.0.18"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.md"
     },
     "walkdir 2.5.0": {
       "name": "walkdir",
@@ -19123,14 +19849,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen 0.2.99": {
+    "wasm-bindgen 0.2.100": {
       "name": "wasm-bindgen",
-      "version": "0.2.99",
+      "version": "0.2.100",
       "package_url": "https://github.com/rustwasm/wasm-bindgen",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen/0.2.99/download",
-          "sha256": "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+          "url": "https://static.crates.io/crates/wasm-bindgen/0.2.100/download",
+          "sha256": "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
         }
       },
       "targets": [
@@ -19171,11 +19897,11 @@
               "target": "cfg_if"
             },
             {
-              "id": "once_cell 1.20.2",
+              "id": "once_cell 1.21.1",
               "target": "once_cell"
             },
             {
-              "id": "wasm-bindgen 0.2.99",
+              "id": "wasm-bindgen 0.2.100",
               "target": "build_script_build"
             }
           ],
@@ -19185,13 +19911,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "wasm-bindgen-macro 0.2.99",
+              "id": "wasm-bindgen-macro 0.2.100",
               "target": "wasm_bindgen_macro"
             }
           ],
           "selects": {}
         },
-        "version": "0.2.99"
+        "version": "0.2.100"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19208,14 +19934,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-backend 0.2.99": {
+    "wasm-bindgen-backend 0.2.100": {
       "name": "wasm-bindgen-backend",
-      "version": "0.2.99",
+      "version": "0.2.100",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-backend/0.2.99/download",
-          "sha256": "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+          "url": "https://static.crates.io/crates/wasm-bindgen-backend/0.2.100/download",
+          "sha256": "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
         }
       },
       "targets": [
@@ -19240,34 +19966,34 @@
         "deps": {
           "common": [
             {
-              "id": "bumpalo 3.16.0",
+              "id": "bumpalo 3.17.0",
               "target": "bumpalo"
             },
             {
-              "id": "log 0.4.25",
+              "id": "log 0.4.26",
               "target": "log"
             },
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.99",
+              "id": "wasm-bindgen-shared 0.2.100",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.99"
+        "version": "0.2.100"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19276,14 +20002,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-macro 0.2.99": {
+    "wasm-bindgen-macro 0.2.100": {
       "name": "wasm-bindgen-macro",
-      "version": "0.2.99",
+      "version": "0.2.100",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-macro/0.2.99/download",
-          "sha256": "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+          "url": "https://static.crates.io/crates/wasm-bindgen-macro/0.2.100/download",
+          "sha256": "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
         }
       },
       "targets": [
@@ -19308,18 +20034,18 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "wasm-bindgen-macro-support 0.2.99",
+              "id": "wasm-bindgen-macro-support 0.2.100",
               "target": "wasm_bindgen_macro_support"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.99"
+        "version": "0.2.100"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19328,14 +20054,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-macro-support 0.2.99": {
+    "wasm-bindgen-macro-support 0.2.100": {
       "name": "wasm-bindgen-macro-support",
-      "version": "0.2.99",
+      "version": "0.2.100",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.99/download",
-          "sha256": "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+          "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.100/download",
+          "sha256": "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
         }
       },
       "targets": [
@@ -19360,30 +20086,30 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             },
             {
-              "id": "wasm-bindgen-backend 0.2.99",
+              "id": "wasm-bindgen-backend 0.2.100",
               "target": "wasm_bindgen_backend"
             },
             {
-              "id": "wasm-bindgen-shared 0.2.99",
+              "id": "wasm-bindgen-shared 0.2.100",
               "target": "wasm_bindgen_shared"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.99"
+        "version": "0.2.100"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19392,14 +20118,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "wasm-bindgen-shared 0.2.99": {
+    "wasm-bindgen-shared 0.2.100": {
       "name": "wasm-bindgen-shared",
-      "version": "0.2.99",
+      "version": "0.2.100",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/wasm-bindgen-shared/0.2.99/download",
-          "sha256": "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+          "url": "https://static.crates.io/crates/wasm-bindgen-shared/0.2.100/download",
+          "sha256": "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
         }
       },
       "targets": [
@@ -19436,14 +20162,18 @@
         "deps": {
           "common": [
             {
-              "id": "wasm-bindgen-shared 0.2.99",
+              "id": "unicode-ident 1.0.18",
+              "target": "unicode_ident"
+            },
+            {
+              "id": "wasm-bindgen-shared 0.2.100",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.99"
+        "version": "0.2.100"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19461,14 +20191,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "web-sys 0.3.76": {
+    "web-sys 0.3.77": {
       "name": "web-sys",
-      "version": "0.3.76",
+      "version": "0.3.77",
       "package_url": "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/web-sys/0.3.76/download",
-          "sha256": "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+          "url": "https://static.crates.io/crates/web-sys/0.3.77/download",
+          "sha256": "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
         }
       },
       "targets": [
@@ -19493,18 +20223,18 @@
         "deps": {
           "common": [
             {
-              "id": "js-sys 0.3.76",
+              "id": "js-sys 0.3.77",
               "target": "js_sys"
             },
             {
-              "id": "wasm-bindgen 0.2.99",
+              "id": "wasm-bindgen 0.2.100",
               "target": "wasm_bindgen"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.76"
+        "version": "0.3.77"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19513,14 +20243,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "webpki-roots 0.26.7": {
+    "webpki-roots 0.26.8": {
       "name": "webpki-roots",
-      "version": "0.26.7",
+      "version": "0.26.8",
       "package_url": "https://github.com/rustls/webpki-roots",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/webpki-roots/0.26.7/download",
-          "sha256": "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+          "url": "https://static.crates.io/crates/webpki-roots/0.26.8/download",
+          "sha256": "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
         }
       },
       "targets": [
@@ -19545,7 +20275,7 @@
         "deps": {
           "common": [
             {
-              "id": "rustls-pki-types 1.10.1",
+              "id": "rustls-pki-types 1.11.0",
               "target": "rustls_pki_types",
               "alias": "pki_types"
             }
@@ -19553,7 +20283,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.26.7"
+        "version": "0.26.8"
       },
       "license": "MPL-2.0",
       "license_ids": [
@@ -19593,11 +20323,11 @@
         "deps": {
           "common": [
             {
-              "id": "either 1.13.0",
+              "id": "either 1.15.0",
               "target": "either"
             },
             {
-              "id": "rustix 0.38.42",
+              "id": "rustix 0.38.44",
               "target": "rustix"
             }
           ],
@@ -19610,7 +20340,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "once_cell 1.20.2",
+                "id": "once_cell 1.21.1",
                 "target": "once_cell"
               }
             ]
@@ -19932,6 +20662,45 @@
         },
         "edition": "2021",
         "version": "0.52.0"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "license-apache-2.0"
+    },
+    "windows-link 0.1.0": {
+      "name": "windows-link",
+      "version": "0.1.0",
+      "package_url": "https://github.com/microsoft/windows-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/windows-link/0.1.0/download",
+          "sha256": "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "windows_link",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "windows_link",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.1.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -21460,32 +22229,21 @@
         ],
         "crate_features": {
           "common": [
-            "byteorder",
-            "default",
-            "derive",
-            "simd",
-            "zerocopy-derive"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "byteorder 1.5.0",
-              "target": "byteorder"
-            }
+            "simd"
           ],
           "selects": {}
         },
         "edition": "2018",
         "proc_macro_deps": {
-          "common": [
-            {
-              "id": "zerocopy-derive 0.7.35",
-              "target": "zerocopy_derive"
-            }
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "cfg(any())": [
+              {
+                "id": "zerocopy-derive 0.7.35",
+                "target": "zerocopy_derive"
+              }
+            ]
+          }
         },
         "version": "0.7.35"
       },
@@ -21497,14 +22255,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "zerocopy 0.8.16": {
+    "zerocopy 0.8.23": {
       "name": "zerocopy",
-      "version": "0.8.16",
+      "version": "0.8.23",
       "package_url": "https://github.com/google/zerocopy",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/zerocopy/0.8.16/download",
-          "sha256": "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+          "url": "https://static.crates.io/crates/zerocopy/0.8.23/download",
+          "sha256": "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
         }
       },
       "targets": [
@@ -21547,7 +22305,7 @@
         "deps": {
           "common": [
             {
-              "id": "zerocopy 0.8.16",
+              "id": "zerocopy 0.8.23",
               "target": "build_script_build"
             }
           ],
@@ -21559,13 +22317,13 @@
           "selects": {
             "cfg(any())": [
               {
-                "id": "zerocopy-derive 0.8.16",
+                "id": "zerocopy-derive 0.8.23",
                 "target": "zerocopy_derive"
               }
             ]
           }
         },
-        "version": "0.8.16"
+        "version": "0.8.23"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -21615,15 +22373,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
@@ -21640,14 +22398,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "zerocopy-derive 0.8.16": {
+    "zerocopy-derive 0.8.23": {
       "name": "zerocopy-derive",
-      "version": "0.8.16",
+      "version": "0.8.23",
       "package_url": "https://github.com/google/zerocopy",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/zerocopy-derive/0.8.16/download",
-          "sha256": "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
+          "url": "https://static.crates.io/crates/zerocopy-derive/0.8.23/download",
+          "sha256": "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
         }
       },
       "targets": [
@@ -21672,22 +22430,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.93",
+              "id": "proc-macro2 1.0.94",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.38",
+              "id": "quote 1.0.40",
               "target": "quote"
             },
             {
-              "id": "syn 2.0.98",
+              "id": "syn 2.0.100",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.16"
+        "version": "0.8.23"
       },
       "license": "BSD-2-Clause OR Apache-2.0 OR MIT",
       "license_ids": [
@@ -21775,16 +22533,28 @@
     "armv7-linux-androideabi": [
       "armv7-linux-androideabi"
     ],
+    "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_os = \"windows\"))": [],
+    "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_vendor = \"apple\", any(target_os = \"ios\", target_os = \"macos\", target_os = \"tvos\", target_os = \"visionos\", target_os = \"watchos\")))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim"
+    ],
+    "cfg(all(any(all(target_arch = \"aarch64\", target_endian = \"little\"), all(target_arch = \"arm\", target_endian = \"little\")), any(target_os = \"android\", target_os = \"linux\")))": [
+      "aarch64-linux-android",
+      "armv7-linux-androideabi"
+    ],
     "cfg(all(any(target_arch = \"x86_64\", target_arch = \"arm64ec\"), target_env = \"msvc\", not(windows_raw_dylib)))": [],
-    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-linux-android",
       "armv7-linux-androideabi",
       "i686-linux-android",
       "x86_64-linux-android"
     ],
-    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
+    "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-linux-android",
-      "armv7-linux-androideabi"
+      "armv7-linux-androideabi",
+      "i686-linux-android",
+      "x86_64-linux-android"
     ],
     "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(getrandom_backend = \"custom\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": [
       "aarch64-linux-android",
@@ -21793,8 +22563,21 @@
       "x86_64-linux-android",
       "x86_64-unknown-linux-gnu"
     ],
+    "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
+      "x86_64-unknown-linux-gnu"
+    ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", any(target_arch = \"s390x\", target_arch = \"powerpc\")), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc\"), all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "armv7-linux-androideabi",
+      "i686-linux-android",
+      "x86_64-apple-ios",
+      "x86_64-linux-android"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_endian = \"little\", target_arch = \"s390x\"), any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"s390x\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
       "aarch64-apple-darwin",
@@ -21808,7 +22591,6 @@
     ],
     "cfg(all(target_arch = \"aarch64\", target_env = \"msvc\", not(windows_raw_dylib)))": [],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [],
-    "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [],
     "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -21825,17 +22607,6 @@
     ],
     "cfg(all(windows, not(target_vendor = \"win7\")))": [],
     "cfg(any())": [],
-    "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
-      "aarch64-apple-darwin",
-      "aarch64-apple-ios",
-      "aarch64-apple-ios-sim",
-      "aarch64-linux-android",
-      "armv7-linux-androideabi",
-      "i686-linux-android",
-      "x86_64-apple-ios",
-      "x86_64-linux-android",
-      "x86_64-unknown-linux-gnu"
-    ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -21874,6 +22645,17 @@
       "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(windows, unix, target_os = \"redox\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-linux-android",
+      "armv7-linux-androideabi",
+      "i686-linux-android",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
       "aarch64-apple-ios-sim",
@@ -21961,9 +22743,9 @@
   },
   "direct_deps": [
     "android_logger 0.14.1",
-    "anyhow 1.0.95",
+    "anyhow 1.0.97",
     "assert_matches 1.5.0",
-    "async-trait 0.1.86",
+    "async-trait 0.1.87",
     "bd-api 1.0.0",
     "bd-buffer 1.0.0",
     "bd-client-common 1.0.0",
@@ -21981,24 +22763,24 @@
     "bd-shutdown 1.0.0",
     "bd-test-helpers 1.0.0",
     "bd-time 1.0.0",
-    "chrono 0.4.39",
+    "chrono 0.4.40",
     "criterion 0.5.1",
     "ctor 0.2.9",
     "jni 0.21.1",
-    "log 0.4.25",
+    "log 0.4.26",
     "objc 0.2.7",
     "objc-foundation 0.1.1",
     "parking_lot 0.12.3",
     "protobuf 4.0.0-alpha.0",
     "regex 1.11.1",
-    "serde 1.0.217",
-    "serde_json 1.0.138",
+    "serde 1.0.219",
+    "serde_json 1.0.140",
     "simple-xml 0.1.10",
     "tempdir 0.3.7",
-    "time 0.3.37",
-    "tokio 1.43.0",
+    "time 0.3.39",
+    "tokio 1.44.1",
     "tracing-subscriber 0.3.19",
-    "uuid 1.13.1"
+    "uuid 1.15.1"
   ],
   "direct_dev_deps": [
     "pretty_assertions 1.4.1"

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "63af841a51c5f1c47c024c120795702f8e6f0bd8df90e767d355c83f356d2d83",
+  "checksum": "caaf54f982f0df243acfdcb656906728413982a33d66825394bec2cf62babd34",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -16797,6 +16797,10 @@
         "deps": {
           "common": [
             {
+              "id": "ahash 0.8.11",
+              "target": "ahash"
+            },
+            {
               "id": "anyhow 1.0.97",
               "target": "anyhow"
             },
@@ -16819,6 +16823,10 @@
             {
               "id": "bd-log 1.0.0",
               "target": "bd_log"
+            },
+            {
+              "id": "bd-log-primitives 1.0.0",
+              "target": "bd_log_primitives"
             },
             {
               "id": "bd-logger 1.0.0",
@@ -22742,6 +22750,7 @@
     "x86_64-uwp-windows-msvc": []
   },
   "direct_deps": [
+    "ahash 0.8.11",
     "android_logger 0.14.1",
     "anyhow 1.0.97",
     "assert_matches 1.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.15",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,9 +48,9 @@ checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_logger"
@@ -72,9 +86,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arc-swap"
@@ -90,9 +104,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
 dependencies = [
  "flate2",
  "futures-core",
@@ -103,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -248,14 +262,14 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "8faa168b8c4ffca39c2699e772943af41ec2b75fb1683dda07b28a6d285c53dc"
 
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -284,7 +298,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -302,7 +316,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "static_assertions",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tracing",
@@ -311,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -324,7 +338,7 @@ dependencies = [
  "log",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "uuid",
@@ -333,7 +347,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -357,21 +371,21 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
  "log",
  "parking_lot",
  "sketches-rust",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "log",
@@ -381,21 +395,25 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bd-log-primitives",
  "bd-runtime",
  "bd-shutdown",
+ "itertools 0.14.0",
  "log",
+ "regex",
+ "time",
+ "tinyjson",
  "tokio",
 ]
 
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -412,11 +430,11 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
- "ctor 0.3.6",
+ "ctor 0.4.1",
  "log",
  "tokio",
 ]
@@ -424,7 +442,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -452,7 +470,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snap",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -465,7 +483,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -474,13 +492,13 @@ dependencies = [
  "flate2",
  "log",
  "protobuf",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -504,7 +522,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -516,7 +534,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "base64",
@@ -531,7 +549,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -548,7 +566,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -564,7 +582,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -578,7 +596,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -588,17 +606,19 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
+ "ahash",
  "anyhow",
  "bd-proto",
+ "serde",
  "time",
 ]
 
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -637,7 +657,7 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tower 0.5.2",
@@ -648,20 +668,20 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
  "bd-proto",
  "protobuf",
  "regex",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "base64",
@@ -676,12 +696,12 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -690,20 +710,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bd-panic"
+version = "1.0.0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+dependencies = [
+ "color-backtrace",
+ "log",
+ "termcolor",
+]
+
+[[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "log",
  "protobuf",
  "protobuf-codegen",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -716,7 +746,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -724,7 +754,7 @@ dependencies = [
  "bd-runtime",
  "bd-shutdown",
  "bd-time",
- "ctor 0.3.6",
+ "ctor 0.4.1",
  "log",
  "time",
  "tokio",
@@ -733,7 +763,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -747,7 +777,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -758,7 +788,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "regex",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
 ]
@@ -766,7 +796,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -786,7 +816,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -797,7 +827,7 @@ dependencies = [
  "bd-shutdown",
  "bd-stats-common",
  "bd-time",
- "ctor 0.3.6",
+ "ctor 0.4.1",
  "log",
  "parking_lot",
  "time",
@@ -807,7 +837,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "log",
  "tokio",
@@ -816,12 +846,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -837,6 +867,7 @@ dependencies = [
  "bd-log-primitives",
  "bd-matcher",
  "bd-metadata",
+ "bd-panic",
  "bd-proto",
  "bd-resource-utilization",
  "bd-session",
@@ -858,7 +889,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -871,7 +902,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=090996dddec2fda608c19a43263e2fedce428351#090996dddec2fda608c19a43263e2fedce428351"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -895,25 +926,36 @@ dependencies = [
  "regex",
  "serde",
  "sha2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
 ]
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block"
@@ -932,21 +974,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "capture"
@@ -980,9 +1016,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -1001,16 +1037,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1042,18 +1078,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1064,6 +1100,16 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color-backtrace"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2123a5984bd52ca861c66f66a9ab9883b27115c607f801f86c1bc2a84eb69f0f"
+dependencies = [
+ "backtrace",
+ "termcolor",
+]
 
 [[package]]
 name = "combine"
@@ -1089,9 +1135,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1168,9 +1214,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1194,18 +1240,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.3.6"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d960ecacd0a1bf55e73144b72de745e7bf275c7952c50e36e8af0a0cb7ab1f"
+checksum = "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
 dependencies = [
  "ctor-proc-macro",
+ "dtor",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c426d2ba3e525b39c1f0a9ba41b9fe61878dee11fa4e4a76b6ab440f46c5db5d"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "dashmap"
@@ -1248,10 +1295,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.13.0"
+name = "dtor"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -1264,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1305,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -1475,9 +1537,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1516,9 +1578,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "home"
@@ -1531,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1552,12 +1614,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1565,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1658,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1686,13 +1748,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1715,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -1743,9 +1805,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1759,15 +1821,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.20"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1776,9 +1838,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "lock_api"
@@ -1792,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "logger_benchmark"
@@ -1872,9 +1940,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1955,15 +2023,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "overload"
@@ -2002,18 +2070,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2034,9 +2102,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-shared"
@@ -2118,11 +2186,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -2137,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -2216,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2254,8 +2322,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
- "zerocopy 0.8.16",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -2275,7 +2343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2304,12 +2372,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.16",
 ]
 
 [[package]]
@@ -2343,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -2405,15 +2472,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2435,22 +2501,35 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
  "ring",
@@ -2471,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -2488,15 +2567,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2515,24 +2594,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2541,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2553,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -2646,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "snap"
@@ -2665,12 +2744,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "static_assertions"
@@ -2714,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2741,16 +2814,25 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2802,11 +2884,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2822,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2843,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -2858,19 +2940,25 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinyjson"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a"
 
 [[package]]
 name = "tinytemplate"
@@ -2884,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2913,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2934,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3086,15 +3174,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3107,6 +3195,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "unwrap-infallible"
@@ -3122,18 +3216,18 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3146,6 +3240,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"
@@ -3183,20 +3283,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -3208,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3218,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3231,15 +3332,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3247,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3263,7 +3367,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -3305,6 +3409,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -3475,17 +3585,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.16"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8c07a70861ce02bad1607b5753ecb2501f67847b9f9ada7c160fff0ec6300c"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.16",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -3501,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.16"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5226bc9a9a9836e7428936cde76bb6b22feea1a8bfdbc0d241136e4d13417e25"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,6 +2761,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "swift_bridge"
 version = "1.0.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-trait",
  "bd-api",
@@ -2768,6 +2769,7 @@ dependencies = [
  "bd-device",
  "bd-key-value",
  "bd-log",
+ "bd-log-primitives",
  "bd-logger",
  "bd-noop-network",
  "bd-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,26 +17,26 @@ android_logger = { version = "0.14.1", default-features = false }
 anyhow = "1.0.95"
 assert_matches = "1.5.0"
 async-trait = "0.1.86"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351", default-features = false }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "090996dddec2fda608c19a43263e2fedce428351" }
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0", default-features = false }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
 chrono = "0.4.39"
 clap = { version = "4.5.28", features = ["derive", "env"] }
 ctor = "0.2.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+ahash = "0.8.11"
 android_logger = { version = "0.14.1", default-features = false }
 anyhow = "1.0.95"
 assert_matches = "1.5.0"

--- a/platform/shared/src/lib.rs
+++ b/platform/shared/src/lib.rs
@@ -9,7 +9,7 @@ pub mod error;
 pub mod metadata;
 
 use bd_client_common::error::handle_unexpected;
-use bd_logger::{log_level, AnnotatedLogField, LogField, LogFieldKind, LogType};
+use bd_logger::{log_level, AnnotatedLogField, LogFieldKind, LogType};
 use bd_runtime::runtime::Snapshot;
 use parking_lot::Once;
 use std::future::Future;
@@ -176,20 +176,19 @@ impl LoggerHolder {
         return;
       }
 
-      let fields = vec![AnnotatedLogField {
-        field: LogField {
-          key: "_duration_ms".into(),
+      let fields = [(
+          "_duration_ms".into(),
+          AnnotatedLogField {
           value: duration_ms.to_string().into(),
-        },
         kind: LogFieldKind::Ootb,
-      }];
+      })].into();
 
       self.log(
         log_level::INFO,
         LogType::Lifecycle,
         "AppLaunchTTI".into(),
         fields,
-        vec![],
+        [].into(),
         None,
         false,
       );
@@ -197,20 +196,18 @@ impl LoggerHolder {
   }
 
   pub fn log_screen_view(&self, screen_name: String) {
-    let fields = vec![AnnotatedLogField {
-      field: LogField {
-        key: "_screen_name".into(),
-        value: screen_name.into(),
-      },
-      kind: LogFieldKind::Ootb,
-    }];
+    let fields = [(
+         "_screen_name".into(),
+        AnnotatedLogField::new_ootb(
+        screen_name,
+    ))].into();
 
     self.log(
       log_level::INFO,
       LogType::UX,
       "ScreenView".into(),
       fields,
-      vec![],
+      [].into(),
       None,
       false,
     );

--- a/platform/shared/src/lib.rs
+++ b/platform/shared/src/lib.rs
@@ -177,11 +177,13 @@ impl LoggerHolder {
       }
 
       let fields = [(
-          "_duration_ms".into(),
-          AnnotatedLogField {
+        "_duration_ms".into(),
+        AnnotatedLogField {
           value: duration_ms.to_string().into(),
-        kind: LogFieldKind::Ootb,
-      })].into();
+          kind: LogFieldKind::Ootb,
+        },
+      )]
+      .into();
 
       self.log(
         log_level::INFO,
@@ -197,10 +199,10 @@ impl LoggerHolder {
 
   pub fn log_screen_view(&self, screen_name: String) {
     let fields = [(
-         "_screen_name".into(),
-        AnnotatedLogField::new_ootb(
-        screen_name,
-    ))].into();
+      "_screen_name".into(),
+      AnnotatedLogField::new_ootb(screen_name),
+    )]
+    .into();
 
     self.log(
       log_level::INFO,

--- a/platform/swift/source/Cargo.toml
+++ b/platform/swift/source/Cargo.toml
@@ -7,6 +7,7 @@ publish      = false
 version      = "1.0.0"
 
 [dependencies]
+ahash.workspace              = true
 anyhow.workspace             = true
 async-trait.workspace        = true
 bd-api.workspace             = true
@@ -14,6 +15,7 @@ bd-client-common.workspace   = true
 bd-device.workspace          = true
 bd-key-value.workspace       = true
 bd-log.workspace             = true
+bd-log-primitives.workspace  = true
 bd-logger.workspace          = true
 bd-noop-network.workspace    = true
 bd-runtime.workspace         = true

--- a/platform/swift/source/src/bridge.rs
+++ b/platform/swift/source/src/bridge.rs
@@ -27,6 +27,7 @@ use bd_logger::{
   AnnotatedLogFields,
   LogField,
   LogFieldKind,
+  LogFields,
   LogLevel,
   MetadataProvider,
 };
@@ -397,7 +398,7 @@ impl MetadataProvider for LogMetadataProvider {
     })
   }
 
-  fn fields(&self) -> anyhow::Result<(AnnotatedLogFields, AnnotatedLogFields)> {
+  fn fields(&self) -> anyhow::Result<(LogFields, LogFields)> {
     // Safety: Since we receive MetadataProvider as a typed protocol, we know that it
     // responds to `ootbFields` and `customFields` selectors.
     objc::rc::autoreleasepool(|| unsafe {

--- a/platform/swift/source/src/bridge.rs
+++ b/platform/swift/source/src/bridge.rs
@@ -10,7 +10,7 @@
 mod bridge_tests;
 
 use crate::bridge::ffi::make_nsstring;
-use crate::ffi::{convert_fields, nsstring_into_string};
+use crate::ffi::nsstring_into_string;
 use crate::key_value_storage::UserDefaultsStorage;
 use crate::{events, ffi, resource_utilization, session_replay};
 use anyhow::anyhow;
@@ -22,15 +22,7 @@ use bd_client_common::error::{
   MetadataErrorReporter,
   UnexpectedErrorHandler,
 };
-use bd_logger::{
-  AnnotatedLogField,
-  AnnotatedLogFields,
-  LogField,
-  LogFieldKind,
-  LogFields,
-  LogLevel,
-  MetadataProvider,
-};
+use bd_logger::{LogFieldKind, LogFields, LogLevel, MetadataProvider};
 use bd_noop_network::NoopNetwork;
 use objc::rc::StrongPtr;
 use objc::runtime::Object;
@@ -508,7 +500,7 @@ extern "C" fn capture_create_logger(
       .with_client_stats(true)
       .with_internal_logger(true)
       .build()
-      .map(|(logger, _, future)| LoggerHolder::new(logger, future))?;
+      .map(|(logger, _, future, _)| LoggerHolder::new(logger, future))?;
 
       Ok(logger.into_raw())
     },
@@ -589,9 +581,10 @@ extern "C" fn capture_write_log(
       let log_str = unsafe { CStr::from_ptr(log) }.to_str()?.to_string();
 
       // TODO(Augustyniak): Differentiate between incoming OOTB and custom log fields.
-      let fields = unsafe { ffi::convert_fields(fields, LogFieldKind::Ootb) }?;
+      let fields = unsafe { ffi::convert_annotated_fields(fields, LogFieldKind::Ootb) }?;
 
-      let matching_fields = unsafe { ffi::convert_fields(matching_fields, LogFieldKind::Ootb) }?;
+      let matching_fields =
+        unsafe { ffi::convert_annotated_fields(matching_fields, LogFieldKind::Ootb) }?;
 
       logger_id.log(
         log_level,
@@ -617,7 +610,7 @@ extern "C" fn capture_write_session_replay_screen_log(
 ) {
   with_handle_unexpected(
     || -> anyhow::Result<()> {
-      let fields = unsafe { convert_fields(fields, LogFieldKind::Ootb) }?;
+      let fields = unsafe { ffi::convert_annotated_fields(fields, LogFieldKind::Ootb) }?;
 
       logger_id.log_session_replay_screen(fields, time::Duration::seconds_f64(duration_s));
       Ok(())
@@ -634,7 +627,7 @@ extern "C" fn capture_write_session_replay_screenshot_log(
 ) {
   with_handle_unexpected(
     || -> anyhow::Result<()> {
-      let fields = unsafe { convert_fields(fields, LogFieldKind::Ootb) }?;
+      let fields = unsafe { ffi::convert_annotated_fields(fields, LogFieldKind::Ootb) }?;
 
       logger_id.log_session_replay_screenshot(fields, time::Duration::seconds_f64(duration_s));
       Ok(())
@@ -651,7 +644,7 @@ extern "C" fn capture_write_resource_utilization_log(
 ) {
   with_handle_unexpected(
     || -> anyhow::Result<()> {
-      let fields = unsafe { convert_fields(fields, LogFieldKind::Ootb) }?;
+      let fields = unsafe { ffi::convert_annotated_fields(fields, LogFieldKind::Ootb) }?;
 
       logger_id.log_resource_utilization(fields, time::Duration::seconds_f64(duration_s));
       Ok(())
@@ -668,7 +661,7 @@ extern "C" fn capture_write_sdk_start_log(
 ) {
   with_handle_unexpected(
     || -> anyhow::Result<()> {
-      let fields = unsafe { convert_fields(fields, LogFieldKind::Ootb) }?;
+      let fields = unsafe { ffi::convert_annotated_fields(fields, LogFieldKind::Ootb) }?;
 
       logger_id.log_sdk_start(fields, time::Duration::seconds_f64(duration_s));
       Ok(())
@@ -715,7 +708,7 @@ extern "C" fn capture_write_app_update_log(
         app_version,
         bd_logger::AppVersionExtra::BuildNumber(build_number),
         app_install_size_bytes.into(),
-        vec![],
+        [].into(),
         Duration::seconds_f64(duration_s),
       );
       Ok(())

--- a/platform/swift/source/src/ffi.rs
+++ b/platform/swift/source/src/ffi.rs
@@ -8,6 +8,7 @@
 // Helpers for safely interacting with Objective-C types.
 use crate::ffi;
 use ahash::AHashMap;
+use bd_log_primitives::LogFieldKey;
 use bd_logger::{
   AnnotatedLogField,
   AnnotatedLogFields,
@@ -15,9 +16,6 @@ use bd_logger::{
   LogFieldValue,
   LogFields,
   StringOrBytes,
-};
-use bd_log_primitives::{
-  LogFieldKey,
 };
 use objc::rc::StrongPtr;
 use objc::runtime::Object;

--- a/platform/test_helpers/src/lib.rs
+++ b/platform/test_helpers/src/lib.rs
@@ -165,10 +165,6 @@ fn perform_benchmarking_runtime_update(stream: &StreamHandle) {
         bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
         ValueKind::Int(100),
       ),
-      (
-        bd_runtime::runtime::workflows::WorkflowsEnabledFlag::path(),
-        ValueKind::Bool(true),
-      ),
       // Enable resource utilization logs.
       (
         bd_runtime::runtime::resource_utilization::ResourceUtilizationEnabledFlag::path(),
@@ -324,8 +320,8 @@ pub extern "C" fn run_large_upload_test(logger_id: LoggerId<'_>) -> bool {
       log_level::DEBUG,
       LogType::Normal,
       LogMessage::Bytes(vec![0; 100_000]),
-      vec![],
-      vec![],
+      [].into(),
+      [].into(),
       None,
       true,
     );
@@ -360,8 +356,8 @@ pub extern "C" fn run_aggressive_upload_test_with_stream_drops(logger_id: Logger
           log_level::TRACE,
           LogType::Normal,
           "hello".into(),
-          vec![],
-          vec![],
+          [].into(),
+          [].into(),
           None,
           false,
         );
@@ -399,8 +395,8 @@ pub extern "C" fn run_aggressive_upload_test(logger_id: LoggerId<'_>) {
       log_level::TRACE,
       LogType::Normal,
       "hello".into(),
-      vec![],
-      vec![],
+      [].into(),
+      [].into(),
       None,
       false,
     );

--- a/test/benchmark/src/bin/live_benchmark.rs
+++ b/test/benchmark/src/bin/live_benchmark.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_logger::{log_level, AnnotatedLogField, InitParams,  LogType};
+use bd_logger::{log_level, AnnotatedLogField, InitParams, LogType};
 use bd_session::fixed::UUIDCallbacks;
 use bd_session::{fixed, Strategy};
 use bd_shutdown::ComponentShutdownTrigger;

--- a/test/benchmark/src/bin/live_benchmark.rs
+++ b/test/benchmark/src/bin/live_benchmark.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_logger::{log_level, AnnotatedLogField, InitParams, LogField, LogFieldValue, LogType};
+use bd_logger::{log_level, AnnotatedLogField, InitParams,  LogType};
 use bd_session::fixed::UUIDCallbacks;
 use bd_session::{fixed, Strategy};
 use bd_shutdown::ComponentShutdownTrigger;
@@ -27,8 +27,8 @@ fn test_live_match_performance(c: &mut Criterion) {
     bd_hyper_network::HyperNetwork::run_on_thread(&bitdrift_api_url(), shutdown.make_shutdown());
 
   let metadata_provider = Arc::new(LogMetadata {
-    timestamp: time::OffsetDateTime::now_utc(),
-    fields: Vec::new(),
+    timestamp: time::OffsetDateTime::now_utc().into(),
+    ..Default::default()
   });
 
   let store = Arc::new(bd_key_value::Store::new(Box::<InMemoryStorage>::default()));
@@ -64,8 +64,8 @@ fn test_live_match_performance(c: &mut Criterion) {
         log_level::TRACE,
         LogType::Normal,
         "hello".into(),
-        vec![],
-        vec![],
+        [].into(),
+        [].into(),
         None,
         false,
       );
@@ -73,8 +73,8 @@ fn test_live_match_performance(c: &mut Criterion) {
         log_level::DEBUG,
         LogType::Normal,
         "hello".into(),
-        vec![],
-        vec![],
+        [].into(),
+        [].into(),
         None,
         false,
       );
@@ -82,8 +82,8 @@ fn test_live_match_performance(c: &mut Criterion) {
         log_level::INFO,
         LogType::Normal,
         "hello".into(),
-        vec![],
-        vec![],
+        [].into(),
+        [].into(),
         None,
         false,
       );
@@ -91,8 +91,8 @@ fn test_live_match_performance(c: &mut Criterion) {
         log_level::WARNING,
         LogType::Normal,
         "hello".into(),
-        vec![],
-        vec![],
+        [].into(),
+        [].into(),
         None,
         false,
       );
@@ -100,8 +100,8 @@ fn test_live_match_performance(c: &mut Criterion) {
         log_level::ERROR,
         LogType::Normal,
         "hello".into(),
-        vec![],
-        vec![],
+        [].into(),
+        [].into(),
         None,
         false,
       );
@@ -113,18 +113,17 @@ fn test_live_match_performance(c: &mut Criterion) {
         log_level::INFO,
         LogType::Normal,
         "analytics event: action.action_name".into(),
-        vec![AnnotatedLogField {
-          field: LogField {
-            key: "log_arg".into(),
-            value: LogFieldValue::String(
-              "{\"auth\":{\"driver_dispatchable\":1,\"session_id\": \
-               \"5B2CB91F-9C1F-4F16-9054-25D2DDE04B4F\"}}"
-                .into(),
-            ),
+        [(
+          "log_arg".into(),
+          AnnotatedLogField {
+            value: "{\"auth\":{\"driver_dispatchable\":1,\"session_id\": \
+                    \"5B2CB91F-9C1F-4F16-9054-25D2DDE04B4F\"}}"
+              .into(),
+            kind: bd_logger::LogFieldKind::Ootb,
           },
-          kind: bd_logger::LogFieldKind::Ootb,
-        }],
-        vec![],
+        )]
+        .into(),
+        [].into(),
         None,
         false,
       );

--- a/test/benchmark/src/bin/logger_benchmark.rs
+++ b/test/benchmark/src/bin/logger_benchmark.rs
@@ -32,8 +32,8 @@ fn do_log(logger: &LoggerHandle) {
     log_level::TRACE,
     LogType::Normal,
     "hello".into(),
-    vec![],
-    vec![],
+    [].into(),
+    [].into(),
     None,
     false,
   );
@@ -56,8 +56,8 @@ fn simple_log(c: &mut Criterion) {
       Arc::new(UUIDCallbacks),
     ))),
     metadata_provider: Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: Vec::new(),
+      timestamp: time::OffsetDateTime::now_utc().into(),
+      ..Default::default()
     }),
     resource_utilization_target: Box::new(bd_test_helpers::resource_utilization::EmptyTarget),
     session_replay_target: Box::new(bd_test_helpers::session_replay::NoOpTarget),
@@ -100,8 +100,8 @@ fn with_matcher_and_buffer(c: &mut Criterion) {
       Arc::new(UUIDCallbacks),
     ))),
     metadata_provider: Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: Vec::new(),
+      timestamp: time::OffsetDateTime::now_utc().into(),
+      ..Default::default()
     }),
     resource_utilization_target: Box::new(bd_test_helpers::resource_utilization::EmptyTarget),
     session_replay_target: Box::new(bd_test_helpers::session_replay::NoOpTarget),


### PR DESCRIPTION
This brings in a number of changes relating to crash handling and some changes to the log fields interface that required a few changes 

This seems to increase the binary size by a bit so we should decide whether we want to block this on figuring out how to claw back some of the binary size loss