### PR TITLE
Fix ReplayPreviewClient

### DIFF
--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/ReplayPreviewClient.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/ReplayPreviewClient.kt
@@ -28,11 +28,6 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Allows to capture the screen and send the binary data over a persistent websocket connection
- * @param replayManager The replay module to use for screen capture
- * @param context The context of the app to capture
- * @param protocol The protocol to use for the websocket connection (default is ws)
- * @param host The host to connect to (default is Android's emulator loopback IP: 10.0.2.2)
- * @param port The port to connect to (default is 3001)
  */
 class ReplayPreviewClient(
     errorHandler: ErrorHandler,
@@ -47,7 +42,7 @@ class ReplayPreviewClient(
         ReplayCaptureEngine(
             sessionReplayConfiguration,
             errorHandler,
-            logger,
+            this,
             MainThreadHandler(),
             WindowManager(errorHandler),
             DisplayManagers(context),


### PR DESCRIPTION
Currently only used in `main` by the bazel test app https://github.com/bitdriftlabs/capture-sdk/blob/7710b85d8ad6dbefb13786726c4fc35ba4dfab9e/examples/android/MainActivity.kt#L199-L200
But also used in https://github.com/bitdriftlabs/capture-sdk/tree/murki/flappy-chippy-2025 branch for the flappy bird demo game used in conferences 

Bug was introduced in the refactor I did when implementing screenshot capabilities https://github.com/bitdriftlabs/capture-sdk/pull/118/files#diff-4bf2532079ca32a1a99c66c47c5a3cd33d667ecbfbbaebfa81d72dfc647aaf56R49