### PR TITLE
Apk size fix for caching main 

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    types:
+      - closed # Ensure this only triggers for PR that are merged into main
   pull_request:
 # Cancel in-progress CI jobs when a new commit is pushed to a PR.
 concurrency:


### PR DESCRIPTION
This job didn't save the latest apk size properly https://github.com/bitdriftlabs/capture-sdk/actions/runs/14980657611/job/42083886389

Run actions/cache/save@v3
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/capture-sdk/capture-sdk --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key apk-main-baseline, another job may be creating this cache.
Warning: Cache save failed.