### PR TITLE
enable relr for android build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -81,7 +81,6 @@ build:release-android --android_platforms=@rules_android//:armeabi-v7a,@rules_an
 build:release-android --config=release-common
 build:release-android --copt=-flto=thin --linkopt=-flto=thin
 build:release-android --config=android
-build:release-android --linkopt=-Wl,--dead_strip
 build:release-android --linkopt=-Wl,--pack-dyn-relocs=android
 # build:release-android --linkopt=-Wl,--use-android-relr-tags
 


### PR DESCRIPTION
Per https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#relr-and-relocation-packing this is safe now that we are targeting min version 24