### PR TITLE
[Android] [StrictMode] Ignore known offenders from gradle test app

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
@@ -23,7 +23,7 @@ public class BitdriftInit {
     public static void initBitdriftCaptureInJava(
             HttpUrl apiUrl,
             String apiKey,
-            String sessionStrategyName,
+            SessionStrategy sessionStrategy,
             Configuration configuration) {
         String userID = UUID.randomUUID().toString();
         List<FieldProvider> fieldProviders = new ArrayList<>();
@@ -35,19 +35,11 @@ public class BitdriftInit {
 
         Capture.Logger.start(
             apiKey,
-            mapToSessionStrategy(sessionStrategyName),
+            sessionStrategy,
             configuration,
             fieldProviders,
             null,
             apiUrl
         );
-    }
-
-    private static SessionStrategy mapToSessionStrategy(String sessionStrategyName) {
-        if(sessionStrategyName.equals(SessionStrategyPreferences.ACTIVITY_BASED.getDisplayName())){
-            return new SessionStrategy.ActivityBased();
-        }else{
-            return new SessionStrategy.Fixed();
-        }
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/StrictModeReporter.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/StrictModeReporter.kt
@@ -22,6 +22,10 @@ internal class StrictModeReporter {
     fun onViolation(violationType: ViolationType, violation: Violation) {
         val cause = violation.toString()
         val stackTrace = Log.getStackTraceString(violation)
+        if (KNOWN_ISSUES_LIST.any { stackTrace.contains(it) }) {
+            // Avoid emitting for known violations
+            return
+        }
         val strictModeFields = mapOf(
             "strict_mode_reason" to violation.toString(),
             "strict_mode_stack_trace" to stackTrace
@@ -33,5 +37,9 @@ internal class StrictModeReporter {
     internal enum class ViolationType {
         VM,
         THREAD
+    }
+
+    private companion object{
+        val KNOWN_ISSUES_LIST  = listOf("Sentry", "BugSnag")
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/StrictModeReporter.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/StrictModeReporter.kt
@@ -23,7 +23,6 @@ internal class StrictModeReporter {
         val cause = violation.toString()
         val stackTrace = Log.getStackTraceString(violation)
         if (KNOWN_ISSUES_LIST.any { stackTrace.contains(it) }) {
-            // Avoid emitting for known violations
             return
         }
         val strictModeFields = mapOf(


### PR DESCRIPTION
Resolves to BIT-5479

Removes known top offenders from gradle test app that we don't have any control.

**_NOTE: Also added leftover test for session id changed from [see context](https://bitdrift.slack.com/archives/C058ZD2M2CQ/p1749117566334359)_**

| Before | After |
| -------| ------|
| <img width="966" alt="image" src="https://github.com/user-attachments/assets/774bba53-ce70-4354-95ab-b3d796e11bec" /> |  <img width="979" alt="image" src="https://github.com/user-attachments/assets/9a5b9606-1fbc-4b4e-ae27-92ddf74e97c8" /> |