### PR TITLE
[Android] Add native load duration to Capture SDK start log

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -31,6 +31,8 @@ interface StackTraceProvider {
 @Suppress("UndocumentedPublicClass")
 internal object CaptureJniLibrary : IBridge {
     private val isAlreadyLoaded = AtomicBoolean(false)
+
+    @Volatile
     private var loadDuration: Duration? = null
 
     /**
@@ -50,12 +52,7 @@ internal object CaptureJniLibrary : IBridge {
      * Returns the native library duration in milliseconds if previously loaded via
      * CaptureJniLibrary.load() call.
      */
-    fun getLoadDurationInMillis(): String? =
-        if (!isAlreadyLoaded.get()) {
-            null
-        } else {
-            loadDuration?.toDouble(DurationUnit.MILLISECONDS)?.toString()
-        }
+    fun getLoadDurationInMillis(): String? = loadDuration?.toDouble(DurationUnit.MILLISECONDS)?.toString()
 
     /**
      * Creates a new logger, returning a handle that can be used to interact with the logger.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -16,8 +16,6 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.measureTime
 
-private const val LOAD_DURATION_NOT_AVAILABLE: String = "n/a"
-
 // We use our own type here instead of a builtin function to allow us to avoid proguard-rewriting this class.
 
 /**
@@ -49,15 +47,14 @@ internal object CaptureJniLibrary : IBridge {
     }
 
     /**
-     * Returns the native library duration in milliseconds.
-     *
-     * NOTE: Will return "n/a", if there wasn't any prior call to CaptureJniLibrary.load()
+     * Returns the native library duration in milliseconds if previously loaded via
+     * CaptureJniLibrary.load() call.
      */
-    fun getLoadDurationInMillis(): String =
+    fun getLoadDurationInMillis(): String? =
         if (!isAlreadyLoaded.get()) {
-            LOAD_DURATION_NOT_AVAILABLE
+            null
         } else {
-            loadDuration?.toDouble(DurationUnit.MILLISECONDS)?.toString() ?: LOAD_DURATION_NOT_AVAILABLE
+            loadDuration?.toDouble(DurationUnit.MILLISECONDS)?.toString()
         }
 
     /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -29,7 +29,7 @@ interface StackTraceProvider {
 
 @Suppress("UndocumentedPublicClass")
 internal object CaptureJniLibrary : IBridge {
-    private val loadDuration: AtomicReference<Double?> = AtomicReference(null)
+    private val loadDurationInMilli: AtomicReference<Double?> = AtomicReference(null)
 
     /**
      * Loads the shared library. This is safe to call multiple times.
@@ -39,14 +39,14 @@ internal object CaptureJniLibrary : IBridge {
             measureTime {
                 System.loadLibrary("capture")
             }
-        loadDuration.compareAndSet(null, duration.toDouble(DurationUnit.MILLISECONDS))
+        loadDurationInMilli.compareAndSet(null, duration.toDouble(DurationUnit.MILLISECONDS))
     }
 
     /**
      * Returns the native library duration in milliseconds if previously loaded via
      * CaptureJniLibrary.load() call.
      */
-    fun getLoadDurationInMillis(): String? = loadDuration.get()?.toString()
+    fun getLoadDurationInMillis(): String? = loadDurationInMilli.get()?.toString()
 
     /**
      * Creates a new logger, returning a handle that can be used to interact with the logger.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -12,7 +12,6 @@ import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.measureTime
 
@@ -30,7 +29,7 @@ interface StackTraceProvider {
 
 @Suppress("UndocumentedPublicClass")
 internal object CaptureJniLibrary : IBridge {
-    private val loadDuration: AtomicReference<Duration?> = AtomicReference(null)
+    private val loadDuration: AtomicReference<Double?> = AtomicReference(null)
 
     /**
      * Loads the shared library. This is safe to call multiple times.
@@ -40,14 +39,14 @@ internal object CaptureJniLibrary : IBridge {
             measureTime {
                 System.loadLibrary("capture")
             }
-        loadDuration.compareAndSet(null, duration)
+        loadDuration.compareAndSet(null, duration.toDouble(DurationUnit.MILLISECONDS))
     }
 
     /**
      * Returns the native library duration in milliseconds if previously loaded via
      * CaptureJniLibrary.load() call.
      */
-    fun getLoadDurationInMillis(): String? = loadDuration.get()?.toDouble(DurationUnit.MILLISECONDS)?.toString()
+    fun getLoadDurationInMillis(): String? = loadDuration.get()?.toString()
 
     /**
      * Creates a new logger, returning a handle that can be used to interact with the logger.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -502,10 +502,12 @@ internal class LoggerImpl(
             buildMap {
                 put("_app_installation_source", installationSource)
                 put("_capture_start_thread", captureStartThread.toFieldValue())
-                put(
-                    "_native_load_duration_ms",
-                    CaptureJniLibrary.getLoadDurationInMillis().toFieldValue(),
-                )
+                CaptureJniLibrary.getLoadDurationInMillis()?.let {
+                    put(
+                        "_native_load_duration_ms",
+                        it.toFieldValue(),
+                    )
+                }
                 putAll(fatalIssueReporter.getLogStatusFieldsMap())
             }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -500,11 +500,11 @@ internal class LoggerImpl(
 
         val sdkStartFields =
             buildMap {
-                putAll(
-                    mapOf(
-                        "_app_installation_source" to installationSource,
-                        "_capture_start_thread" to captureStartThread.toFieldValue(),
-                    ),
+                put("_app_installation_source", installationSource)
+                put("_capture_start_thread", captureStartThread.toFieldValue())
+                put(
+                    "_native_load_duration_ms",
+                    CaptureJniLibrary.getLoadDurationInMillis().toFieldValue(),
                 )
                 putAll(fatalIssueReporter.getLogStatusFieldsMap())
             }


### PR DESCRIPTION
## What

Resolves BIT-5887 (See [related context](https://bitdrift.slack.com/archives/C058ZD2M2CQ/p1753180710509879?thread_ts=1752696297.259089&cid=C058ZD2M2CQ) )

Adds another duration field for native load to the `SDKConfigured` log. This will help breaking down on production the overall `Capture.Logger.start` time

## Verification

Verified on these sessions:

- [gradle test app session](https://timeline.bitdrift.dev/session/e04fbe48-5922-4f28-b4f3-f207b2f34c18?utm_source=sdk&pages=1&utilization=0&expanded=-7944603258184882928) with the GradleTest sample app

<img width="348" height="27" alt="image" src="https://github.com/user-attachments/assets/4895e9be-9e09-4a10-9b03-aa328b317b1a" />

<img width="349" height="28" alt="image" src="https://github.com/user-attachments/assets/7f4db075-a3d9-437b-9a30-73feeeea0c6d" />

- [bazel release test app](https://timeline.bitdrift.dev/session/5f2bd465-a012-4fe0-b7fb-b374df283eb2?utm_source=sdk&pages=1&utilization=0&expanded=5496365138251104009)

<img width="365" height="31" alt="image" src="https://github.com/user-attachments/assets/3216ecdf-68c1-4ebd-90a3-643283bc9a04" />

<img width="392" height="33" alt="image" src="https://github.com/user-attachments/assets/af951feb-49df-45de-8c39-03829bc3f6f2" />




