### PR TITLE
bring in timestamp fix from shared-core

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "caaf54f982f0df243acfdcb656906728413982a33d66825394bec2cf62babd34",
+  "checksum": "e0c5f354af3cf0ff1354925cead43da65658a60af0e4f93c5307b623063403cb",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-api"
         }
@@ -1725,7 +1725,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -1854,7 +1854,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -1958,7 +1958,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2075,7 +2075,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2147,7 +2147,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2203,7 +2203,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2296,7 +2296,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-device"
         }
@@ -2380,7 +2380,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-events"
         }
@@ -2444,7 +2444,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -2664,7 +2664,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -2747,7 +2747,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -2871,7 +2871,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -2935,7 +2935,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3011,7 +3011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-log"
         }
@@ -3095,7 +3095,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3175,7 +3175,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -3247,7 +3247,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -3303,7 +3303,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -3367,7 +3367,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-logger"
         }
@@ -3588,7 +3588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-matcher"
         }
@@ -3656,7 +3656,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -3732,7 +3732,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -3771,7 +3771,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -3836,7 +3836,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-panic"
         }
@@ -3892,7 +3892,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -3987,7 +3987,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4090,7 +4090,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -4174,7 +4174,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -4246,7 +4246,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -4338,7 +4338,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-session"
         }
@@ -4434,7 +4434,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -4534,7 +4534,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -4586,7 +4586,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -4625,7 +4625,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -4798,7 +4798,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-time"
         }
@@ -4871,7 +4871,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+            "Rev": "05f74685cc2d58a9055deb7c896c14639d6dd2c1"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,7 @@ checksum = "8faa168b8c4ffca39c2699e772943af41ec2b75fb1683dda07b28a6d285c53dc"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -347,7 +347,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "bd-proto",
  "bd-stats-common",
@@ -385,7 +385,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "log",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "bd-runtime",
  "bd-shutdown",
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "base64",
@@ -549,7 +549,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-time",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -668,7 +668,7 @@ dependencies = [
 [[package]]
 name = "bd-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "base64",
@@ -696,12 +696,12 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "color-backtrace",
  "log",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "log",
  "protobuf",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-internal-logging",
@@ -763,7 +763,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "bd-stats-common",
  "bd-time",
@@ -796,7 +796,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -816,7 +816,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "log",
  "tokio",
@@ -846,12 +846,12 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0#c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=05f74685cc2d58a9055deb7c896c14639d6dd2c1#05f74685cc2d58a9055deb7c896c14639d6dd2c1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,26 +18,26 @@ android_logger = { version = "0.14.1", default-features = false }
 anyhow = "1.0.95"
 assert_matches = "1.5.0"
 async-trait = "0.1.86"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0", default-features = false }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c33e53b0d2fd2ffcc8d2dcf887dac324a8b948d0" }
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1", default-features = false }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "05f74685cc2d58a9055deb7c896c14639d6dd2c1" }
 chrono = "0.4.39"
 clap = { version = "4.5.28", features = ["derive", "env"] }
 ctor = "0.2.9"


### PR DESCRIPTION
This brings in a fix to use the correct unit when inferring the timestamp of a crash report