### PR TITLE
[andr] Move expensive operations on start to a bg thread

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -130,11 +130,11 @@ internal class LoggerImpl(
                         // order of providers matters in here, the earlier in the list the higher their priority in
                         // case of key conflicts.
                         ootbFieldProviders =
-                            listOf(
-                                clientAttributes,
-                                networkAttributes,
-                                deviceAttributes,
-                            ),
+                        listOf(
+                            clientAttributes,
+                            networkAttributes,
+                            deviceAttributes,
+                        ),
                         errorHandler = errorHandler,
                         customFieldProviders = fieldProviders,
                     )
@@ -263,8 +263,9 @@ internal class LoggerImpl(
                 CaptureJniLibrary.startLogger(this.loggerId)
             }
 
+        val captureStartThread = Thread.currentThread().name
         eventListenerDispatcher.executorService.execute {
-            writeSdkStartLog(context, clientAttributes, initDuration = duration)
+            writeSdkStartLog(context, clientAttributes, duration, captureStartThread)
         }
     }
 
@@ -389,15 +390,15 @@ internal class LoggerImpl(
         try {
             val expectedPreviousProcessSessionId =
                 when (attributesOverrides) {
-                    is LogAttributesOverrides.SessionID -> attributesOverrides.expectedPreviousProcessSessionId
+                    is LogAttributesOverrides.SessionID  -> attributesOverrides.expectedPreviousProcessSessionId
                     is LogAttributesOverrides.OccurredAt -> null
-                    else -> null
+                    else                                 -> null
                 }
             val occurredAtTimestampMs: Long =
                 when (attributesOverrides) {
-                    is LogAttributesOverrides.SessionID -> attributesOverrides.occurredAtTimestampMs
+                    is LogAttributesOverrides.SessionID  -> attributesOverrides.occurredAtTimestampMs
                     is LogAttributesOverrides.OccurredAt -> attributesOverrides.occurredAtTimestampMs
-                    else -> 0
+                    else                                 -> 0
                 }
 
             CaptureJniLibrary.writeLog(
@@ -490,6 +491,7 @@ internal class LoggerImpl(
         appContext: Context,
         clientAttributes: ClientAttributes,
         initDuration: Duration,
+        captureStartThread: String,
     ) {
         val installationSource =
             clientAttributes
@@ -501,7 +503,7 @@ internal class LoggerImpl(
                 putAll(
                     mapOf(
                         "_app_installation_source" to installationSource,
-                        "_capture_start_thread" to Thread.currentThread().name.toFieldValue(),
+                        "_capture_start_thread" to captureStartThread.toFieldValue(),
                     ),
                 )
                 putAll(fatalIssueReporter.getLogStatusFieldsMap())

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -130,11 +130,11 @@ internal class LoggerImpl(
                         // order of providers matters in here, the earlier in the list the higher their priority in
                         // case of key conflicts.
                         ootbFieldProviders =
-                        listOf(
-                            clientAttributes,
-                            networkAttributes,
-                            deviceAttributes,
-                        ),
+                            listOf(
+                                clientAttributes,
+                                networkAttributes,
+                                deviceAttributes,
+                            ),
                         errorHandler = errorHandler,
                         customFieldProviders = fieldProviders,
                     )
@@ -389,15 +389,15 @@ internal class LoggerImpl(
         try {
             val expectedPreviousProcessSessionId =
                 when (attributesOverrides) {
-                    is LogAttributesOverrides.SessionID  -> attributesOverrides.expectedPreviousProcessSessionId
+                    is LogAttributesOverrides.SessionID -> attributesOverrides.expectedPreviousProcessSessionId
                     is LogAttributesOverrides.OccurredAt -> null
-                    else                                 -> null
+                    else -> null
                 }
             val occurredAtTimestampMs: Long =
                 when (attributesOverrides) {
-                    is LogAttributesOverrides.SessionID  -> attributesOverrides.occurredAtTimestampMs
+                    is LogAttributesOverrides.SessionID -> attributesOverrides.occurredAtTimestampMs
                     is LogAttributesOverrides.OccurredAt -> attributesOverrides.occurredAtTimestampMs
-                    else                                 -> 0
+                    else -> 0
                 }
 
             CaptureJniLibrary.writeLog(

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -130,11 +130,11 @@ internal class LoggerImpl(
                         // order of providers matters in here, the earlier in the list the higher their priority in
                         // case of key conflicts.
                         ootbFieldProviders =
-                        listOf(
-                            clientAttributes,
-                            networkAttributes,
-                            deviceAttributes,
-                        ),
+                            listOf(
+                                clientAttributes,
+                                networkAttributes,
+                                deviceAttributes,
+                            ),
                         errorHandler = errorHandler,
                         customFieldProviders = fieldProviders,
                     )
@@ -390,15 +390,15 @@ internal class LoggerImpl(
         try {
             val expectedPreviousProcessSessionId =
                 when (attributesOverrides) {
-                    is LogAttributesOverrides.SessionID  -> attributesOverrides.expectedPreviousProcessSessionId
+                    is LogAttributesOverrides.SessionID -> attributesOverrides.expectedPreviousProcessSessionId
                     is LogAttributesOverrides.OccurredAt -> null
-                    else                                 -> null
+                    else -> null
                 }
             val occurredAtTimestampMs: Long =
                 when (attributesOverrides) {
-                    is LogAttributesOverrides.SessionID  -> attributesOverrides.occurredAtTimestampMs
+                    is LogAttributesOverrides.SessionID -> attributesOverrides.occurredAtTimestampMs
                     is LogAttributesOverrides.OccurredAt -> attributesOverrides.occurredAtTimestampMs
-                    else                                 -> 0
+                    else -> 0
                 }
 
             CaptureJniLibrary.writeLog(

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -121,7 +121,7 @@ internal class LoggerImpl(
                         .addQueryParameter("utm_source", "sdk")
                         .build()
 
-                val networkAttributes = NetworkAttributes(context, eventListenerDispatcher.executorService)
+                val networkAttributes = NetworkAttributes(context)
                 val deviceAttributes = DeviceAttributes(context)
 
                 metadataProvider =

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
@@ -41,11 +41,13 @@ import android.telephony.TelephonyManager.NETWORK_TYPE_UNKNOWN
 import androidx.core.content.ContextCompat
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.Fields
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
 
 @SuppressLint("MissingPermission")
 internal class NetworkAttributes(
     private val context: Context,
+    executor: ExecutorService,
 ) : ConnectivityManager.NetworkCallback(),
     FieldProvider {
     @SuppressLint("InlinedApi")
@@ -76,7 +78,9 @@ internal class NetworkAttributes(
     private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     init {
-        monitorNetworkType()
+        executor.execute {
+            monitorNetworkType()
+        }
     }
 
     override fun invoke(): Fields =
@@ -100,7 +104,6 @@ internal class NetworkAttributes(
             } catch (e: Throwable) {
                 // Issue with some versions of Android: https://issuetracker.google.com/issues/175055271
                 // can sometime throw an exception: "package does not belong to 10006"
-                // We'll also exercise this path when api level < 23
                 updateNetworkType(NetworkCapabilities(null))
             }
         }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
@@ -75,8 +75,12 @@ internal class NetworkAttributes(
             NETWORK_TYPE_UNKNOWN to "unknown",
         )
     private val currentNetworkType: AtomicReference<String> = AtomicReference("unknown")
-    private val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
-    private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val telephonyManager by lazy {
+        context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+    }
+    private val connectivityManager by lazy {
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    }
 
     init {
         executor.execute {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
@@ -41,13 +41,14 @@ import android.telephony.TelephonyManager.NETWORK_TYPE_UNKNOWN
 import androidx.core.content.ContextCompat
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.Fields
+import io.bitdrift.capture.threading.CaptureDispatchers
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
 
 @SuppressLint("MissingPermission")
 internal class NetworkAttributes(
     private val context: Context,
-    executor: ExecutorService,
+    executor: ExecutorService = CaptureDispatchers.CommonBackground.executorService,
 ) : ConnectivityManager.NetworkCallback(),
     FieldProvider {
     @SuppressLint("InlinedApi")

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/NetworkAttributesTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/NetworkAttributesTest.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.verify
 import io.bitdrift.capture.attributes.NetworkAttributes
 import org.assertj.core.api.Assertions.assertThat
@@ -34,7 +35,7 @@ class NetworkAttributesTest {
     fun carrier() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val networkAttributes = NetworkAttributes(context).invoke()
+        val networkAttributes = NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         assertThat(networkAttributes).containsEntry("carrier", "")
     }
@@ -44,7 +45,7 @@ class NetworkAttributesTest {
         grantPermissions(Manifest.permission.ACCESS_NETWORK_STATE)
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val networkAttributes = NetworkAttributes(context).invoke()
+        val networkAttributes = NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         assertThat(networkAttributes).containsEntry("network_type", "wwan")
     }
@@ -53,7 +54,7 @@ class NetworkAttributesTest {
     fun network_type_access_network_state_not_granted() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val networkAttributes = NetworkAttributes(context).invoke()
+        val networkAttributes = NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         assertThat(networkAttributes).containsEntry("network_type", "unknown")
     }
@@ -66,7 +67,7 @@ class NetworkAttributesTest {
         val mockedActiveNetwork = obtainMockedActiveNetwork(mockedConnectivityManager)
         doReturn(null).`when`(mockedConnectivityManager).getNetworkCapabilities(eq(mockedActiveNetwork))
 
-        val networkAttributes = NetworkAttributes(context).invoke()
+        val networkAttributes = NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         assertThat(networkAttributes).containsEntry("network_type", "unknown")
     }
@@ -77,7 +78,7 @@ class NetworkAttributesTest {
         val context = spy(ApplicationProvider.getApplicationContext<Context>())
         val mockedConnectivityManager = obtainMockedConnectivityManager(context)
 
-        NetworkAttributes(context).invoke()
+        NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         verify(mockedConnectivityManager).registerDefaultNetworkCallback(
             any(ConnectivityManager.NetworkCallback::class.java),
@@ -89,7 +90,7 @@ class NetworkAttributesTest {
         grantPermissions(Manifest.permission.READ_PHONE_STATE)
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val networkAttributes = NetworkAttributes(context).invoke()
+        val networkAttributes = NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         assertThat(networkAttributes).containsEntry("radio_type", "unknown")
     }
@@ -98,7 +99,7 @@ class NetworkAttributesTest {
     fun radio_type_read_phone_state_not_granted() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
-        val networkAttributes = NetworkAttributes(context).invoke()
+        val networkAttributes = NetworkAttributes(context, MoreExecutors.newDirectExecutorService()).invoke()
 
         assertThat(networkAttributes).containsEntry("radio_type", "forbidden")
     }


### PR DESCRIPTION
Tackling mainly:
- [x] `monitorNetworkType()` (went from 9.70% to 0.79%)
- [x] `writeSdkStartLog()` (went from 2.27% to 0%)

This should make `start()` perform 11.18% faster

|Before|After|
|---|---|
|<img width="2204" height="934" alt="Screenshot 2025-07-17 at 9 59 14 AM (1)" src="https://github.com/user-attachments/assets/425a6433-b843-4ca7-b703-d85c8fe8e1e0" />|<img width="1139" height="421" alt="Screenshot 2025-07-17 at 12 36 30 PM" src="https://github.com/user-attachments/assets/474fc06a-4ac4-404a-b386-4fd211def9d4" />|

Session example testing the `SDKConfigured` log with the right `network_type` value: https://timeline.bitdrift.dev/session/fda02916-f33f-4365-8262-94d6132b2266?utm_source=sdk&pages=1&utilization=0&h=3450357454420969661
<img width="1883" height="574" alt="Screenshot 2025-07-17 at 1 17 22 PM" src="https://github.com/user-attachments/assets/3532158a-49af-4ca0-84e0-627ad2ea4828" />

After the change this is the threading structure:
```
connectivityManager operations called in thread=io.bitdrift.capture.background-thread-worker
updateNetworkType() callback called in thread=io.bitdrift.capture.background-thread-worker
updateNetworkType() callback called in thread=ConnectivityThread
writeSdkStartLog() called in thread=io.bitdrift.capture.background-thread-worker
```