### PR TITLE
feat: add public interface to the sdk version

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -106,6 +106,16 @@ object Capture {
         private val mainThreadHandler by lazy { MainThreadHandler() }
 
         /**
+         * Get the current version of the Capture library
+         *
+         * @return the version as a String
+         */
+        @JvmStatic
+        val sdkVersion: String get() {
+            return BuildConstants.SDK_VERSION
+        }
+
+        /**
          * WARNING: For now this API is not exposed to customers. If there is a request for this
          * will open visibility again
          *

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -31,6 +31,13 @@ extension Logger {
         self.getShared()
     }
 
+    /// Get the current version of the Capture library
+    ///
+    /// - returns: the version as a String
+    public static var sdkVersion: String {
+        capture_get_sdk_version()
+    }
+
     /// Initializes the Capture SDK with the specified API key, providers, and configuration.
     /// Calling other SDK methods has no effect unless the logger has been initialized.
     /// Subsequent calls to this function will have no effect.

--- a/platform/swift/source/LoggerObjc.swift
+++ b/platform/swift/source/LoggerObjc.swift
@@ -5,6 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+internal import CaptureLoggerBridge
 import Foundation
 
 @objc(CAPIssueReporterType)
@@ -122,6 +123,14 @@ public final class LoggerObjc: NSObject {
     @objc
     public static func setSleepMode(_ mode: SleepMode) {
         Capture.Logger.setSleepMode(mode)
+    }
+
+    /// Get the current version of the Capture library
+    ///
+    /// - returns: the version as a String
+    @objc
+    public static func sdkVersion() -> String {
+        return capture_get_sdk_version()
     }
 
     /// Defines the initialization of a new session within the current configured logger.


### PR DESCRIPTION
Adds `Capture.Logger.sdkVersion()` for both Apple and Android platforms (using `+[CAPLogger sdkVersion]` for Objective-C)

Picked `sdkVersion` over `version` to avoid shadowing [`NSObject.version()`](https://developer.apple.com/documentation/objectivec/nsobject-swift.class/version())