### PR TITLE
fix(ios): allow version format to skip patch or minor specifiers

### DIFF
--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -17,7 +17,7 @@
 // - `osName` is everything before the version number ("iPhone OS")
 // - `osVersion` is the dot-delimited numbers
 // - `buildNumber` is the parenthesized letters and numbers
-static NSString *const OS_VERSION_MATCHER = @"^(?<osName>.*)\\s+(?<osVersion>\\d+\\.\\d+\\.\\d+)\\s+\\((?<buildNumber>.*)\\)$";
+static NSString *const OS_VERSION_MATCHER = @"^(?<osName>.*)\\s+(?<osVersion>\\d+.*)\\s+\\((?<buildNumber>.*)\\)$";
 // Name to use for `MXHangDiagnostic` events if no better name is detected
 static NSString *const DEFAULT_HANG_NAME = @"App Hang";
 // SDK identifier used in generated files


### PR DESCRIPTION
e.g. "iPhone OS 19.6.7" vs "iPhone OS 19.6" vs "iPhone OS 19blah" 

all should be valid

[sample event with change](https://explorations.bitdrift.dev/issues/13660455870436558104/85f70480-2bc6-4bad-a637-c2ff702e1b2f)