### PR TITLE
[Android] Add another generic ANR to gradle test app

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FatalIssueGenerator.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FatalIssueGenerator.kt
@@ -10,10 +10,12 @@
 package io.bitdrift.gradletestapp
 
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -26,12 +28,7 @@ import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.subjects.BehaviorSubject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
@@ -63,6 +60,18 @@ internal object FatalIssueGenerator {
         callOnMainThread {
             val aResultWillNeverGet = uuidSubject.blockingFirst()
             Log.e(TAG_NAME, aResultWillNeverGet)
+        }
+    }
+
+    fun forceGenericAnr(context: Context) {
+        callOnMainThread {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val activityManager: ActivityManager =
+                    context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                activityManager.appNotResponding("Generic ANR triggered")
+            }else{
+                Log.e(TAG_NAME, "Triggering generic ANR not available on this API level")
+            }
         }
     }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -263,6 +263,7 @@ class FirstFragment : Fragment() {
             AppExitReason.ANR_BROADCAST_RECEIVER -> FatalIssueGenerator.forceBroadcastReceiverAnr(view.context)
             AppExitReason.ANR_COROUTINES -> FatalIssueGenerator.forceCoroutinesAnr()
             AppExitReason.ANR_DEADLOCK -> FatalIssueGenerator.forceDeadlockAnr()
+            AppExitReason.ANR_GENERIC -> FatalIssueGenerator.forceGenericAnr(view.context)
             AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueGenerator.forceThreadSleepAnr()
             AppExitReason.APP_CRASH_COROUTINE_EXCEPTION -> FatalIssueGenerator.forceCoroutinesCrash()
             AppExitReason.APP_CRASH_REGULAR_JVM_EXCEPTION -> FatalIssueGenerator.forceUnhandledException()
@@ -286,6 +287,7 @@ class FirstFragment : Fragment() {
         ANR_BROADCAST_RECEIVER,
         ANR_COROUTINES,
         ANR_DEADLOCK,
+        ANR_GENERIC,
         ANR_SLEEP_MAIN_THREAD,
         APP_CRASH_COROUTINE_EXCEPTION,
         APP_CRASH_REGULAR_JVM_EXCEPTION,

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -79,6 +79,7 @@ import timber.log.Timber
 import java.util.concurrent.Executors
 import kotlin.random.Random
 import kotlin.time.DurationUnit
+import kotlin.time.measureTime
 import kotlin.time.toDuration
 
 /**
@@ -314,14 +315,22 @@ class GradleTestApp : Application() {
 
     private fun setupCrashSdks() {
         val bugSnagApiKey = sharedPreferences.getString(BUG_SNAG_SDK_API_KEY, "")
-        if(!bugSnagApiKey.isNullOrEmpty()){
-            Bugsnag.start(this, bugSnagApiKey)
+        if (!bugSnagApiKey.isNullOrEmpty()) {
+            val bugSnagStartTime = measureTime {
+                Bugsnag.start(this, bugSnagApiKey)
+            }
+            Timber.i("Bugsnag.start() took ${bugSnagStartTime.inWholeMilliseconds} ms")
         }
 
         val sentryKey = sharedPreferences.getString(SENTRY_SDK_DSN_KEY, "")
-        SentryAndroid.init(this) { options: SentryAndroidOptions ->
-            options.dsn = sentryKey
-            options.isEnabled = !sentryKey.isNullOrEmpty();
+        if (!sentryKey.isNullOrEmpty()) {
+            val sentryStartTime = measureTime {
+                SentryAndroid.init(this) { options: SentryAndroidOptions ->
+                    options.dsn = sentryKey
+                    options.isEnabled = true
+                }
+            }
+            Timber.i("SentryAndroid.init() took ${sentryStartTime.inWholeMilliseconds} ms")
         }
     }
 }


### PR DESCRIPTION
## What

Adding another generic ANR to gradle test app

Also adding a log for vendor crash reporting libraries init time (if configured via API keys)

## Session

Vendor init time https://timeline.bitdrift.dev/session/f2e2531c-df83-487a-9859-ed0a61cf4f95?utm_source=sdk&pages=1&utilization=0&expanded=-2110746614877349815&stacktrace=open

Report https://explorations.bitdrift.dev/issues/10916070037627890839/cb80e6b5-1c94-41dd-8a49-d0328524fafd?utm_source=sdk