### PR TITLE
[Android] [Fatal Issue Reporting] Avoid sending duplicated JVM crash log when BuiltIn is configured

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -251,6 +251,7 @@ internal class LoggerImpl(
                         runtime,
                         errorHandler,
                         memoryMetricsProvider = memoryMetricsProvider,
+                        fatalIssueMechanism = fatalIssueReporter.getReportingMechanism(),
                     )
 
                 // Install the app exit logger before the Capture logger is started to ensure

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -25,6 +25,7 @@ import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
 import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.reports.FatalIssueMechanism
 import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitReasonResult
@@ -46,6 +47,7 @@ internal class AppExitLogger(
     private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider = LatestAppExitInfoProvider,
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = CaptureUncaughtExceptionHandler,
+    private val fatalIssueMechanism: FatalIssueMechanism,
 ) : JvmCrashListener {
     companion object {
         private const val APP_EXIT_EVENT_NAME = "AppExit"
@@ -131,7 +133,8 @@ internal class AppExitLogger(
         thread: Thread,
         throwable: Throwable,
     ) {
-        if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)) {
+        // When FatalIssueMechanism.BuiltIn is configured will rely on shared-core to emit the related JVM crash log
+        if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS) || fatalIssueMechanism == FatalIssueMechanism.BuiltIn) {
             return
         }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueReporter.kt
@@ -70,6 +70,11 @@ internal class FatalIssueReporter(
     }
 
     /**
+     * Returns the configured [io.bitdrift.capture.reports.FatalIssueMechanism]
+     */
+    override fun getReportingMechanism(): FatalIssueMechanism = fatalIssueReporterStatus.mechanism
+
+    /**
      * Applicable when [FatalIssueMechanism.BuiltIn] is available, given that registration
      * only occurs for calls like initialize(FatalIssueMechanism.BUILT_IN)
      */

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IFatalIssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IFatalIssueReporter.kt
@@ -11,7 +11,7 @@ import android.content.Context
 import io.bitdrift.capture.providers.FieldValue
 
 /**
- * Handles internal reporting of crashes
+ * Handles internal reporting of Fatal Issues
  */
 interface IFatalIssueReporter {
     /**
@@ -21,6 +21,11 @@ interface IFatalIssueReporter {
         appContext: Context,
         fatalIssueMechanism: FatalIssueMechanism,
     )
+
+    /**
+     * Returns the configured [io.bitdrift.capture.reports.FatalIssueMechanism]
+     */
+    fun getReportingMechanism(): FatalIssueMechanism
 
     /**
      * Generates the [InternalFieldsMap] to be reported upon Capture.Logger.start with

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -20,6 +20,7 @@ import io.bitdrift.capture.attributes.ClientAttributes
 import io.bitdrift.capture.attributes.DeviceAttributes
 import io.bitdrift.capture.attributes.NetworkAttributes
 import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.fakes.FakeFatalIssueReporter
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponse
 import io.bitdrift.capture.network.HttpResponseInfo
@@ -61,7 +62,7 @@ class CaptureLoggerTest {
 
     private lateinit var logger: LoggerImpl
     private var testServerPort: Int? = null
-    private val fatalIssueReporter: IFatalIssueReporter = mock()
+    private val fatalIssueReporter: IFatalIssueReporter = FakeFatalIssueReporter()
 
     @Before
     fun setUp() {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
@@ -10,9 +10,9 @@ package io.bitdrift.capture
 import androidx.test.core.app.ApplicationProvider
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.error.ErrorReportRequest
 import io.bitdrift.capture.error.ErrorReporterService
+import io.bitdrift.capture.fakes.FakeFatalIssueReporter
 import io.bitdrift.capture.network.okhttp.OkHttpApiClient
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit
 class ErrorReporterTest {
     private lateinit var server: MockWebServer
     private lateinit var reporter: ErrorReporterService
-    private val fatalIssueReporter: IFatalIssueReporter = mock()
+    private val fatalIssueReporter: IFatalIssueReporter = FakeFatalIssueReporter()
 
     init {
         CaptureJniLibrary.load()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
@@ -9,6 +9,7 @@ package io.bitdrift.capture
 
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
+import io.bitdrift.capture.fakes.FakeFatalIssueReporter
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.IFatalIssueReporter
 import okhttp3.HttpUrl
@@ -24,7 +25,7 @@ import java.util.concurrent.CountDownLatch
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [21])
 class SessionStrategyTest {
-    private val fatalIssueReporter: IFatalIssueReporter = mock()
+    private val fatalIssueReporter: IFatalIssueReporter = FakeFatalIssueReporter()
 
     @Before
     fun setUp() {
@@ -34,7 +35,7 @@ class SessionStrategyTest {
 
     @Test
     fun fixedSessionStrategy() {
-        var generatedSessionIds = mutableListOf<String>()
+        val generatedSessionIds = mutableListOf<String>()
 
         val logger =
             LoggerImpl(

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
@@ -8,7 +8,7 @@
 package io.bitdrift.capture
 
 import androidx.test.core.app.ApplicationProvider
-import com.nhaarman.mockitokotlin2.mock
+import io.bitdrift.capture.fakes.FakeFatalIssueReporter
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.IFatalIssueReporter
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [21])
 class SessionUrlTest {
-    private val fatalIssueReporter: IFatalIssueReporter = mock()
+    private val fatalIssueReporter: IFatalIssueReporter = FakeFatalIssueReporter()
 
     @Before
     fun setUp() {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeFatalIssueReporter.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeFatalIssueReporter.kt
@@ -1,0 +1,30 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture.fakes
+
+import android.content.Context
+import io.bitdrift.capture.providers.FieldValue
+import io.bitdrift.capture.reports.FatalIssueMechanism
+import io.bitdrift.capture.reports.IFatalIssueReporter
+
+/**
+ * Fake [IFatalIssueReporter]
+ */
+class FakeFatalIssueReporter : IFatalIssueReporter {
+    private var fatalIssueMechanism: FatalIssueMechanism = FatalIssueMechanism.BuiltIn
+
+    override fun initialize(
+        appContext: Context,
+        fatalIssueMechanism: FatalIssueMechanism,
+    ) {
+        // no-op
+    }
+
+    override fun getReportingMechanism(): FatalIssueMechanism = fatalIssueMechanism
+
+    override fun getLogStatusFieldsMap(): Map<String, FieldValue> = emptyMap()
+}


### PR DESCRIPTION
See demo session here https://timeline.bitdrift.dev/session/74db95e7-ab92-4fb1-a1f4-94c12df35baa?utm_source=sdk&pages=1&utilization=0&expanded=1057666215724288368

_**NOTE: This can be merged now given we are not opening built in to public yet. See https://github.com/bitdriftlabs/capture-sdk/pull/394**_ 

| Before (on local frontend version) | After (on local frontend version) |
|------- |-------|
| <img width="1126" alt="image" src="https://github.com/user-attachments/assets/b8c0b0c2-51b2-4106-8d69-75d01280d3b4" /> | <img width="1108" alt="image" src="https://github.com/user-attachments/assets/d9cd0317-bfcd-4289-86c5-cbbc1ed6d1aa" />|