### PR TITLE
[ios] include any string convertible field in error logs

### DIFF
--- a/platform/swift/source/shared/extensions/Error+Extensions.swift
+++ b/platform/swift/source/shared/extensions/Error+Extensions.swift
@@ -18,11 +18,14 @@ extension Error {
         fields["_error_details"] = String(describing: self)
 
         for (key, value) in (self as NSError).userInfo {
-            guard let value = value as? Encodable else {
-                continue
+            let fieldsKey = "_error_info_\(key)"
+            if let value = value as? Encodable {
+                fields[fieldsKey] = value
+            } else if let value = value as? CustomStringConvertible {
+                fields[fieldsKey] = String(describing: value)
+            } else if let value = value as? CustomDebugStringConvertible {
+                fields[fieldsKey] = String(describing: value)
             }
-
-            fields["_error_info_\(key)"] = value
         }
 
         return fields


### PR DESCRIPTION
Error logs currently include any [Encodable](https://developer.apple.com/documentation/swift/encodable/) fields from an `Error`'s [userInfo](https://developer.apple.com/documentation/foundation/nserror/1411580-userinfo) dictionary. Additional fields which aren't Encodable could be included using the [description](https://developer.apple.com/documentation/swift/customstringconvertible/) or [debugDescription](https://developer.apple.com/documentation/swift/customdebugstringconvertible/) properties if present (indicated by conformance to `CustomStringConvertible` or `CustomDebugStringConvertible` respectively). The `String(describing:)` function provides a nice shorthand for grabbing a description if present.