### PR TITLE
[Android] Add more Fatal Issue types into gradle sample app

### DIFF
--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation("com.squareup.papa:papa:0.26")
     implementation("androidx.metrics:metrics-performance:1.0.0-beta01")
     implementation("com.bugsnag:bugsnag-android:6.12.0")
+    implementation ("io.reactivex.rxjava3:rxandroid:3.0.0")
+    implementation ("io.reactivex.rxjava3:rxjava:3.0.0")
     implementation("io.sentry:sentry-android:8.2.0")
 
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.4.0")

--- a/platform/jvm/gradle-test-app/src/androidTest/java/io/bitdrift/gradletestapp/AndroidViewReplayTest.kt
+++ b/platform/jvm/gradle-test-app/src/androidTest/java/io/bitdrift/gradletestapp/AndroidViewReplayTest.kt
@@ -60,9 +60,10 @@ class AndroidViewReplayTest {
 
             assertThat(metrics.errorViewCount).isEqualTo(0)
             assertThat(metrics.exceptionCausingViewCount).isEqualTo(0)
+
             // AppCompatTextView multiline label
-            assertThat(screen).contains(ReplayRect(type = ReplayType.Label, x = 36, y = 421, width = 758, height = 47))
-            assertThat(screen).contains(ReplayRect(type = ReplayType.Label, x = 36, y = 463, width = 698, height = 38))
+            assertThat(screen).contains(ReplayRect(type = ReplayType.Label, x = 35, y = 387, width = 539, height = 84))
+            assertThat(screen).contains(ReplayRect(type = ReplayType.Label, x = 36, y = 499, width = 758, height = 47))
         }
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ApiKeySettingsDialog.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ApiKeySettingsDialog.kt
@@ -27,6 +27,8 @@ import androidx.compose.material.AlertDialog
 //noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.Button
 //noinspection UsingMaterialAndMaterial3Libraries
+import androidx.compose.material.ButtonDefaults
+//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.Text
 //noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.TextField
@@ -36,8 +38,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.input.ImeAction
 
 import androidx.compose.ui.text.input.TextFieldValue
@@ -127,7 +131,10 @@ class SettingsApiKeysDialogFragment(private val sharedPreferences: SharedPrefere
             },
             confirmButton = {
                 Button(
-                    onClick = { persistApiKeysAndDismiss() }) {
+                    onClick = { persistApiKeysAndDismiss() },
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = colorResource(id = R.color.green)
+                    )) {
                     Text("OK")
                 }
             }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FatalIssueSimulator.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FatalIssueSimulator.kt
@@ -1,0 +1,101 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
+package io.bitdrift.gradletestapp
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import io.bitdrift.capture.Capture
+import io.bitdrift.capture.Capture.Logger
+import io.bitdrift.capture.CaptureJniLibrary
+import io.bitdrift.capture.LoggerImpl
+import io.reactivex.rxjava3.subjects.BehaviorSubject
+
+/**
+ * Artificially creates different types of Fatal issues (ANR, JVM Crash, Native Crash,etc)
+ */
+internal object FatalIssueSimulator {
+
+    private val uuidSubject: BehaviorSubject<String> = BehaviorSubject.create();
+    private val oomList = mutableListOf<ByteArray>()
+
+    fun forceDeadlockAnr() {
+        initializeInBackground()
+        startProcessing()
+    }
+
+    fun forceThreadSleepAnr() {
+        Handler(Looper.getMainLooper()).post {
+            Thread.sleep(15000)
+        }
+    }
+
+    fun forceBlockingGetAnr() {
+        val aResultWillNeverGet = uuidSubject.blockingFirst()
+        Log.e("FatalIssueSimulator", aResultWillNeverGet)
+    }
+
+    fun forceUnhandledException() {
+        throw RuntimeException("Forced unhandled exception")
+    }
+
+    fun forceNativeCrash() {
+        val logger = Capture.logger()
+        CaptureJniLibrary.destroyLogger((logger as LoggerImpl).loggerId)
+        Logger.logInfo { "Forced native crash" }
+    }
+
+    fun forceOutOfMemoryCrash() {
+        if (oomList.isNotEmpty()) {
+            return
+        }
+        Thread {
+            while (true) {
+                oomList.add(ByteArray(1024 * 1024))
+                Thread.sleep(50)
+            }
+        }.start()
+    }
+
+    private fun initializeInBackground() {
+        val backgroundThread: Thread = object : Thread() {
+            override fun run() {
+                synchronized(SECOND_LOCK_RESOURCE) {
+                    logThreadStatus("waiting on second lock")
+                    try {
+                        sleep(THREAD_DELAY_IN_MILLI)
+                    } catch (_: InterruptedException) {
+                    }
+                    synchronized(FIRST_LOCK_RESOURCE) { logThreadStatus("waiting on first lock") }
+                }
+            }
+        }
+        backgroundThread.name = "background_thread_for_deadlock_demo"
+        backgroundThread.start()
+    }
+
+    private fun startProcessing() {
+        synchronized(FIRST_LOCK_RESOURCE) {
+            logThreadStatus("waiting on first lock")
+            try {
+                Thread.sleep(THREAD_DELAY_IN_MILLI)
+            } catch (_: InterruptedException) {
+            }
+            synchronized(SECOND_LOCK_RESOURCE) { logThreadStatus("waiting on second lock") }
+        }
+    }
+
+    private val FIRST_LOCK_RESOURCE: Any = "first_lock"
+    private val SECOND_LOCK_RESOURCE: Any = "second_lock"
+    private const val THREAD_DELAY_IN_MILLI: Long = 10
+    private fun logThreadStatus(lockInfo: String) {
+        Log.d("DEADLOCK_TAG", "Thread [" + Thread.currentThread().name + "] " + lockInfo)
+    }
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -254,12 +254,12 @@ class FirstFragment : Fragment() {
     private fun forceAppExit(view: View) {
         val selectedAppExitReason = binding.spnAppExitOptions.selectedItem.toString()
         when (AppExitReason.valueOf(selectedAppExitReason)) {
-            AppExitReason.ANR_BLOCKING_GET -> FatalIssueSimulator.forceBlockingGetAnr()
-            AppExitReason.ANR_DEADLOCK -> FatalIssueSimulator.forceDeadlockAnr()
-            AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueSimulator.forceThreadSleepAnr()
-            AppExitReason.APP_CRASH_EXCEPTION -> FatalIssueSimulator.forceUnhandledException()
-            AppExitReason.APP_CRASH_NATIVE -> FatalIssueSimulator.forceNativeCrash()
-            AppExitReason.APP_CRASH_OUT_OF_MEMORY -> FatalIssueSimulator.forceOutOfMemoryCrash()
+            AppExitReason.ANR_BLOCKING_GET -> FatalIssueGenerator.forceBlockingGetAnr()
+            AppExitReason.ANR_DEADLOCK -> FatalIssueGenerator.forceDeadlockAnr()
+            AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueGenerator.forceThreadSleepAnr()
+            AppExitReason.APP_CRASH_EXCEPTION -> FatalIssueGenerator.forceUnhandledException()
+            AppExitReason.APP_CRASH_NATIVE -> FatalIssueGenerator.forceNativeCrash()
+            AppExitReason.APP_CRASH_OUT_OF_MEMORY -> FatalIssueGenerator.forceOutOfMemoryCrash()
             AppExitReason.SYSTEM_EXIT -> exitProcess(0)
         }
     }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -5,8 +5,6 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
-
 package io.bitdrift.gradletestapp
 
 import android.annotation.SuppressLint
@@ -34,11 +32,8 @@ import com.example.rocketreserver.LoginMutation
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
-import io.bitdrift.capture.Capture
 import io.bitdrift.capture.Capture.Logger
-import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.LogLevel
-import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.apollo.CaptureApolloInterceptor
 import io.bitdrift.capture.network.okhttp.CaptureOkHttpEventListenerFactory
 import io.bitdrift.gradletestapp.databinding.FragmentFirstBinding
@@ -259,27 +254,23 @@ class FirstFragment : Fragment() {
     private fun forceAppExit(view: View) {
         val selectedAppExitReason = binding.spnAppExitOptions.selectedItem.toString()
         when (AppExitReason.valueOf(selectedAppExitReason)) {
-            AppExitReason.APP_CRASH_EXCEPTION -> {
-                throw RuntimeException("Forced unhandled exception")
-            }
-            AppExitReason.ANR -> {
-                Thread.sleep(15000)
-            }
-            AppExitReason.SYSTEM_EXIT -> {
-                exitProcess(0)
-            }
-            AppExitReason.APP_CRASH_NATIVE -> {
-                val logger = Capture.logger()
-                CaptureJniLibrary.destroyLogger((logger as LoggerImpl).loggerId)
-                Logger.logInfo { "Forced native crash" }
-            }
+            AppExitReason.ANR_BLOCKING_GET -> FatalIssueSimulator.forceBlockingGetAnr()
+            AppExitReason.ANR_DEADLOCK -> FatalIssueSimulator.forceDeadlockAnr()
+            AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueSimulator.forceThreadSleepAnr()
+            AppExitReason.APP_CRASH_EXCEPTION -> FatalIssueSimulator.forceUnhandledException()
+            AppExitReason.APP_CRASH_NATIVE -> FatalIssueSimulator.forceNativeCrash()
+            AppExitReason.APP_CRASH_OUT_OF_MEMORY -> FatalIssueSimulator.forceOutOfMemoryCrash()
+            AppExitReason.SYSTEM_EXIT -> exitProcess(0)
         }
     }
 
     enum class AppExitReason {
+        ANR_BLOCKING_GET,
+        ANR_DEADLOCK,
+        ANR_SLEEP_MAIN_THREAD,
         APP_CRASH_EXCEPTION,
+        APP_CRASH_OUT_OF_MEMORY,
         APP_CRASH_NATIVE,
         SYSTEM_EXIT,
-        ANR
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -47,6 +47,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import com.bugsnag.android.Bugsnag

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/MainActivity.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/MainActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -57,6 +58,16 @@ class MainActivity : AppCompatActivity() {
             R.id.action_settings -> {
                 navController.navigate(R.id.action_FirstFragment_to_ConfigFragment)
                 true
+            }
+
+            R.id.switch_app_theme -> {
+                val appNightMode = if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
+                    AppCompatDelegate.MODE_NIGHT_NO
+                } else {
+                    AppCompatDelegate.MODE_NIGHT_YES
+                }
+                AppCompatDelegate.setDefaultNightMode(appNightMode)
+                return true
             }
             else -> super.onOptionsItemSelected(item)
         }

--- a/platform/jvm/gradle-test-app/src/main/res/layout/divider.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/layout/divider.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:background="?dividerColor"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="8dp" />

--- a/platform/jvm/gradle-test-app/src/main/res/layout/fragment_first.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/layout/fragment_first.xml
@@ -22,6 +22,8 @@
             android:layout_height="wrap_content"
             android:text="@string/navigate_config" />
 
+        <include layout="@layout/divider" />
+
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/compose_view"
             android:layout_width="wrap_content"
@@ -37,6 +39,8 @@
             android:id="@+id/textview_first"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
+
+        <include layout="@layout/divider" />
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -78,6 +82,8 @@
             android:layout_margin="2dp"
             android:text="No Code Generated" />
 
+        <include layout="@layout/divider" />
+
         <Button
             android:id="@+id/btnOkHttpRequest"
             android:layout_width="wrap_content"
@@ -97,7 +103,9 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:orientation="vertical">
+
+            <include layout="@layout/divider" />
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/menu"
@@ -121,6 +129,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:gravity="center"
+                android:layout_marginTop="4dp"
                 android:text="@string/log_msg"
                 app:icon="@android:drawable/ic_menu_upload" />
         </LinearLayout>
@@ -128,7 +137,9 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:orientation="vertical">
+
+            <include layout="@layout/divider" />
 
             <Spinner
                 android:id="@+id/spnAppExitOptions"
@@ -142,6 +153,8 @@
                 android:text="@string/app_exit"
                 app:icon="@android:drawable/ic_delete" />
         </LinearLayout>
+
+        <include layout="@layout/divider" />
 
         <Button
             android:id="@+id/btnNavigateCompose"

--- a/platform/jvm/gradle-test-app/src/main/res/menu/menu_main.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/menu/menu_main.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="io.bitdrift.gradletestapp.MainActivity">
     <item
+        android:id="@+id/switch_app_theme"
+        android:title="@string/switch_app_theme"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
         android:title="@string/action_settings"

--- a/platform/jvm/gradle-test-app/src/main/res/values-night/themes.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values-night/themes.xml
@@ -2,8 +2,8 @@
     <!-- Base application theme. -->
     <style name="Theme.MyApplication" parent="Theme.Material3.DayNight">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorPrimary">@color/green</item>
+        <item name="colorPrimaryVariant">@color/green</item>
         <item name="colorOnPrimary">@color/black</item>
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
@@ -12,5 +12,11 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="dividerColor">@color/white</item>
+        <item name="android:itemTextAppearance">@style/SettingsMenuStyle</item>
+    </style>
+
+    <style name="SettingsMenuStyle">
+        <item name="android:textColor">@color/white</item>
     </style>
 </resources>

--- a/platform/jvm/gradle-test-app/src/main/res/values/colors.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/colors.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="purple_200">#FFBB86FC</color>
-    <color name="purple_500">#FF6200EE</color>
-    <color name="purple_700">#FF3700B3</color>
+    <color name="green">#00A76F</color>
+    <color name="dark_blue">#4272B7</color>
     <color name="teal_200">#FF03DAC5</color>
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>

--- a/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="log_level_label">Log Level</string>
 
     <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
+    <string name="switch_app_theme">Switch App Theme</string>
 </resources>

--- a/platform/jvm/gradle-test-app/src/main/res/values/themes.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/themes.xml
@@ -2,16 +2,17 @@
     <!-- Base application theme. -->
     <style name="Theme.MyApplication" parent="Theme.Material3.DayNight">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorPrimary">@color/green</item>
+        <item name="colorPrimaryVariant">@color/green</item>
+        <item name="colorOnPrimary">@color/black</item>
         <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="dividerColor">@color/black</item>
     </style>
 
     <style name="Theme.MyApplication.NoActionBar">


### PR DESCRIPTION
- Adding more FatalIssue type into gradleTestApp
- Minor UI tweaks (e.g. adding night mode switch in menu for easier theme changes)
- Demo session with OOM crash https://timeline.bitdrift.dev/session/b7692479-76c6-451e-b882-e466bcc201aa?pages=1&utilization=0&expanded=-7278528259014036847

| Old Layout with a new Force App Exit type                                                                                | Dark Mode                                                                                  | Light Mode                                                                                 | Switch App Theme                                                                          | Force Exit Options                                                                       |
|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
| <img src="https://github.com/user-attachments/assets/27fa25bd-1a13-4ba8-81f5-430baa14e3fe" width="150" /> | <img src="https://github.com/user-attachments/assets/e2ad80d3-99a4-420b-b96d-75e0cc511512" width="300" /> | <img src="https://github.com/user-attachments/assets/4b692d65-ef3f-43e3-8ba8-9f15d98bc1fd" width="300" /> | <img src="https://github.com/user-attachments/assets/f266dbda-0e31-402a-981f-17206a830c03" width="300" /> | <img src="https://github.com/user-attachments/assets/ed5ccb16-2821-4868-942a-2eafdfda0269" width="300" /> |