### PR TITLE
Add missing proxyOkHttpEventListener property in the unit tests

### DIFF
--- a/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/instrumentation/fakes/TestSpanAddingParameters.kt
+++ b/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/instrumentation/fakes/TestSpanAddingParameters.kt
@@ -47,6 +47,9 @@ class TestSpanAddingParameters(
     override val debug: Property<Boolean>
         get() = DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType)
             .convention(debugOutput)
+    override val proxyOkHttpEventListener: Property<Boolean>
+        get() = DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType)
+            .convention(true)
 
     override val tmpDir: Property<File>
         get() = DefaultProperty<File>(PropertyHost.NO_OP, File::class.java).convention(inMemoryDir)


### PR DESCRIPTION
The interface to `SpanAddingClassVisitorFactory.SpanAddingParameters` has changed, but `TestSpanAddingParameters` has not been updated to match.

Add a default "true" property to satisfy the new interface.
