### PR TITLE
fix(ios): keep unformatted version of OS build info

### DIFF
--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -206,9 +206,6 @@ static int8_t architecture_constant(NSString *arch) {
   NSRange nameRange = [match rangeWithName:@"osName"];
   NSRange versionRange = [match rangeWithName:@"osVersion"];
   NSRange buildRange = [match rangeWithName:@"buildNumber"];
-  if (!nameRange.length || !versionRange.length || !buildRange.length) {
-    return nil;
-  }
   if (self = [super init]) {
     if (!nameRange.length || !versionRange.length || !buildRange.length) {
       self.version = version; // pathological case where there's a match but the captures don't hit


### PR DESCRIPTION
In the event that the version info can't be parsed into the expected format, keep all of it as the "version"

This was intended in the previous version but erroneously merged to a subsequent version

fixed BIT-5529