### PR TITLE
Fixing main build errors

### DIFF
--- a/bazel/BUILD.bitdriftlabs_api
+++ b/bazel/BUILD.bitdriftlabs_api
@@ -9,3 +9,9 @@ filegroup(
   srcs = glob(["**/*.fbs"]),
   visibility = ["//visibility:public"],
 )
+
+filegroup(
+  name = "buffer_log",
+  srcs = ["src/bitdrift_public/fbs/logging/v1/buffer_log.fbs"],
+  visibility = ["//visibility:public"],
+)

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -3,11 +3,10 @@ load("//bazel:bitdrift_build_system.bzl", "bitdrift_rust_binary")
 
 flatbuffer_library_public(
     name = "descriptor",
-    srcs = [
-        "@bitdrift_api//:all_fbs",
-    ],
+    srcs = ["@bitdrift_api//:all_fbs"],
     outs = [
         "buffer_log.schema.json",
+        "reports.schema.json", 
     ],
     language_flag = "--jsonschema",
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -11,7 +11,7 @@ load("//bazel:bitdrift_build_system.bzl", "bitdrift_rust_binary")
 flatbuffer_library_public(
     name = "descriptor",
     srcs = [
-        "@bitdrift_api//:all_fbs",
+        "@bitdrift_api//:buffer_log",
     ],
     outs = [
         "buffer_log.schema.json",
@@ -27,7 +27,7 @@ genrule(
     name = "log_type_kt_source",
     srcs = [":descriptor"],
     outs = ["LogType.kt"],
-    cmd = "$(location :log_enum_codegen) $(locations :descriptor) kotlin > $(OUTS)",
+    cmd = "$(location :log_enum_codegen) $(location :descriptor) kotlin > $(OUTS)",
     tools = [":log_enum_codegen"],
     visibility = ["//visibility:public"],
 )
@@ -36,7 +36,7 @@ genrule(
     name = "log_type_swift_source",
     srcs = [":descriptor"],
     outs = ["LogType.swift"],
-    cmd = "$(location :log_enum_codegen) $(locations :descriptor) swift > $(OUTS)",
+    cmd = "$(location :log_enum_codegen) $(location :descriptor) swift > $(OUTS)",
     tools = [":log_enum_codegen"],
     visibility = ["//visibility:public"],
 )

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -1,12 +1,20 @@
+# capture-sdk - bitdrift's client SDK
+# Copyright Bitdrift, Inc. All rights reserved.
+#
+# Use of this source code is governed by a source available license that can be found in the
+# LICENSE file or at:
+# https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 load("@flatbuffers//:build_defs.bzl", "flatbuffer_library_public")
 load("//bazel:bitdrift_build_system.bzl", "bitdrift_rust_binary")
 
 flatbuffer_library_public(
     name = "descriptor",
-    srcs = ["@bitdrift_api//:all_fbs"],
+    srcs = [
+        "@bitdrift_api//:all_fbs",
+    ],
     outs = [
         "buffer_log.schema.json",
-        "reports.schema.json", 
     ],
     language_flag = "--jsonschema",
 )
@@ -19,7 +27,7 @@ genrule(
     name = "log_type_kt_source",
     srcs = [":descriptor"],
     outs = ["LogType.kt"],
-    cmd = "$(location :log_enum_codegen) $(location :descriptor) kotlin > $(OUTS)",
+    cmd = "$(location :log_enum_codegen) $(locations :descriptor) kotlin > $(OUTS)",
     tools = [":log_enum_codegen"],
     visibility = ["//visibility:public"],
 )
@@ -28,7 +36,7 @@ genrule(
     name = "log_type_swift_source",
     srcs = [":descriptor"],
     outs = ["LogType.swift"],
-    cmd = "$(location :log_enum_codegen) $(location :descriptor) swift > $(OUTS)",
+    cmd = "$(location :log_enum_codegen) $(locations :descriptor) swift > $(OUTS)",
     tools = [":log_enum_codegen"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This needed now given we have [multiple fbs](https://github.com/search?q=repo%3Abitdriftlabs%2Fapi+fbs&type=code) in api now

```
ERROR: /home/runner/work/capture-sdk/capture-sdk/proto/BUILD:4:26: declared output 'proto/buffer_log.schema.json' was not created by genrule. This is probably because the genrule actually didn't create this output, or because the output was a directory and the genrule was run remotely (note that only the contents of declared file outputs are copied from genrules run remotely)
ERROR: /home/runner/work/capture-sdk/capture-sdk/proto/BUILD:4:26: Generating flatbuffer files for descriptor: //proto:descriptor failed: not all outputs were created or valid

```
Discussed here https://bitdrift.slack.com/archives/C058ZD2M2CQ/p1745949413605059