### PR TITLE
fix(ios): avoid referencing logger during init

### DIFF
--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -111,13 +111,11 @@ extension Logger {
     /// - parameter type: mechanism for crash detection
     static func initFatalIssueReporting(_ type: IssueReporterType = .builtIn) {
         if issueReporterInitResult.0 != .notInitialized {
-            log(level: .warning, message: "Fatal issue reporting already being initialized")
             return
         }
 
         issueReporterInitResult = (.initializing, 0)
         guard let outputDir = Logger.reportCollectionDirectory() else {
-            log(level: .warning, message: "Fatal issue reporting output directory not defined, cannot enable reporting")
             issueReporterInitResult = (.initialized(.missingReportsDirectory), 0)
             return
         }
@@ -126,7 +124,6 @@ extension Logger {
             switch type {
             case .builtIn:
                 #if targetEnvironment(simulator)
-                log(level: .info, message: "Fatal issue reporting disabled for simulated devices")
                 return .initialized(.unsupportedHardware)
                 #else
                 let reporter = DiagnosticEventReporter(outputDir: outputDir, sdkVersion: capture_get_sdk_version())


### PR DESCRIPTION
updates fatal issue reporting init paths to avoid logging. this issue was introduced as a side effect of moving fatal issue initialization into `Logger` initialization, and most easily reproducible when launching using a simulator.