### PR TITLE
[Android] [Jank Frames] DroppedFrames/ANR consolidation

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -207,7 +207,7 @@ internal class JankStatsMonitor(
                 put(DROPPED_FRAME_TYPE_KEY, jankFrameType.fieldValue)
                 putAll(this@sendJankFrameData.states.toFields())
             },
-        ) { jankFrameType.messageId }
+        ) { DROPPED_FRAME_MESSAGE_ID }
     }
 
     @WorkerThread
@@ -246,29 +246,27 @@ internal class JankStatsMonitor(
     @OpenForTesting
     internal enum class JankFrameType(
         val logLevel: LogLevel,
-        val messageId: String,
         val fieldValue: FieldValue,
     ) {
         /**
          * Has a duration >= 16 ms and below [RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS]
          */
-        SLOW(LogLevel.WARNING, DROPPED_FRAME_MESSAGE_ID, "Slow".toFieldValue()),
+        SLOW(LogLevel.WARNING, "Slow".toFieldValue()),
 
         /**
          * With a duration between [RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS] and below [RuntimeConfig.ANR_FRAME_THRESHOLD_MS]
          */
-        FROZEN(LogLevel.ERROR, DROPPED_FRAME_MESSAGE_ID, "Frozen".toFieldValue()),
+        FROZEN(LogLevel.ERROR, "Frozen".toFieldValue()),
 
         /**
          * With a duration above [RuntimeConfig.ANR_FRAME_THRESHOLD_MS]
          */
-        ANR(LogLevel.ERROR, ANR_MESSAGE_ID, "ANR".toFieldValue()),
+        ANR(LogLevel.ERROR, "ANR".toFieldValue()),
     }
 
     private companion object {
         private const val ERROR_DURATION_THRESHOLD_MILLIS = 100_000_000L
         private const val DROPPED_FRAME_MESSAGE_ID = "DroppedFrame"
-        private const val ANR_MESSAGE_ID = "ANR"
         private const val SCREEN_NAME_KEY = "_screen_name"
         private const val DROPPED_FRAME_TYPE_KEY = "_frame_issue_type"
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/JankStatsMonitorTest.kt
@@ -335,7 +335,7 @@ class JankStatsMonitorTest {
             eq(null),
             eq(null),
             eq(false),
-            argThat { message: () -> String -> message.invoke() == expectedFrameType.messageId },
+            argThat { message: () -> String -> message.invoke() == "DroppedFrame" },
         )
     }
 


### PR DESCRIPTION
In order to clarify future Fatal Issue events, we are doing minor changes on frontend by combining existing DroppedFrames/Non Fatal ANR into single OOTB (potentially named "Rendering Issues" or simillar)

[See original tech spec here](https://docs.google.com/document/d/1KPu7DZEl6qzI8P4s5WNr-yqg4DJQkzLcHg9RPWAJVTQ/edit?tab=t.t6ha7ymkk1n2#heading=h.28e8c7dq5wf7)

| On current main | On this PR (e.g. v.0.17.16) |
| -----------------| -------------------------|
| [session](https://timeline.bitdrift.dev/s/fa2025ea-05ed-4a02-9353-1cb976c4ebd4?utm_source=sdk)   | [session](https://timeline.bitdrift.dev/s/220815e1-602b-48e3-b1ad-a5b8d5f74fd1?utm_source=sdk)  |
|   <img width="1116" alt="image" src="https://github.com/user-attachments/assets/d8f6b323-4f1d-4fb5-b079-1ef2e8dfd45e" />   |    <img width="1118" alt="image" src="https://github.com/user-attachments/assets/3a38eb7d-ca6e-452d-affd-88a562027c55" />     |
|  <img width="1435" alt="image" src="https://github.com/user-attachments/assets/47e58882-610b-421e-959f-29c59fcb4d66" /> | <img width="1622" alt="image" src="https://github.com/user-attachments/assets/b7da7f3b-f8ba-4629-a147-0069cc3bd500" />|

- Frontend changes https://github.com/bitdriftlabs/bitdrift-frontend/pull/2277 
- Loop api https://github.com/bitdriftlabs/loop-api/pull/2329
- Docs https://github.com/bitdriftlabs/bitdrift-docs/pull/291 