### PR TITLE
[Android] Add composite crash exception to gradle test demo app

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FatalIssueGenerator.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FatalIssueGenerator.kt
@@ -9,6 +9,7 @@
 
 package io.bitdrift.gradletestapp
 
+import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -16,6 +17,7 @@ import io.bitdrift.capture.Capture
 import io.bitdrift.capture.Capture.Logger
 import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.LoggerImpl
+import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 
 /**
@@ -43,12 +45,20 @@ internal object FatalIssueGenerator {
     fun forceBlockingGetAnr() {
         callOnMainThread {
             val aResultWillNeverGet = uuidSubject.blockingFirst()
-            Log.e("FatalIssueSimulator", aResultWillNeverGet)
+            Log.e(TAG_NAME, aResultWillNeverGet)
         }
     }
 
     fun forceUnhandledException() {
         throw RuntimeException("Forced unhandled exception")
+    }
+
+    @SuppressLint("CheckResult")
+    fun forceRxJavaException() {
+        Observable.error<String>(Throwable("Artificial exception"))
+            .subscribe { item -> Log.i(TAG_NAME, "Item received: $item") }
+            // Missing error explicitly in order to crash
+
     }
 
     fun forceNativeCrash() {
@@ -103,6 +113,7 @@ internal object FatalIssueGenerator {
 
     private val FIRST_LOCK_RESOURCE: Any = "first_lock"
     private val SECOND_LOCK_RESOURCE: Any = "second_lock"
+    private val TAG_NAME = "FatalIssueGenerator"
     private const val THREAD_DELAY_IN_MILLI: Long = 10
     private fun logThreadStatus(lockInfo: String) {
         Log.d("DEADLOCK_TAG", "Thread [" + Thread.currentThread().name + "] " + lockInfo)

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -257,7 +257,8 @@ class FirstFragment : Fragment() {
             AppExitReason.ANR_BLOCKING_GET -> FatalIssueGenerator.forceBlockingGetAnr()
             AppExitReason.ANR_DEADLOCK -> FatalIssueGenerator.forceDeadlockAnr()
             AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueGenerator.forceThreadSleepAnr()
-            AppExitReason.APP_CRASH_EXCEPTION -> FatalIssueGenerator.forceUnhandledException()
+            AppExitReason.APP_CRASH_REGULAR_JVM_EXCEPTION -> FatalIssueGenerator.forceUnhandledException()
+            AppExitReason.APP_CRASH_RX_JAVA_EXCEPTION -> FatalIssueGenerator.forceRxJavaException()
             AppExitReason.APP_CRASH_NATIVE -> FatalIssueGenerator.forceNativeCrash()
             AppExitReason.APP_CRASH_OUT_OF_MEMORY -> FatalIssueGenerator.forceOutOfMemoryCrash()
             AppExitReason.SYSTEM_EXIT -> exitProcess(0)
@@ -268,7 +269,8 @@ class FirstFragment : Fragment() {
         ANR_BLOCKING_GET,
         ANR_DEADLOCK,
         ANR_SLEEP_MAIN_THREAD,
-        APP_CRASH_EXCEPTION,
+        APP_CRASH_REGULAR_JVM_EXCEPTION,
+        APP_CRASH_RX_JAVA_EXCEPTION,
         APP_CRASH_OUT_OF_MEMORY,
         APP_CRASH_NATIVE,
         SYSTEM_EXIT,


### PR DESCRIPTION
You can use this one

<img width="412" alt="image" src="https://github.com/user-attachments/assets/7c0116be-575a-45b9-b56c-93c617fc2113" />

 ```
Process: io.bitdrift.gradletestapp, PID: 805
                 io.reactivex.rxjava3.exceptions.OnErrorNotImplementedException: The exception was not handled due to missing onError handler in the subscribe() method call. Further reading: https://github.com/ReactiveX/RxJava/wiki/Error-Handling | java.lang.Throwable: Artificial exception
                 	at io.reactivex.rxjava3.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:717)
                 	at io.reactivex.rxjava3.internal.functions.Functions$OnErrorMissingConsumer.accept(Functions.java:714)
                 	at io.reactivex.rxjava3.internal.observers.LambdaObserver.onError(LambdaObserver.java:77)
                 	at io.reactivex.rxjava3.internal.disposables.EmptyDisposable.error(EmptyDisposable.java:63)
                 	at io.reactivex.rxjava3.internal.operators.observable.ObservableError.subscribeActual(ObservableError.java:37)
                 	at io.reactivex.rxjava3.core.Observable.subscribe(Observable.java:13095)
                 	at io.reactivex.rxjava3.core.Observable.subscribe(Observable.java:13081)
                 	at io.reactivex.rxjava3.core.Observable.subscribe(Observable.java:13021)
                 	at io.bitdrift.gradletestapp.FatalIssueGenerator.forceRxJavaException(FatalIssueGenerator.kt:59)
                 	at io.bitdrift.gradletestapp.FirstFragment.forceAppExit(FirstFragment.kt:261)
                 	at io.bitdrift.gradletestapp.FirstFragment.$r8$lambda$mEC27W5KkQlTSzFLvGXeaUq9vfI(Unknown Source:0)
                 	at io.bitdrift.gradletestapp.FirstFragment$$ExternalSyntheticLambda7.onClick(D8$$SyntheticClass:0)
                 	at android.view.View.performClick(View.java:7659)
                 	at com.google.android.material.button.MaterialButton.performClick(MaterialButton.java:1202)
                 	at android.view.View.performClickInternal(View.java:7636)
                 	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
                 	at android.view.View$PerformClick.run(View.java:30156)
                 	at android.os.Handler.handleCallback(Handler.java:958)
                 	at android.os.Handler.dispatchMessage(Handler.java:99)
                 	at android.os.Looper.loopOnce(Looper.java:205)
                 	at android.os.Looper.loop(Looper.java:294)
                 	at android.app.ActivityThread.main(ActivityThread.java:8177)
                 	at java.lang.reflect.Method.invoke(Native Method)
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
                 Caused by: java.lang.Throwable: Artificial exception
                 	at io.bitdrift.gradletestapp.FatalIssueGenerator.forceRxJavaException(FatalIssueGenerator.kt:58)
                 	at io.bitdrift.gradletestapp.FirstFragment.forceAppExit(FirstFragment.kt:261) 
                 	at io.bitdrift.gradletestapp.FirstFragment.$r8$lambda$mEC27W5KkQlTSzFLvGXeaUq9vfI(Unknown Source:0) 
                 	at io.bitdrift.gradletestapp.FirstFragment$$ExternalSyntheticLambda7.onClick(D8$$SyntheticClass:0) 
                 	at android.view.View.performClick(View.java:7659) 
                 	at com.google.android.material.button.MaterialButton.performClick(MaterialButton.java:1202) 
                 	at android.view.View.performClickInternal(View.java:7636) 
                 	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0) 
                 	at android.view.View$PerformClick.run(View.java:30156) 
                 	at android.os.Handler.handleCallback(Handler.java:958) 
                 	at android.os.Handler.dispatchMessage(Handler.java:99) 
                 	at android.os.Looper.loopOnce(Looper.java:205) 
                 	at android.os.Looper.loop(Looper.java:294) 
                 	at android.app.ActivityThread.main(ActivityThread.java:8177) 
                 	at java.lang.reflect.Method.invoke(Native Method) 
                 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552) 
                 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971) 
```