### PR TITLE
[Android] Add putAllNonNull extensions

### DIFF
--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.robolectric)
     testImplementation(libs.mockwebserver)
+
+    detektPlugins(project(":detekt-custom-rules"))
 }
 
 protobuf {

--- a/platform/jvm/capture/detekt.yml
+++ b/platform/jvm/capture/detekt.yml
@@ -6,3 +6,6 @@ comments:
     active: true
   UndocumentedPublicClass:
     active: true
+bitdrift-custom-rules:
+  UnsafePutAllUsage:
+    active: true

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/error/ErrorReporterService.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/error/ErrorReporterService.kt
@@ -32,6 +32,7 @@ internal class ErrorReporterService(
         return map
     }
 
+    @Suppress("UnsafePutAllUsage")
     override fun reportError(
         message: String,
         details: String?,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
@@ -66,6 +66,7 @@ internal class SessionReplayTarget(
         sessionReplayController.captureScreen(skipReplayComposeViews)
     }
 
+    @Suppress("UnsafePutAllUsage")
     override fun onScreenCaptured(
         encodedScreen: ByteArray,
         screen: FilteredCapture,
@@ -84,6 +85,7 @@ internal class SessionReplayTarget(
         sessionReplayController.captureScreenshot()
     }
 
+    @Suppress("UnsafePutAllUsage")
     override fun onScreenshotCaptured(
         compressedScreen: ByteArray,
         metrics: ScreenshotCaptureMetrics,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -167,6 +167,7 @@ internal class AppExitLogger(
         return error
     }
 
+    @Suppress("UnsafePutAllUsage")
     private fun buildCrashAndMemoryFieldsMap(
         thread: Thread,
         throwable: Throwable,
@@ -182,6 +183,7 @@ internal class AppExitLogger(
         }.toFields()
     }
 
+    @Suppress("UnsafePutAllUsage")
     @RequiresApi(Build.VERSION_CODES.R)
     private fun buildAppExitInternalFieldsMap(applicationExitInfo: ApplicationExitInfo): InternalFieldsMap =
         buildMap {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -198,6 +198,7 @@ internal class JankStatsMonitor(
         performanceMetricsStateHolder = null
     }
 
+    @Suppress("UnsafePutAllUsage")
     @WorkerThread
     private fun FrameData.sendJankFrameData() {
         val jankFrameType = toJankType()

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTarget.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutorService
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
+@Suppress("UnsafePutAllUsage")
 internal class ResourceUtilizationTarget(
     private val memoryMetricsProvider: IMemoryMetricsProvider,
     private val batteryMonitor: BatteryMonitor,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/span/Span.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/span/Span.kt
@@ -13,6 +13,7 @@ import io.bitdrift.capture.LogType
 import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.common.DefaultClock
 import io.bitdrift.capture.common.IClock
+import io.bitdrift.capture.common.putAllSafely
 import io.bitdrift.capture.providers.toFields
 import java.util.UUID
 
@@ -63,9 +64,7 @@ class Span internal constructor(
     private val startTimeMs: Long = clock.elapsedRealtime()
     private val startFields: Map<String, String> =
         buildMap {
-            fields?.let {
-                putAll(it)
-            }
+            putAllSafely(fields)
             put(SpanField.Key.ID, id.toString())
             put(SpanField.Key.NAME, name)
             put(SpanField.Key.TYPE, SpanField.Value.TYPE_START)
@@ -112,10 +111,8 @@ class Span internal constructor(
 
             val endFields =
                 buildMap {
-                    putAll(startFields)
-                    fields?.let {
-                        putAll(it)
-                    }
+                    putAllSafely(startFields)
+                    putAllSafely(fields)
                     put(SpanField.Key.TYPE, SpanField.Value.TYPE_END)
                     put(SpanField.Key.DURATION, durationMs.toString())
                     put(SpanField.Key.RESULT, result.toString().lowercase())

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpRequestInfo.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/HttpRequestInfo.kt
@@ -23,6 +23,7 @@ internal object HttpFieldKey {
 /**
  * Class that encapsulates network request information. method param is required, rest are optional
  */
+@Suppress("UnsafePutAllUsage")
 data class HttpRequestInfo
     @JvmOverloads
     constructor(

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MapExtensions.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/MapExtensions.kt
@@ -1,0 +1,32 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture.common
+
+/**
+ * Handles potential Java Interop issues where a Map with null key values could
+ * be passed in Java. Below a Java example where kotlin will see message value as non-null
+ * (See also BIT-5914)
+ *
+ *  IllegalStateException exception = new IllegalStateException();
+ *  HashMap<String, String> fields = new HashMap<>();
+ *  fields.put("exception_message", exception.getMessage()); // exception.getMessage will return null
+ *
+ * NOTE: Suppressing warning about null-checks that appear redundant because
+ * Kotlin's compiler assumes non-null keys/values, but in practice,
+ * due to Java interop, null values may still appear in the map.
+ */
+@Suppress("SENSELESS_COMPARISON")
+fun MutableMap<String, String>.putAllSafely(fields: Map<String, String>?) {
+    if (fields == null) return
+    for (entry in fields.entries) {
+        val key = entry.key
+        val value = entry.value
+        if (key != null && value != null) {
+            this[key] = value
+        }
+    }
+}

--- a/platform/jvm/detekt-custom-rules/build.gradle.kts
+++ b/platform/jvm/detekt-custom-rules/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+}
+
+group = "io.bitdrift.capture"
+version = "1.0.0"
+
+dependencies {  
+    implementation(libs.detekt.api)
+}

--- a/platform/jvm/detekt-custom-rules/src/main/kotlin/io/bitdrift/capture/CustomRuleProvider.kt
+++ b/platform/jvm/detekt-custom-rules/src/main/kotlin/io/bitdrift/capture/CustomRuleProvider.kt
@@ -1,0 +1,28 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+/**
+ * Entry point for custom bitdrift detekt rules
+ */
+class CustomRuleProvider : RuleSetProvider {
+    override val ruleSetId: String = "bitdrift-custom-rules"
+
+    override fun instance(config: Config): RuleSet {
+        return RuleSet(
+            id = ruleSetId,
+            rules = listOf(
+                UnsafeMutableMapPutAllRule(config)
+                // Append more custom rules as needed here
+            )
+        )
+    }
+}

--- a/platform/jvm/detekt-custom-rules/src/main/kotlin/io/bitdrift/capture/UnsafeMutableMapPutAllRule.kt
+++ b/platform/jvm/detekt-custom-rules/src/main/kotlin/io/bitdrift/capture/UnsafeMutableMapPutAllRule.kt
@@ -1,0 +1,55 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+
+/**
+ * Prevents relying mutableMap.putAll as could lead to runtime crashes if a map passed into
+ * Map<String,String> is passed into
+ * is created from Java call site with null values.
+ *
+ * Suggestion will be to use MapExtensionsKt.putAllSafe(it)
+ *
+ * For more info check BIT-5914
+ */
+class UnsafeMutableMapPutAllRule(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        id = "UnsafePutAllUsage",
+        severity = Severity.Warning,
+        description = "Avoid unsafe putAll usage on MutableMap; Java interop may allow nulls through.",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (expression.calleeExpression?.text != "putAll") return
+        val receiver =
+            (expression.parent as? KtDotQualifiedExpression)?.receiverExpression ?: return
+        val receiverType = bindingContext.getType(receiver) ?: return
+        val fqName = receiverType.constructor.declarationDescriptor?.fqNameUnsafe?.asString()
+        if (fqName == "kotlin.collections.MutableMap") {
+            report(
+                CodeSmell(
+                    issue,
+                    Entity.from(expression),
+                    message = "Calling putAll() on a mutable map may risk null values from Java interop. Use putAllSafe() instead."
+                )
+            )
+        }
+    }
+}

--- a/platform/jvm/detekt-custom-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/platform/jvm/detekt-custom-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+io.bitdrift.capture.CustomRuleProvider

--- a/platform/jvm/gradle/libs.versions.toml
+++ b/platform/jvm/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ appcompat = "1.7.0"
 assertjCore = "3.22.0"
 androidxCore = "1.13.1"
 androidxTestCore = "1.6.1"
+detektApi = "1.23.8"
 detektPlugin = "1.23.7"
 dokkaPlugin = "1.9.20"
 gson = "2.10.1"
@@ -41,6 +42,7 @@ androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTes
 androidx-ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
 apollo-runtime = { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertjCore" }
+detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detektApi" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 junit = { module = "junit:junit", version.ref = "junit" }

--- a/platform/jvm/settings.gradle.kts
+++ b/platform/jvm/settings.gradle.kts
@@ -20,6 +20,7 @@ include(":gradle-test-app")
 
 include(":microbenchmark")
 
+include(":detekt-custom-rules")
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
## Problem

Resolves BIT-5914

Prevents potential runtime crashes given a map could be passed from Java call site with null values.

For example this call will produce a NPE on java site

```
IllegalStateException exception = new IllegalStateException();
HashMap<String, String> fields = new HashMap<>();
fields.put("exception_message", exception.getMessage());
Capture.Logger.logDebug(
        fields,
        exception,
        () -> "Sample message"
        );
```

## Solution

1. Add extension method that internally will check for key/value being null for the case listed above
2. Added a custom detekt rule to prevent further non-safe usages of mutableMap.putAll(fields) in the future


## Verification
1. Verify there are no runtime crashes with the snippet below added into the GradleTestApp. 

```
IllegalStateException exception = new IllegalStateException();
HashMap<String, String> fields = new HashMap<>();
fields.put("exception_message", exception.getMessage());
Capture.Logger.logDebug(
        fields,
        exception,
        () -> "Sample message"
        );
```
        
2. Verify that the custom rules only detekt issues on mutableMap.putAll calls

Will paste screenshot
        