### PR TITLE
Align FatalIssueReporter mechanism on both platforms

### DIFF
--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -124,7 +124,7 @@ extension Logger {
                 MXMetricManager.shared.add(reporter)
                 return .initialized(.monitoring)
                 #endif
-            case .customConfig:
+            case .integration:
                 return CustomConfigIssueReporter.processFiles()
             }
         }

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -16,7 +16,7 @@ public typealias FieldValue = Encodable & Sendable
 
 public enum IssueReporterType {
     case builtIn
-    case customConfig
+    case integration
 }
 
 extension Logger {

--- a/platform/swift/source/LoggerObjc.swift
+++ b/platform/swift/source/LoggerObjc.swift
@@ -10,7 +10,7 @@ import Foundation
 @objc(CAPIssueReporterType)
 public enum IssueReporterTypeObjc: Int8 {
     case builtIn
-    case customConfig
+    case integration
 }
 
 // Make this class not available to Swift code. It should be used by Objective-c code only.
@@ -70,8 +70,8 @@ public final class LoggerObjc: NSObject {
         switch type {
         case .builtIn:
             Capture.Logger.initFatalIssueReporting(.builtIn)
-        case .customConfig:
-            Capture.Logger.initFatalIssueReporting(.customConfig)
+        case .integration:
+            Capture.Logger.initFatalIssueReporting(.integration)
         }
     }
 

--- a/test/platform/swift/unit_integration/core/FatalIssueReporterTests.swift
+++ b/test/platform/swift/unit_integration/core/FatalIssueReporterTests.swift
@@ -42,7 +42,7 @@ final class FatalIssueReporterTests: XCTestCase {
     }
 
     func testNoConfig() {
-        Logger.initFatalIssueReporting(.customConfig)
+        Logger.initFatalIssueReporting(.integration)
         let result = Logger.issueReporterInitResult
         XCTAssertEqual(IssueReporterInitState.initialized(.missingConfigFile), result.0)
 
@@ -53,7 +53,7 @@ final class FatalIssueReporterTests: XCTestCase {
 
     func testNoConfigDir() {
         try! FileManager.default.removeItem(at: reportDir)
-        Logger.initFatalIssueReporting(.customConfig)
+        Logger.initFatalIssueReporting(.integration)
         let result = Logger.issueReporterInitResult
         XCTAssertEqual(IssueReporterInitState.initialized(.missingConfigFile), result.0)
 
@@ -64,7 +64,7 @@ final class FatalIssueReporterTests: XCTestCase {
 
     func testBrokenConfig() {
         createConfig("some nonsense")
-        Logger.initFatalIssueReporting(.customConfig)
+        Logger.initFatalIssueReporting(.integration)
         let result = Logger.issueReporterInitResult
         XCTAssertEqual(IssueReporterInitState.initialized(.malformedConfigFile), result.0)
 
@@ -79,7 +79,7 @@ final class FatalIssueReporterTests: XCTestCase {
                     directory: "the-files/special",
                     filename: "something.yam",
                     contents: String(repeating: "<stuff>", count: 100))
-        Logger.initFatalIssueReporting(.customConfig)
+        Logger.initFatalIssueReporting(.integration)
         let result = Logger.issueReporterInitResult
         XCTAssertEqual(IssueReporterInitState.initialized(.withoutPriorCrash), result.0)
 
@@ -97,7 +97,7 @@ final class FatalIssueReporterTests: XCTestCase {
                     filename: "something.json",
                     contents: initContents,
                     attributes: [.modificationDate: modDate])
-        Logger.initFatalIssueReporting(.customConfig)
+        Logger.initFatalIssueReporting(.integration)
         let result = Logger.issueReporterInitResult
         XCTAssertEqual(IssueReporterInitState.initialized(.sent), result.0)
         XCTAssertLessThan(result.1, 50)
@@ -140,7 +140,7 @@ final class FatalIssueReporterTests: XCTestCase {
                     filename: "old-and-ignore.json",
                     contents: String(repeating: "<bad stuff>", count: 100),
                     attributes: [.modificationDate: modDate - TimeInterval(200)])
-        Logger.initFatalIssueReporting(.customConfig)
+        Logger.initFatalIssueReporting(.integration)
         let result = Logger.issueReporterInitResult
         XCTAssertEqual(IssueReporterInitState.initialized(.sent), result.0)
         XCTAssertLessThan(result.1, 50)


### PR DESCRIPTION
Just a minor rename to bring parity with Android [FatalIssueMechanism definition](https://github.com/bitdriftlabs/capture-sdk/blob/95a288a4471996869fa8271fccb386d2eac3bfbc/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/FatalIssueMechanism.kt#L24)