### PR TITLE
[Android] Pass application context into initFatalIssueReporting

### DIFF
--- a/examples/android/HelloWorldApp.kt
+++ b/examples/android/HelloWorldApp.kt
@@ -29,7 +29,7 @@ class HelloWorldApp : Application() {
         super.onCreate()
         
         @OptIn(ExperimentalBitdriftApi::class)
-        Logger.initFatalIssueReporting()
+        Logger.initFatalIssueReporting(applicationContext)
 
         setupExampleCrashHandler()
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture
 
+import android.content.Context
 import android.util.Log
 import com.github.michaelbull.result.Err
 import io.bitdrift.capture.common.MainThreadHandler
@@ -106,8 +107,8 @@ object Capture {
         @Suppress("UnusedPrivateMember")
         @ExperimentalBitdriftApi
         @JvmStatic
-        fun initFatalIssueReporting() {
-            val fatalIssueReporter = FatalIssueReporter()
+        fun initFatalIssueReporting(applicationContext: Context) {
+            val fatalIssueReporter = FatalIssueReporter(applicationContext)
             if (fatalIssueReporterStatus.state is FatalIssueReporterState.NotInitialized) {
                 fatalIssueReporterStatus = fatalIssueReporter.processPriorReportFiles()
             } else {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
@@ -7,11 +7,12 @@
 
 package io.bitdrift.capture.reports
 
+import android.app.Application
+import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
-import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.common.MainThreadHandler
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
@@ -28,17 +29,21 @@ import kotlin.time.measureTime
  * Handles internal reporting of crashes
  */
 internal class FatalIssueReporter(
+    private val applicationContext: Context,
     private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
 ) {
-    private val appContext by lazy { APP_CONTEXT }
-
     /**
      * Process existing crash report files.
      *
      * @return The status of the crash reporting processing
      */
-    fun processPriorReportFiles(): FatalIssueReporterStatus =
-        runCatching {
+    fun processPriorReportFiles(): FatalIssueReporterStatus {
+        if (applicationContext !is Application) {
+            val errorMessage = "Non-Application context passed into initFatalIssueReporting"
+            Log.e("Bitdrift Capture", errorMessage)
+            return FatalIssueReporterStatus(ProcessingFailure(errorMessage))
+        }
+        return runCatching {
             mainThreadHandler.runAndReturnResult {
                 var fatalIssueReporterState: FatalIssueReporterState
                 val duration =
@@ -52,10 +57,11 @@ internal class FatalIssueReporter(
             Log.e("Bitdrift Capture", errorMessage)
             FatalIssueReporterStatus(ProcessingFailure(errorMessage))
         }
+    }
 
     @UiThread
     private fun verifyDirectoriesAndCopyFiles(): FatalIssueReporterState {
-        val sdkDirectory = SdkDirectory.getPath(appContext)
+        val sdkDirectory = SdkDirectory.getPath(applicationContext)
         val fatalIssueConfigFile = File(sdkDirectory, CONFIGURATION_FILE_PATH)
 
         if (!fatalIssueConfigFile.exists()) {
@@ -64,7 +70,7 @@ internal class FatalIssueReporter(
 
         val fatalIssueConfigFileContents = fatalIssueConfigFile.readText()
         val fatalIssueConfigDetails =
-            getFatalIssueConfigDetails(appContext, fatalIssueConfigFileContents) ?: let {
+            getFatalIssueConfigDetails(applicationContext, fatalIssueConfigFileContents) ?: let {
                 return FatalIssueReporterState.Initialized.MalformedConfigFile
             }
         if (fatalIssueConfigDetails.sourceDirectory.isInvalidDirectory()) {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
@@ -7,8 +7,8 @@
 
 package io.bitdrift.capture
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.reports.FatalIssueReporter
@@ -29,13 +29,12 @@ import java.io.File
 class FatalIssueReporterTest {
     private lateinit var fatalIssueReporter: FatalIssueReporter
     private lateinit var reportsDir: File
+    private val appContext: Context = ApplicationProvider.getApplicationContext()
 
     @Before
     fun setup() {
-        val initializer = ContextHolder()
-        initializer.create(ApplicationProvider.getApplicationContext())
-        reportsDir = File(APP_CONTEXT.filesDir, "bitdrift_capture/reports/")
-        fatalIssueReporter = FatalIssueReporter(Mocks.sameThreadHandler)
+        reportsDir = File(appContext.filesDir, "bitdrift_capture/reports/")
+        fatalIssueReporter = FatalIssueReporter(appContext, Mocks.sameThreadHandler)
     }
 
     @Test
@@ -155,7 +154,7 @@ class FatalIssueReporterTest {
             bitdriftConfigContent?.let {
                 if (!it.contains(",")) return
                 val sourcePath = it.split(",")[0].trim()
-                sourceCrashDirectory = File(sourcePath.replace("{cache_dir}", APP_CONTEXT.cacheDir.absolutePath))
+                sourceCrashDirectory = File(sourcePath.replace("{cache_dir}", appContext.cacheDir.absolutePath))
                 if (sourceCrashDirectory?.exists() == false) {
                     sourceCrashDirectory?.mkdirs()
                 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -93,7 +93,7 @@ class GradleTestApp : Application() {
 
     private fun initLogging() {
         @OptIn(ExperimentalBitdriftApi::class)
-        Capture.Logger.initFatalIssueReporting()
+        Capture.Logger.initFatalIssueReporting(applicationContext)
 
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
         val stringApiUrl = sharedPreferences.getString("apiUrl", null)


### PR DESCRIPTION
Given that there could be cases where customer init the library via content providers there is still a chance that ContextHolder initializer is not yet called prior to `Capture.Logger.initFatalIssueReporting` call.

In this case making it explicit that will need an application context in order to initialize fatal issue reporting 