### PR TITLE
Fix URLSession proxy targeting

### DIFF
--- a/platform/swift/source/integrations/url_session/ProxyURLSessionDelegate.swift
+++ b/platform/swift/source/integrations/url_session/ProxyURLSessionDelegate.swift
@@ -28,7 +28,7 @@ class ProxyURLSessionDelegate: NSObject {
     }
 
     override func responds(to aSelector: Selector!) -> Bool {
-        return self.target?.responds(to: aSelector) ?? super.responds(to: aSelector)
+        return self.target?.responds(to: aSelector) == true || super.responds(to: aSelector)
     }
 }
 


### PR DESCRIPTION
When using URLSession without swizzling and with:

- A custom delegate set (uncommon)
- Said delegate does not include the method `(_, task:didFinishCollecting:)`

Given this weird optional check we were not properly proxying the `didFinishCollecting` method to our own and therefore missing network responses.

IMO this should be a compiler warning/error.