### PR TITLE
feat: add public interface to the sdk version

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -100,6 +100,18 @@ object Capture {
         private val mainThreadHandler by lazy { MainThreadHandler() }
 
         /**
+         * Get the current version of the Capture library
+         *
+         * @return the version as a String or null if loading failed
+         */
+        @JvmStatic
+        val sdkVersion: String? get() {
+            // support operation prior to the library being initialized
+            CaptureJniLibrary.load()
+            return CaptureJniLibrary.getSdkVersion();
+        }
+
+        /**
          * Initializes fatal issue (ANR, JVM Crash, Native crash) reporting mechanism.
          *
          * @param context an optional context reference. You should provide the context if called from a [android.content.ContentProvider]

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/FatalIssueReporterProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/FatalIssueReporterProcessor.kt
@@ -10,7 +10,7 @@ package io.bitdrift.capture.reports.processor
 import android.content.Context
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.flatbuffers.FlatBufferBuilder
-import io.bitdrift.capture.CaptureJniLibrary
+import io.bitdrift.capture.Capture
 import io.bitdrift.capture.attributes.ClientAttributes
 import io.bitdrift.capture.reports.binformat.v1.AppBuildNumber
 import io.bitdrift.capture.reports.binformat.v1.DeviceMetrics
@@ -176,10 +176,5 @@ internal interface ISDKVersionProvider {
 }
 
 private class CoreSDKVersionProvider : ISDKVersionProvider {
-    override fun getSDKVersion(): String? {
-        // Ensure native lib is loaded - it will not yet be loaded when
-        // evaluating the SDK version during fatal issue handler initialization
-        CaptureJniLibrary.load()
-        return CaptureJniLibrary.getSdkVersion()
-    }
+    override fun getSDKVersion(): String? = Capture.Logger.version()
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/MainActivity.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
+import io.bitdrift.capture.Capture
 import io.bitdrift.gradletestapp.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -31,6 +31,13 @@ extension Logger {
         self.getShared()
     }
 
+    /// Get the current version of the Capture library
+    ///
+    /// - returns: the version as a String
+    public static var sdkVersion: String {
+        capture_get_sdk_version()
+    }
+
     /// Initializes the Capture SDK with the specified API key, providers, and configuration.
     /// Calling other SDK methods has no effect unless the logger has been initialized.
     /// Subsequent calls to this function will have no effect.

--- a/platform/swift/source/LoggerObjc.swift
+++ b/platform/swift/source/LoggerObjc.swift
@@ -5,6 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+internal import CaptureLoggerBridge
 import Foundation
 
 // Make this class not available to Swift code. It should be used by Objective-c code only.
@@ -46,6 +47,14 @@ public final class LoggerObjc: NSObject {
         if let logger, enableURLSessionIntegration {
             logger.enableIntegrations([.urlSession()], disableSwizzling: false)
         }
+    }
+
+    /// Get the current version of the Capture library
+    ///
+    /// - returns: the version as a String
+    @objc
+    public static func sdkVersion() -> String {
+        return capture_get_sdk_version();
     }
 
     /// Defines the initialization of a new session within the current configured logger.


### PR DESCRIPTION
Adds Capture.Logger.sdkVersion() for both Apple and Android platforms (using `+[CAPLogger sdkVersion]` for Objective-C)

Picked `sdkVersion` over `version` to avoid shadowing NSObject.version() https://developer.apple.com/documentation/objectivec/nsobject-swift.class/version()