### PR TITLE
[Android] Prevent interopt crash for toFields

### DIFF
--- a/bazel/android/build.bzl
+++ b/bazel/android/build.bzl
@@ -46,6 +46,8 @@ def bitdrift_kt_android_local_test(name, deps = [], jvm_flags = [], **kwargs):
 
         deps = [":_{}_lib".format(name)]
 
+    java_test_files = native.glob(["src/test/**/*.java"], allow_empty = True)
+
     # Robolectric does some class loader magic which doesn't work well with loading a static
     # library. To get around this, we create one test target per source file to avoid multiple
     # class loaders being used. An alternative to this that we might consider is to avoid loading
@@ -59,7 +61,7 @@ def bitdrift_kt_android_local_test(name, deps = [], jvm_flags = [], **kwargs):
             deps = deps + ["//bazel/android:test_suite_lib"],
             manifest = "//platform/jvm:AndroidManifest.xml",
             jvm_flags = jvm_flags + ["-Dcapture_api_url=https://localhost:1234"],
-            srcs = [s],
+            srcs = [s] + java_test_files,
             **kwargs
         )
 

--- a/platform/jvm/capture/BUILD.bazel
+++ b/platform/jvm/capture/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_java//java:defs.bzl", "java_lite_proto_library")
-load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
@@ -14,14 +13,6 @@ java_lite_proto_library(
     name = "tombstone_proto_java_lite",
     visibility = ["//visibility:public"],
     deps = [":tombstone_proto"],
-)
-
-java_library(
-    name = "java_test_utils",
-    srcs = glob(
-        include = ["src/test/**/*.java"],
-    ),
-    visibility = ["//visibility:public"],
 )
 
 # export proguard library rules
@@ -91,7 +82,6 @@ bitdrift_kt_android_local_test(
         "exclusive",
     ],
     deps = [
-        ":java_test_utils",
         "//platform/jvm/capture:capture_logger_lib",
         artifact("junit:junit"),
         artifact("org.robolectric:robolectric"),

--- a/platform/jvm/capture/BUILD.bazel
+++ b/platform/jvm/capture/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_lite_proto_library")
+load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
@@ -13,6 +14,14 @@ java_lite_proto_library(
     name = "tombstone_proto_java_lite",
     visibility = ["//visibility:public"],
     deps = [":tombstone_proto"],
+)
+
+java_library(
+    name = "java_test_utils",
+    srcs = glob(
+        include = ["src/test/**/*.java"],
+    ),
+    visibility = ["//visibility:public"],
 )
 
 # export proguard library rules
@@ -82,6 +91,7 @@ bitdrift_kt_android_local_test(
         "exclusive",
     ],
     deps = [
+        ":java_test_utils",
         "//platform/jvm/capture:capture_logger_lib",
         artifact("junit:junit"),
         artifact("org.robolectric:robolectric"),

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
@@ -118,8 +118,19 @@ internal fun Pair<String, String>.toField(): Pair<String, FieldValue> = Pair(thi
 
 /**
  * Converts a Map<String, String> into a List<Field>.
+ *
+ * NOTE: Suppresses null-check warnings due to possible nulls from Java interop.
+ *
  */
-internal fun Map<String, String>?.toFields(): Map<String, FieldValue> =
-    this?.entries?.associate {
-        it.key to it.value.toFieldValue()
-    } ?: emptyMap()
+@Suppress("SENSELESS_COMPARISON")
+internal fun Map<String, String>?.toFields(): Map<String, FieldValue> {
+    if (this == null) return emptyMap()
+
+    val result = HashMap<String, FieldValue>(size)
+    for ((key, value) in this) {
+        if (key != null && value != null) {
+            result[key] = value.toFieldValue()
+        }
+    }
+    return result
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FieldProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FieldProviderTest.kt
@@ -7,9 +7,8 @@
 
 package io.bitdrift.capture
 
-import io.bitdrift.capture.providers.FieldValue
-import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.utils.JavaMapInteroptIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -17,31 +16,10 @@ class FieldProviderTest {
     @Test
     fun toFields_withJavaNullableValueMap_shouldNotCrash() {
         val mapWithNullValue: Map<String, String> =
-            io.bitdrift.capture.utils.JavaMapInteroptIssue
-                .buildMapWithNullableValue()
+            JavaMapInteroptIssue.buildMapWithNullableValue()
 
         val convertedFields = mapWithNullValue.toFields()
 
         assertThat(convertedFields).isEmpty()
     }
-
-    @Test(expected = NullPointerException::class)
-    fun nonSafeToFields_withJavaNullableValueMap_shouldExpectNpe() {
-        val mapWithNullValue: Map<String, String> =
-            io.bitdrift.capture.utils.JavaMapInteroptIssue
-                .buildMapWithNullableValue()
-
-        /**
-         * This should throw NPE. See BIT-5914 for more context on original issue
-         */
-        mapWithNullValue.toFieldsNonSafe()
-    }
-
-    /**
-     * Do not use in prod, only for test purposes
-     */
-    private fun Map<String, String>?.toFieldsNonSafe(): Map<String, FieldValue> =
-        this?.entries?.associate {
-            it.key to it.value.toFieldValue()
-        } ?: emptyMap()
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FieldProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FieldProviderTest.kt
@@ -1,0 +1,47 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+import io.bitdrift.capture.providers.FieldValue
+import io.bitdrift.capture.providers.toFieldValue
+import io.bitdrift.capture.providers.toFields
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class FieldProviderTest {
+    @Test
+    fun toFields_withJavaNullableValueMap_shouldNotCrash() {
+        val mapWithNullValue: Map<String, String> =
+            io.bitdrift.capture.utils.JavaMapInteroptIssue
+                .buildMapWithNullableValue()
+
+        val convertedFields = mapWithNullValue.toFields()
+
+        assertThat(convertedFields).isEmpty()
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun nonSafeToFields_withJavaNullableValueMap_shouldExpectNpe() {
+        val mapWithNullValue: Map<String, String> =
+            io.bitdrift.capture.utils.JavaMapInteroptIssue
+                .buildMapWithNullableValue()
+
+        /**
+         * This should throw NPE. See BIT-5914 for more context on original issue
+         */
+        mapWithNullValue.toFieldsNonSafe()
+    }
+
+    /**
+     * Do not use in prod, only for test purposes
+     */
+    private fun Map<String, String>?.toFieldsNonSafe(): Map<String, FieldValue> =
+        this?.entries?.associate {
+            it.key to it.value.toFieldValue()
+        } ?: emptyMap()
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/JavaMapInteroptIssue.java
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/JavaMapInteroptIssue.java
@@ -1,0 +1,31 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builds a map to be consumed by FieldProvider.toFields extension method to replicate potential
+ * interopt issue
+ */
+public class JavaMapInteroptIssue {
+
+    /**
+     * Create a map with a null value for interopt issue with kotlin
+     *
+     * For more context see BIT-5914
+     *
+     * @return Map
+     */
+    public static Map<String, String> buildMapWithNullableValue() {
+        final IllegalStateException exception = new IllegalStateException();
+        final HashMap<String, String> fields = new HashMap<>();
+        fields.put("exception_message", exception.getMessage());
+        return fields;
+    }
+}


### PR DESCRIPTION
## What

Resolves BIT-5914

Prevents potential NPE if a map with null key/value is constructed via Java and passed into Capture.Logger calls

## Verification

Verified with JUnit test with existing call and updated one. See [initial commit for demo](https://github.com/bitdriftlabs/capture-sdk/pull/519/commits/6302e3cb4ee1d6012f3d3e5ac9baa0d49323c947)

Temporary add this method call to GradleTestApp. App should not crash

<img width="690" height="526" alt="image" src="https://github.com/user-attachments/assets/cd2202ba-6650-4d82-bd46-469402be359d" />
