### PR TITLE
[FatalIssueReporting][BuiltIn] Hide public api since is not ready yet

### DIFF
--- a/examples/android/HelloWorldApp.kt
+++ b/examples/android/HelloWorldApp.kt
@@ -30,7 +30,7 @@ class HelloWorldApp : Application() {
         super.onCreate()
         
         @OptIn(ExperimentalBitdriftApi::class)
-        Logger.initFatalIssueReporting(fatalIssueMechanism = FatalIssueMechanism.BuiltIn)
+        Logger.initFatalIssueReporting()
 
         setupExampleCrashHandler()
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -110,10 +110,11 @@ object Capture {
         @ExperimentalBitdriftApi
         @JvmStatic
         @JvmOverloads
-        fun initFatalIssueReporting(
-            context: Context? = null,
-            fatalIssueMechanism: FatalIssueMechanism,
-        ) {
+        fun initFatalIssueReporting(context: Context? = null) {
+            // TODO:(FranAguilera) BIT-5401: To allow passing fatalIssueMechanism config once
+            // we are ready to ship [io.bitdrift.capture.reports.FatalIssueMechanism.BuiltIn]
+            val fatalIssueMechanism = FatalIssueMechanism.Integration
+
             if (context == null && !ContextHolder.isInitialized) {
                 Log.w(LOG_TAG, "Attempted to initialize Fatal Issue Reporting with a null context. Skipping enabling crash tracking.")
                 return

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -98,7 +98,7 @@ class GradleTestApp : Application() {
     private fun initLogging() {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
         @OptIn(ExperimentalBitdriftApi::class)
-        Capture.Logger.initFatalIssueReporting(fatalIssueMechanism = getFatalIssueSourceConfig(sharedPreferences))
+        Capture.Logger.initFatalIssueReporting()
 
         val stringApiUrl = sharedPreferences.getString("apiUrl", null)
         val apiUrl = stringApiUrl?.toHttpUrlOrNull()

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -97,7 +97,11 @@ extension Logger {
     /// This API is experimental and subject to change
     ///
     /// - parameter type: mechanism for crash detection
-    public static func initFatalIssueReporting(_ type: IssueReporterType = .customConfig) {
+    public static func initFatalIssueReporting() {
+        // TODO:(FranAguilera) BIT-5401: To add config option once we are ready to ship BuiltIn
+        // [io.bitdrift.capture.reports.FatalIssueMechanism.BuiltIn]**/
+        let type: IssueReporterType = .customConfig
+
         switch type {
         case .builtIn:
             if let outputDir = Logger.reportCollectionDirectory() {

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -95,11 +95,8 @@ extension Logger {
 
     /// Initializes the issue reporting mechanism. Must be called prior to `Logger.start()`
     /// This API is experimental and subject to change
-    ///
-    /// - parameter type: mechanism for crash detection
     public static func initFatalIssueReporting() {
         // TODO:(FranAguilera) BIT-5401: To add config option once we are ready to ship BuiltIn
-        // [io.bitdrift.capture.reports.FatalIssueMechanism.BuiltIn]**/
         let type: IssueReporterType = .customConfig
 
         switch type {

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -97,7 +97,7 @@ extension Logger {
     /// This API is experimental and subject to change
     public static func initFatalIssueReporting() {
         // TODO:(FranAguilera) BIT-5401: To add config option once we are ready to ship BuiltIn
-        let type: IssueReporterType = .customConfig
+        let type: IssueReporterType = getIssueReporterType()
 
         switch type {
         case .builtIn:
@@ -118,6 +118,12 @@ extension Logger {
                 log(level: .warning, message: "Fatal issue reporting already being initialized")
             }
         }
+    }
+
+    private static func getIssueReporterType() -> IssueReporterType {
+        // TODO:(FranAguilera) BIT-5401.
+        // Only added to make rules_swift happy. All of this will be reverted at BIT-5401
+        return .customConfig
     }
 
     /// Retrieves the session ID. It is nil before the Capture SDK is started.

--- a/platform/swift/source/reports/CrashReportingIntegration.swift
+++ b/platform/swift/source/reports/CrashReportingIntegration.swift
@@ -8,12 +8,10 @@
 extension Integration {
     /// Enables reporting unexpected app terminations
     ///
-    /// - parameter type: mechanism used for crash detection
-    ///
     /// - returns: The crash reporting integration
-    public static func crashReporting(_ type: IssueReporterType = .builtIn) -> Integration {
+    public static func crashReporting() -> Integration {
         .init { _, _ in
-            Logger.initFatalIssueReporting(type)
+            Logger.initFatalIssueReporting()
         }
     }
 }


### PR DESCRIPTION
Given BuiltIn is not quite ready, hiding from init the BuiltIn mechanism and defaulting to Integration (same as latest release)