### PR TITLE
Add sensible defaults for initFatalIssueReporting

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -102,6 +102,7 @@ object Capture {
         /**
          * Initializes fatal issue (ANR, JVM Crash, Native crash) reporting mechanism.
          *
+         * @param fatalIssueMechanism the [FatalIssueMechanism] to use for crash detection
          * @param context an optional context reference. You should provide the context if called from a [android.content.ContentProvider]
          *
          * This should be called prior to Capture.Logger.start()
@@ -111,8 +112,8 @@ object Capture {
         @JvmStatic
         @JvmOverloads
         fun initFatalIssueReporting(
+            fatalIssueMechanism: FatalIssueMechanism = FatalIssueMechanism.BuiltIn,
             context: Context? = null,
-            fatalIssueMechanism: FatalIssueMechanism,
         ) {
             if (context == null && !ContextHolder.isInitialized) {
                 Log.w(LOG_TAG, "Attempted to initialize Fatal Issue Reporting with a null context. Skipping enabling crash tracking.")

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -97,7 +97,7 @@ extension Logger {
     /// This API is experimental and subject to change
     ///
     /// - parameter type: mechanism for crash detection
-    public static func initFatalIssueReporting(_ type: IssueReporterType = .customConfig) {
+    public static func initFatalIssueReporting(_ type: IssueReporterType = .builtIn) {
         if issueReporterInitResult.0 != .notInitialized {
             log(level: .warning, message: "Fatal issue reporting already being initialized")
             return


### PR DESCRIPTION
Allows for users to just call Logger.initFatalIssueReporting() with BuiltIn by default