### PR TITLE
fix(ios): disallow empty report error stack

### DIFF
--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -128,12 +128,17 @@ static uint64_t count_frames(NSDictionary *rootFrame) {
 static uint32_t crashed_thread_index(NSArray *stacks) {
   for (uint32_t index = 0; index < stacks.count; index++) {
     if ([number_for_key(stacks[index], @"threadAttributed") boolValue]) {
-      return index;
+      if (count_frames(thread_root_frame(stacks[index])) > 0) {
+        // match only if thread contains frames (FB18302500)
+        return index;
+      }
+      break;
     }
   }
   for (uint32_t index = 0; index < stacks.count; index++) {
     if (count_frames(thread_root_frame(stacks[index])) > 0) {
-      return index; // grab first thread with frames if none attributed
+      // grab first thread with frames if none attributed or attributed to empty
+      return index;
     }
   }
 


### PR DESCRIPTION
workaround for known metrickit issue where an empty thread is marked as causing a crash diagnostic (FB18302500)