### PR TITLE
[Android] [BuiltIn-FatalIssueReporter] Ensure that appexit processing runs off main thread

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import io.bitdrift.capture.Capture.LOG_TAG
+import io.bitdrift.capture.common.IBackgroundThreadHandler
 import io.bitdrift.capture.common.MainThreadHandler
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
@@ -28,6 +29,7 @@ import io.bitdrift.capture.reports.jvmcrash.JvmCrashListener
 import io.bitdrift.capture.reports.parser.FatalIssueConfigParser.getFatalIssueConfigDetails
 import io.bitdrift.capture.reports.persistence.FatalIssueReporterStorage
 import io.bitdrift.capture.reports.processor.FatalIssueReporterProcessor
+import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.SdkDirectory
 import java.io.File
 import java.lang.Thread
@@ -42,6 +44,7 @@ import kotlin.time.measureTime
  */
 internal class FatalIssueReporter(
     private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
+    private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider = LatestAppExitInfoProvider,
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = CaptureUncaughtExceptionHandler,
 ) : IFatalIssueReporter,
@@ -150,7 +153,9 @@ internal class FatalIssueReporter(
                                 FatalIssueReporterStorage(destinationDirectory.destinationDirectory),
                             )
                         captureUncaughtExceptionHandler.install(this)
-                        persistLastExitReasonIfNeeded(appContext)
+                        backgroundThreadHandler.runAsync {
+                            persistLastExitReasonIfNeeded(appContext)
+                        }
                         fatalIssueReporterState = FatalIssueReporterState.BuiltInModeInitialized
                     }
                 fatalIssueReporterState to duration

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
@@ -17,6 +17,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.common.MainThreadHandler
+import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
 import io.bitdrift.capture.fakes.FakeJvmException
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
@@ -44,6 +45,7 @@ class FatalIssueReporterTest {
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = mock()
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider = mock()
     private val appContext = ApplicationProvider.getApplicationContext<Context>()
+    private val backgroundThreadHandler = FakeBackgroundThreadHandler()
 
     @Before
     fun setup() {
@@ -238,6 +240,7 @@ class FatalIssueReporterTest {
     private fun buildReporter(mainThreadHandler: MainThreadHandler): FatalIssueReporter =
         FatalIssueReporter(
             mainThreadHandler,
+            backgroundThreadHandler,
             latestAppExitInfoProvider,
             captureUncaughtExceptionHandler,
         )


### PR DESCRIPTION
This was a leftover from https://github.com/bitdriftlabs/capture-sdk/pull/296

TBF some samples on real device with prior ANR