### PR TITLE
[andr] Allow to explicitly pass context to init() method

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -56,7 +56,7 @@ internal sealed class LoggerState {
  * Top level namespace Capture SDK.
  */
 object Capture {
-    private const val LOG_TAG = "bitdrift capture"
+    private const val LOG_TAG = "BitdriftCapture"
     private val default: AtomicReference<LoggerState> = AtomicReference(LoggerState.NotStarted)
     private var fatalIssueReporterStatus: FatalIssueReporterStatus = FatalIssueReporterStatus(FatalIssueReporterState.NotInitialized)
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -110,6 +110,7 @@ object Capture {
         @Suppress("UnusedPrivateMember")
         @ExperimentalBitdriftApi
         @JvmStatic
+        @JvmOverloads
         fun initFatalIssueReporting(context: Context? = null) {
             if (context == null && !ContextHolder.isInitialized) {
                 Log.w(LOG_TAG, "Attempted to initialize Fatal Issue Reporting with a null context. Skipping enabling crash tracking.")

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture
 
+import android.content.Context
 import android.util.Log
 import com.github.michaelbull.result.Err
 import io.bitdrift.capture.common.MainThreadHandler
@@ -55,6 +56,7 @@ internal sealed class LoggerState {
  * Top level namespace Capture SDK.
  */
 object Capture {
+    private const val LOG_TAG = "bitdrift capture"
     private val default: AtomicReference<LoggerState> = AtomicReference(LoggerState.NotStarted)
     private var fatalIssueReporterStatus: FatalIssueReporterStatus = FatalIssueReporterStatus(FatalIssueReporterState.NotInitialized)
 
@@ -101,18 +103,26 @@ object Capture {
         /**
          * Initializes fatal issue (ANR, JVM Crash, Native crash) reporting mechanism.
          *
+         * @param context an optional context reference. You should provide the context if called from a [android.content.ContentProvider]
+         *
          * This should be called prior to Capture.Logger.start()
          */
         @Suppress("UnusedPrivateMember")
         @ExperimentalBitdriftApi
         @JvmStatic
-        fun initFatalIssueReporting() {
-            val fatalIssueReporter = FatalIssueReporter()
-            if (fatalIssueReporterStatus.state is FatalIssueReporterState.NotInitialized) {
-                fatalIssueReporterStatus = fatalIssueReporter.processPriorReportFiles()
-            } else {
-                Log.w("capture", "Fatal issue reporting already being initialized")
+        fun initFatalIssueReporting(context: Context? = null) {
+            if (context == null && !ContextHolder.isInitialized) {
+                Log.w(LOG_TAG, "Attempted to initialize Fatal Issue Reporting with a null context. Skipping enabling crash tracking.")
+                return
             }
+
+            val fatalIssueReporter = FatalIssueReporter(context?.applicationContext ?: ContextHolder.APP_CONTEXT)
+            if (fatalIssueReporterStatus.state is FatalIssueReporterState.Initialized) {
+                Log.w(LOG_TAG, "Fatal issue reporting already being initialized")
+                return
+            }
+
+            fatalIssueReporterStatus = fatalIssueReporter.processPriorReportFiles()
         }
 
         /**
@@ -169,7 +179,7 @@ object Capture {
             // There's nothing we can do if we don't have yet access to the application context.
             if (!ContextHolder.isInitialized) {
                 Log.w(
-                    "capture",
+                    LOG_TAG,
                     "Attempted to initialize Capture before androidx.startup.Initializers " +
                         "are run. Aborting logger initialization.",
                 )
@@ -192,11 +202,11 @@ object Capture {
                         )
                     default.set(LoggerState.Started(logger))
                 } catch (e: Throwable) {
-                    Log.w("capture", "Failed to start Capture", e)
+                    Log.w(LOG_TAG, "Failed to start Capture", e)
                     default.set(LoggerState.StartFailure)
                 }
             } else {
-                Log.w("capture", "Multiple attempts to start Capture")
+                Log.w(LOG_TAG, "Multiple attempts to start Capture")
             }
         }
 
@@ -284,9 +294,7 @@ object Capture {
          */
         @JvmStatic
         fun removeField(key: String) {
-            logger()?.let {
-                it.removeField(key)
-            }
+            logger()?.removeField(key)
         }
 
         /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
@@ -7,11 +7,11 @@
 
 package io.bitdrift.capture.reports
 
+import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
-import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.common.MainThreadHandler
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
@@ -28,10 +28,9 @@ import kotlin.time.measureTime
  * Handles internal reporting of crashes
  */
 internal class FatalIssueReporter(
+    private val appContext: Context,
     private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
 ) {
-    private val appContext by lazy { APP_CONTEXT }
-
     /**
      * Process existing crash report files.
      *

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
@@ -7,8 +7,8 @@
 
 package io.bitdrift.capture
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.reports.FatalIssueReporter
@@ -29,13 +29,12 @@ import java.io.File
 class FatalIssueReporterTest {
     private lateinit var fatalIssueReporter: FatalIssueReporter
     private lateinit var reportsDir: File
+    val appContext = ApplicationProvider.getApplicationContext<Context>()
 
     @Before
     fun setup() {
-        val initializer = ContextHolder()
-        initializer.create(ApplicationProvider.getApplicationContext())
-        reportsDir = File(APP_CONTEXT.filesDir, "bitdrift_capture/reports/")
-        fatalIssueReporter = FatalIssueReporter(Mocks.sameThreadHandler)
+        reportsDir = File(appContext.filesDir, "bitdrift_capture/reports/")
+        fatalIssueReporter = FatalIssueReporter(ApplicationProvider.getApplicationContext(), Mocks.sameThreadHandler)
     }
 
     @Test
@@ -155,7 +154,7 @@ class FatalIssueReporterTest {
             bitdriftConfigContent?.let {
                 if (!it.contains(",")) return
                 val sourcePath = it.split(",")[0].trim()
-                sourceCrashDirectory = File(sourcePath.replace("{cache_dir}", APP_CONTEXT.cacheDir.absolutePath))
+                sourceCrashDirectory = File(sourcePath.replace("{cache_dir}", appContext.cacheDir.absolutePath))
                 if (sourceCrashDirectory?.exists() == false) {
                     sourceCrashDirectory?.mkdirs()
                 }


### PR DESCRIPTION
Allow sdk consumers to explicitly pass a context instant when initializing crash reporting. This is particularly useful when they want to call our `initFatalIssueReporting()` method from a content provider since they can do:
```kotlin
    override fun onCreate(): Boolean {
        @OptIn(ExperimentalBitdriftApi::class)
        Capture.Logger.initFatalIssueReporting(getContext())
        Bugsnag.start(getContext()!!, "bugsnag_apikey")
        return true
    }
```

This is an alternative proposal to #307