### PR TITLE
[Android] Add optional context parameter to Capture.start

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -70,7 +70,7 @@ internal class LoggerImpl(
     dateProvider: DateProvider,
     private val errorHandler: ErrorHandler = ErrorHandler(),
     sessionStrategy: SessionStrategy,
-    context: Context = ContextHolder.APP_CONTEXT,
+    context: Context,
     clientAttributes: ClientAttributes =
         ClientAttributes(
             context,
@@ -109,7 +109,7 @@ internal class LoggerImpl(
     init {
         val duration =
             measureTime {
-                setUpInternalLogging()
+                setUpInternalLogging(context)
 
                 CaptureJniLibrary.load()
 
@@ -121,8 +121,8 @@ internal class LoggerImpl(
                         .addQueryParameter("utm_source", "sdk")
                         .build()
 
-                val networkAttributes = NetworkAttributes(ContextHolder.APP_CONTEXT)
-                val deviceAttributes = DeviceAttributes(ContextHolder.APP_CONTEXT)
+                val networkAttributes = NetworkAttributes(context)
+                val deviceAttributes = DeviceAttributes(context)
 
                 metadataProvider =
                     MetadataProvider(
@@ -520,8 +520,8 @@ internal class LoggerImpl(
      */
     @Suppress("SpreadOperator")
     @SuppressLint("PrivateApi")
-    private fun setUpInternalLogging() {
-        if (BuildTypeChecker.isDebuggable(ContextHolder.APP_CONTEXT)) {
+    private fun setUpInternalLogging(context: Context) {
+        if (BuildTypeChecker.isDebuggable(context)) {
             val defaultLevel = "info"
             runCatching {
                 // TODO(murki): Alternatively we could use JVM -D arg to pass properties

--- a/platform/jvm/gradle-test-app/src/main/AndroidManifest.xml
+++ b/platform/jvm/gradle-test-app/src/main/AndroidManifest.xml
@@ -16,6 +16,19 @@
 
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge"
+            >
+            <!-- Disable automatic initialization of Bitdrift ContextHolder -->
+            <meta-data
+                android:name="io.bitdrift.capture.ContextHolder"
+                tools:node="remove"
+                />
+        </provider>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
@@ -7,6 +7,8 @@
 
 package io.bitdrift.gradletestapp;
 
+import android.content.Context;
+
 import io.bitdrift.capture.Capture;
 import io.bitdrift.capture.Configuration;
 import io.bitdrift.capture.providers.FieldProvider;
@@ -24,7 +26,8 @@ public class BitdriftInit {
             HttpUrl apiUrl,
             String apiKey,
             SessionStrategy sessionStrategy,
-            Configuration configuration) {
+            Configuration configuration,
+            Context context) {
         String userID = UUID.randomUUID().toString();
         List<FieldProvider> fieldProviders = new ArrayList<>();
         fieldProviders.add(() -> {
@@ -39,7 +42,8 @@ public class BitdriftInit {
             configuration,
             fieldProviders,
             null,
-            apiUrl
+            apiUrl,
+            context
         );
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -116,6 +116,7 @@ class GradleTestApp : Application() {
             sharedPreferences.getString(BITDRIFT_API_KEY, ""),
             getSessionStrategy(),
             configuration,
+            this
         )
         // Timber
         if (BuildConfig.DEBUG) {


### PR DESCRIPTION
## What

Adding optional context to Capture.Logger.start, this is useful for starts called on ContentProviders, etc 

Similar to https://github.com/bitdriftlabs/capture-sdk/pull/308

## Verification

Updated Gradle Test app to prevent default AppContext initialization and initialize SDK with the context passed in

See session https://timeline.bitdrift.dev/s/a70c6f8d-149f-4305-911b-b61a55aefb82?utm_source=sdk