### PR TITLE
enable panic=abort for gradle build

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1e621e97cc4a6f8d46a2a87f63e991f70a740458bb4b57e57c8d40e11cb784b6",
+  "checksum": "596b5831e5adc0c0cef33395d5b896bb2c3596283f5b85292db77f2f5e801186",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,9 @@ tokio = { version = "1.45.1", features = ["full", "test-util"] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 uuid = { version = "1.17.0", features = ["v4"] }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
This sets panic=abort for the cdylib when built via Gradle. This mirrors our setup with Bazel

Fixes BIT-5715