### PR TITLE
[Android] [BIT-4820] Fix frame duration workflow

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -35,7 +35,6 @@ import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeConfig
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.IEventListenerLogger
-import io.bitdrift.capture.events.span.SpanField
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.threading.CaptureDispatchers
@@ -202,7 +201,7 @@ internal class JankStatsMonitor(
             LogType.UX,
             jankFrameLogDetails.logLevel,
             buildMap {
-                put(SpanField.Key.DURATION, toDurationMillis().toString().toFieldValue())
+                put(DURATION_NAME_KEY, toDurationMillis().toString().toFieldValue())
                 putAll(this@sendJankFrameData.states.toFields())
             },
         ) { jankFrameLogDetails.message }
@@ -293,5 +292,6 @@ internal class JankStatsMonitor(
         private const val DROPPED_FRAME_MESSAGE_ID = "DroppedFrame"
         private const val ANR_MESSAGE_ID = "ANR"
         private const val SCREEN_NAME_KEY = "_screen_name"
+        private const val DURATION_NAME_KEY = "_frame_duration_ms"
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
@@ -291,7 +291,7 @@ class JankStatsMonitorTest {
             any(),
             eq(
                 mapOf(
-                    "_duration_ms" to jankDurationInMilli.toString().toFieldValue(),
+                    "_frame_duration_ms" to jankDurationInMilli.toString().toFieldValue(),
                     "_screen_name" to screenName.toFieldValue(),
                 ),
             ),
@@ -325,7 +325,7 @@ class JankStatsMonitorTest {
         verify(logger).log(
             eq(LogType.UX),
             eq(expectedLogLevel),
-            eq(mapOf("_duration_ms" to jankDurationInMilli.toString().toFieldValue())),
+            eq(mapOf("_frame_duration_ms" to jankDurationInMilli.toString().toFieldValue())),
             eq(null),
             eq(null),
             eq(false),


### PR DESCRIPTION
Resolves BIT-4820

The theory here is that _duration_ms is a frequently used field that can get triggered on other events relying on this, so the proposal here is to update the event with a more explicit name

This depends on https://github.com/bitdriftlabs/bitdrift-frontend/pull/2236 being deployed

Verified with client changes emitting `_frame_duration_ms` and existing `_duration_ms`

<img width="1758" alt="image" src="https://github.com/user-attachments/assets/c7e529cb-e960-4dda-96b5-551ad49efe6d" />

<img width="1735" alt="image" src="https://github.com/user-attachments/assets/fba84c3a-707f-4092-88f8-48f4156e9891" />
