### PR TITLE
fix(ios): remove completely empty threads from reports

### DIFF
--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -149,6 +149,9 @@ static void serialize_error_threads(BDProcessorHandle handle, NSDictionary *cras
     NSDictionary *thread = call_stacks[thread_index];
     NSDictionary *frame = thread_root_frame(thread);
     uint64_t frame_count = count_frames(frame);
+    if (frame_count == 0 && thread_index != crashed_index) {
+      continue;
+    }
     BDStackFrame *stack = frame_count
       ? (BDStackFrame *)calloc(frame_count, sizeof(BDStackFrame))
       : 0;


### PR DESCRIPTION
Since threads are being generated from the call stack tree, it is possible for some leaves to be empty, which is otherwise confusing and not meaningful in reports. this change drops empty-leaf threads entirely unless the thread is indicated to be the crash cause (via the `threadAttributed` property being true)

[Sample event](https://explorations.bitdrift.dev/issues/14205186291592388220/72552b76-7651-4f8c-99b8-096289628143) just to confirm otherwise normal behavior 