### PR TITLE
ci(android): ensure microbenchmark target builds

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -248,6 +248,9 @@ jobs:
     - name: Check Licenses for modules
       working-directory: ./platform/jvm
       run: ./gradlew replay:checkLicense common:checkLicense # capture:checkLicense doesn't work at the moment
+    - name: Build Microbenchmark target
+      working-directory: ./platform/jvm
+      run: ./gradlew microbenchmark:assembleAndroidTest
     - name: Instrumentation Tests
       uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # pin@v2.33
       with:


### PR DESCRIPTION
Resolves BIT-5767

Related to https://github.com/bitdriftlabs/capture-sdk/pull/487