### PR TITLE
[android] make report type use an enum value

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReport.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReport.kt
@@ -7,16 +7,13 @@
 
 package io.bitdrift.capture.reports
 
-import com.google.gson.annotations.SerializedName
-
 /**
  * Represents the model where will store Crash/ANR/etc
  *
  * TODO(FranAguilera): BIT-5070 Update to include full FatalIssueReport
  */
 internal data class FatalIssueReport(
-    @SerializedName("issue_type")
-    val issueType: String,
+    val type: FatalIssueType,
     val errors: List<Exception>,
 )
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueType.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueType.kt
@@ -12,27 +12,27 @@ package io.bitdrift.capture.reports
  *
  * Each type represents a specific kind of fatal issue that may trigger the reporting mechanism.
  *
- * @param displayName The readable name of the fatal issue type used for logging or reporting purposes.
+ * @param value The binary representation value for the type
  */
 enum class FatalIssueType(
     /**
-     * The readable name of the fatal issue type.
+     * The serialized value for the type
      */
-    val displayName: String,
+    val value: Int,
 ) {
     /**
      * Represents a JVM crash, typically caused by unhandled exceptions or fatal errors within the JVM.
      */
-    JVM_CRASH("jvm_crash"),
+    JVM_CRASH(3),
 
     /**
      * Represents a native crash, which could be caused by an issue in native code (e.g., C, C++, rust).
      */
-    NATIVE_CRASH("native_crash"),
+    NATIVE_CRASH(5),
 
     /**
      * Represents an ANR (Application Not Responding) error, which occurs when the application is
      * unresponsive for a specific period (usually 5 seconds).
      */
-    ANR("anr"),
+    ANR(1),
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/persistence/FatalIssueReporterStorage.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/persistence/FatalIssueReporterStorage.kt
@@ -27,7 +27,7 @@ internal class FatalIssueReporterStorage(
         fatalIssueReport: FatalIssueReport,
     ) {
         // TODO(FranAguilera): BIT-5083 Replace storing via Gson with native call
-        val fileName = "${terminationTimeStampInMilli}_${fatalIssueType.displayName}.json"
+        val fileName = "${terminationTimeStampInMilli}_${fatalIssueType.name}.json"
         val outputFile = File(destinationDirectory, fileName)
         outputFile.writeText(gson.toJson(fatalIssueReport))
     }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/FatalIssueReporterProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/FatalIssueReporterProcessor.kt
@@ -85,7 +85,7 @@ internal class FatalIssueReporterProcessor(
                     reason = throwable.message ?: "n/a",
                 ),
             )
-        return FatalIssueReport(FatalIssueType.JVM_CRASH.displayName, errors)
+        return FatalIssueReport(FatalIssueType.JVM_CRASH, errors)
     }
 
     /**
@@ -95,7 +95,7 @@ internal class FatalIssueReporterProcessor(
     private fun getNativeCrashReport(
         description: String?,
         traceInputStream: InputStream,
-    ): FatalIssueReport = FatalIssueReport(FatalIssueType.NATIVE_CRASH.displayName, emptyList())
+    ): FatalIssueReport = FatalIssueReport(FatalIssueType.NATIVE_CRASH, emptyList())
 
     /**
      * TODO(FranAguilera): BIT-5070 Update to include full FatalIssueReport
@@ -112,6 +112,6 @@ internal class FatalIssueReporterProcessor(
                     reason = "ANR reason wip",
                 ),
             )
-        return FatalIssueReport(FatalIssueType.ANR.displayName, errors)
+        return FatalIssueReport(FatalIssueType.ANR, errors)
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterProcessorTest.kt
@@ -48,7 +48,7 @@ class FatalIssueReporterProcessorTest {
             eq(FatalIssueType.JVM_CRASH),
             fatalIssueReportCaptor.capture(),
         )
-        assertThat(fatalIssueReportCaptor.firstValue.issueType).isEqualTo("jvm_crash")
+        assertThat(fatalIssueReportCaptor.firstValue.type).isEqualTo(FatalIssueType.JVM_CRASH)
         assertThat(fatalIssueReportCaptor.firstValue.errors[0].reason).isEqualTo("Fake JVM exception")
         assertThat(fatalIssueReportCaptor.firstValue.errors[0].name).isEqualTo("io.bitdrift.capture.fakes.FakeJvmException")
     }
@@ -73,7 +73,7 @@ class FatalIssueReporterProcessorTest {
             eq(FatalIssueType.ANR),
             fatalIssueReportCaptor.capture(),
         )
-        assertThat(fatalIssueReportCaptor.firstValue.issueType).isEqualTo("anr")
+        assertThat(fatalIssueReportCaptor.firstValue.type).isEqualTo(FatalIssueType.ANR)
         assertThat(fatalIssueReportCaptor.firstValue.errors[0].reason).isEqualTo("ANR reason wip")
         assertThat(fatalIssueReportCaptor.firstValue.errors[0].name).isEqualTo(description)
     }
@@ -95,7 +95,7 @@ class FatalIssueReporterProcessorTest {
             eq(FatalIssueType.NATIVE_CRASH),
             fatalIssueReportCaptor.capture(),
         )
-        assertThat(fatalIssueReportCaptor.firstValue.issueType).isEqualTo("native_crash")
+        assertThat(fatalIssueReportCaptor.firstValue.type).isEqualTo(FatalIssueType.NATIVE_CRASH)
         assertThat(fatalIssueReportCaptor.firstValue.errors.isEmpty()).isTrue()
     }
 


### PR DESCRIPTION
there are a limited number of types, and this avoids string parsing during binary serialization