### PR TITLE
[Android] Adding Architecture, supported ABIs to reports

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
@@ -39,6 +39,14 @@ internal class ClientAttributes(
             }
         }
 
+    val supportedAbis: List<String>
+        get() = Build.SUPPORTED_ABIS.toList()
+
+    val architecture: String
+        get() {
+            return supportedAbis.firstOrNull() ?: "unknown"
+        }
+
     @Suppress("SwallowedException")
     private val packageInfo: PackageInfo? =
         try {
@@ -63,6 +71,8 @@ internal class ClientAttributes(
             // A positive integer used as an internal version number.
             // This number helps determine whether one version is more recent than another.
             "_app_version_code" to appVersionCode.toString(),
+            // The current architecture e.g. (arm64-v8a)
+            "_architecture" to architecture,
         )
 
     private fun isForeground(): String {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
@@ -19,6 +19,7 @@ import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.attributes.ClientAttributes
 import junit.framework.TestCase.assertEquals
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
@@ -36,22 +37,27 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
 class ClientAttributesTest {
+    private lateinit var appContext: Context
+
+    @Before
+    fun setUp() {
+        appContext = ApplicationProvider.getApplicationContext()
+    }
+
     @Test
     fun foreground() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
 
-        val clientAttributes = ClientAttributes(context, mockedLifecycleOwnerLifecycleStateStarted).invoke()
+        val clientAttributes = ClientAttributes(appContext, mockedLifecycleOwnerLifecycleStateStarted).invoke()
 
         assertThat(clientAttributes).containsEntry("foreground", "1")
     }
 
     @Test
     fun not_foreground() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         val mockedLifecycleOwnerLifecycleStateCreated = obtainMockedLifecycleOwnerWith(Lifecycle.State.CREATED)
 
-        val clientAttributes = ClientAttributes(context, mockedLifecycleOwnerLifecycleStateCreated).invoke()
+        val clientAttributes = ClientAttributes(appContext, mockedLifecycleOwnerLifecycleStateCreated).invoke()
 
         assertThat(clientAttributes).containsEntry("foreground", "0")
     }
@@ -59,7 +65,7 @@ class ClientAttributesTest {
     @Test
     fun app_id() {
         val packageName = "my.bitdrift.test"
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         doReturn(packageName).`when`(context).packageName
         val mockedLifecycleOwnerLifecycleStateStarted =
             obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -71,7 +77,7 @@ class ClientAttributesTest {
 
     @Test
     fun app_id_unknown() {
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         doReturn(null).`when`(context).packageName
         val mockedLifecycleOwnerLifecycleStateStarted =
             obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -84,7 +90,7 @@ class ClientAttributesTest {
     @Test
     fun app_version() {
         val versionName = "1.2.3.4"
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val mockedPackageInfo = obtainMockedPackageInfo(context)
         mockedPackageInfo.versionName = versionName
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -96,10 +102,9 @@ class ClientAttributesTest {
 
     @Test
     fun app_version_unknown() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
 
-        val clientAttributes = ClientAttributes(context, mockedLifecycleOwnerLifecycleStateStarted).invoke()
+        val clientAttributes = ClientAttributes(appContext, mockedLifecycleOwnerLifecycleStateStarted).invoke()
 
         assertThat(clientAttributes).containsEntry("app_version", "?.?.?")
     }
@@ -107,7 +112,7 @@ class ClientAttributesTest {
     @Test
     fun app_version_code() {
         val versionCode = 66
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val mockedPackageInfo = obtainMockedPackageInfo(context)
         mockedPackageInfo.versionCode = versionCode
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -119,7 +124,7 @@ class ClientAttributesTest {
 
     @Test
     fun app_version_code_unknown() {
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val packageManager = obtainMockedPackageManager(context)
         doReturn(null).`when`(packageManager).getPackageInfo(anyString(), eq(0))
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -133,7 +138,7 @@ class ClientAttributesTest {
     @Config(sdk = [28])
     fun app_version_code_android_pie() {
         val versionCode = 66L
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val mockedPackageInfo = obtainMockedPackageInfo(context)
         doReturn(versionCode).`when`(mockedPackageInfo).longVersionCode
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -146,7 +151,7 @@ class ClientAttributesTest {
     @Test
     @Config(sdk = [28])
     fun app_version_code_unknown_android_pie() {
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val packageManager = obtainMockedPackageManager(context)
         doReturn(null).`when`(packageManager).getPackageInfo(anyString(), eq(0))
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
@@ -159,7 +164,7 @@ class ClientAttributesTest {
     @Test
     @Config(sdk = [33])
     fun package_info_android_tiramisu() {
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val packageManager = obtainMockedPackageManager(context)
         val mockedLifecycleOwnerLifecycleStateStarted = obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED)
 
@@ -208,6 +213,16 @@ class ClientAttributesTest {
         assertInstallationSource(hasValidInstallationSource, expectedInstallationSource)
     }
 
+    @Test
+    fun architecture_withStartedLifecycle_shouldReturnArm() {
+        val clientAttributes =
+            ClientAttributes(appContext, obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED))
+
+        val fields = clientAttributes.invoke()
+
+        assertThat(fields).containsEntry("_architecture", "armeabi-v7a")
+    }
+
     private fun assertInstallationSource(
         hasValidInstallationSource: Boolean,
         expectedInstallationSource: String,
@@ -215,7 +230,7 @@ class ClientAttributesTest {
     ) {
         val errorHandler: ErrorHandler = mock()
 
-        val context = spy(ApplicationProvider.getApplicationContext<Context>())
+        val context = spy(appContext)
         val installerSourceName =
             if (isDebugBuild) {
                 "Debug build installation"

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterProcessorTest.kt
@@ -16,6 +16,8 @@ import com.nhaarman.mockitokotlin2.verify
 import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.fakes.FakeJvmException
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.createTraceInputStream
+import io.bitdrift.capture.reports.binformat.v1.Architecture
+import io.bitdrift.capture.reports.binformat.v1.Platform
 import io.bitdrift.capture.reports.binformat.v1.Report
 import io.bitdrift.capture.reports.binformat.v1.ReportType
 import io.bitdrift.capture.reports.persistence.IFatalIssueReporterStorage
@@ -83,7 +85,7 @@ class FatalIssueReporterProcessorTest {
             "persistJvmCrash_withFakeException_shouldCreateNonEmptyErrorModel",
         )
         assertThat(error.stackTrace(0)!!.sourceFile!!.path).isEqualTo("FatalIssueReporterProcessorTest.kt")
-        assertThat(error.stackTrace(0)!!.sourceFile!!.line).isEqualTo(56)
+        assertThat(error.stackTrace(0)!!.sourceFile!!.line).isEqualTo(58)
         assertThat(error.stackTrace(0)!!.sourceFile!!.column).isEqualTo(0)
     }
 
@@ -357,6 +359,12 @@ class FatalIssueReporterProcessorTest {
         assertThat(binaryImage).isNotNull
         assertThat(binaryImage?.path).isEqualTo("/apex/com.android.runtime/lib64/bionic/libc.so")
         assertThat(binaryImage?.id).isEqualTo("a87908b48b368e6282bcc9f34bcfc28c")
+
+        val deviceMetrics = report.deviceMetrics
+        assertThat(deviceMetrics).isNotNull
+        assertThat(deviceMetrics?.platform).isEqualTo(Platform.Android)
+        assertThat(deviceMetrics?.arch).isEqualTo(Architecture.arm32)
+        assertThat(deviceMetrics?.cpuAbis(0)).isEqualTo("armeabi-v7a")
     }
 
     @Test


### PR DESCRIPTION
## What

Resolves BIT-5777, BIT-5246

Adding architecture, cpuAbis to Reports

## Verification

[timeline session](https://timeline.bitdrift.dev/session/87c72347-ff73-4bb3-be27-b7c6052f0b57?utm_source=sdk&pages=1&utilization=0&expanded=2241004306869461929 )

<img width="654" height="231" alt="image" src="https://github.com/user-attachments/assets/c1a8b5bb-d7e0-436a-86de-db502a748bf4" />
