### PR TITLE
[Android] Minor improvements

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -330,7 +330,7 @@ jobs:
   # job completing, we are able to gate it on all the previous jobs without explicitly enumerating them.
   verify_android:
     runs-on: ubuntu-latest
-    needs: ["pre_check", "build_and_compare_apk", "verify_android_hello_world_per_version", "gradle_tests"]
+    needs: ["pre_check", "gradle_tests", "build_and_compare_apk", "verify_android_hello_world_per_version"]
     if: always()
     steps:
     # Checkout repo to Github Actions runner

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -11,6 +11,7 @@ import io.bitdrift.capture.error.IErrorReporter
 import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
+import java.util.concurrent.atomic.AtomicReference
 
 // We use our own type here instead of a builtin function to allow us to avoid proguard-rewriting this class.
 
@@ -26,12 +27,22 @@ interface StackTraceProvider {
 
 @Suppress("UndocumentedPublicClass")
 internal object CaptureJniLibrary : IBridge {
+
+    private val isLoaded: AtomicReference<Boolean> = AtomicReference(false)
+
     /**
      * Loads the shared library. This is safe to call multiple times.
      */
     fun load() {
-        System.loadLibrary("capture")
+        if (isLoaded.compareAndSet(false, true)) {
+            System.loadLibrary("capture")
+        }
     }
+
+    /**
+     * Returns true if the library is already loaded
+     */
+    fun isLoaded(): Boolean = isLoaded.get()
 
     /**
      * Creates a new logger, returning a handle that can be used to interact with the logger.


### PR DESCRIPTION
- Expose CaptureJniLibrary.isLoaded
- c.i. improvements. Run first `gradle_tests` over `build_and_compare_apk` given that build_and_compare buils on bazel and takes way consideable time. gradle_tests also has some compilation checks recently added 