### PR TITLE
[ANDR] Copy jank framedata before using it

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -85,15 +85,16 @@ internal class JankStatsMonitor(
         if (!volatileFrameData.isJank) {
             return
         }
+        if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+            stopCollection()
+            return
+        }
+
         // From the docs: note that the FrameData object sent in the callback is reused on every frame
         // to prevent having to allocate new objects for data reporting.
         // This means that you must copy and cache that data elsewhere since that object should be considered stale
         // and obsolete as soon as the callback returns.
         val frameData = volatileFrameData.copy()
-        if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
-            stopCollection()
-            return
-        }
 
         val durationNano = frameData.toDurationNano()
         val durationMillis = frameData.toDurationMillis()


### PR DESCRIPTION
While prepping for my droidcon talk I realized we never copy the volatile data like [the docs say](https://developer.android.com/topic/performance/jankstats#reporting) (and like I suggested here: https://github.com/bitdriftlabs/capture-sdk/pull/222#discussion_r1962292003) and then we use it for potentially async operations. This could explain some of the invalid values we sometimes get.

![Screenshot 2025-06-23 at 10 05 44 AM](https://github.com/user-attachments/assets/39afc61a-cd2c-4e50-947d-c105368d4aaf)
