### PR TITLE
[Android] Avoid creating additional ErrorHandler instance

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -137,6 +137,7 @@ internal class LoggerImpl(
                                 networkAttributes,
                                 deviceAttributes,
                             ),
+                        errorHandler = errorHandler,
                         customFieldProviders = fieldProviders,
                     )
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/MetadataProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/MetadataProvider.kt
@@ -16,7 +16,7 @@ internal class MetadataProvider(
     private val dateProvider: DateProvider,
     private val ootbFieldProviders: List<FieldProvider>,
     private val customFieldProviders: List<FieldProvider>,
-    private val errorHandle: ErrorHandler = ErrorHandler(),
+    private val errorHandler: ErrorHandler,
     private val errorLog: ((String, Throwable) -> Unit) = { message, throwable -> Log.w("capture", message, throwable) },
 ) : IMetadataProvider {
     override fun timestamp(): Long = dateProvider.invoke().time
@@ -40,7 +40,7 @@ internal class MetadataProvider(
                     // The issue is not with our code but customer's provider.
                     val message = "Field Provider \"${fieldProvider.javaClass.name}\" threw an exception"
                     errorLog(message, e)
-                    errorHandle.handleError(message, e)
+                    errorHandler.handleError(message, e)
                 }
             }
         }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/MetadataProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/MetadataProviderTest.kt
@@ -51,7 +51,7 @@ class MetadataProviderTest {
                 dateProvider = dateProvider,
                 ootbFieldProviders = listOf(throwingFieldProvider1, workingFieldProviders1),
                 customFieldProviders = listOf(throwingFieldProvider2, workingFieldProviders2),
-                errorHandle = mock { },
+                errorHandler = mock { },
                 errorLog = { _, _ -> },
             )
 


### PR DESCRIPTION
Looks like we are creating 2 instances of ErrorHandler unnecessarily