### PR TITLE
[Android] Improvements on SDKConfigured duration

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -510,9 +510,9 @@ object Capture {
         context: Context?,
     ) {
         try {
-            val appContext = context?.applicationContext ?: ContextHolder.APP_CONTEXT
+            val startSdkTimer = TimeSource.Monotonic.markNow()
 
-            val wholeDurationTimer = TimeSource.Monotonic.markNow()
+            val appContext = context?.applicationContext ?: ContextHolder.APP_CONTEXT
 
             val clientAttributes =
                 ClientAttributes(
@@ -549,7 +549,7 @@ object Capture {
 
             val sdkConfiguredDuration =
                 SdkConfiguredDuration(
-                    wholeStartDuration = wholeDurationTimer.elapsedNow(),
+                    wholeStartDuration = startSdkTimer.elapsedNow(),
                     nativeLoadDuration = nativeLoadDuration,
                     loggerImplBuildDuration = loggerImplBuildDuration,
                 )

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -11,9 +11,6 @@ import io.bitdrift.capture.error.IErrorReporter
 import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.DurationUnit
-import kotlin.time.measureTime
 
 // We use our own type here instead of a builtin function to allow us to avoid proguard-rewriting this class.
 
@@ -29,24 +26,12 @@ interface StackTraceProvider {
 
 @Suppress("UndocumentedPublicClass")
 internal object CaptureJniLibrary : IBridge {
-    private val loadDurationInMilli: AtomicReference<Double?> = AtomicReference(null)
-
     /**
      * Loads the shared library. This is safe to call multiple times.
      */
     fun load() {
-        val duration =
-            measureTime {
-                System.loadLibrary("capture")
-            }
-        loadDurationInMilli.compareAndSet(null, duration.toDouble(DurationUnit.MILLISECONDS))
+        System.loadLibrary("capture")
     }
-
-    /**
-     * Returns the native library duration in milliseconds if previously loaded via
-     * CaptureJniLibrary.load() call.
-     */
-    fun getLoadDurationInMillis(): String? = loadDurationInMilli.get()?.toString()
 
     /**
      * Creates a new logger, returning a handle that can be used to interact with the logger.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ErrorHandler.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ErrorHandler.kt
@@ -15,12 +15,6 @@ import io.bitdrift.capture.common.ErrorHandler
  * unexpected failures.
  */
 internal class ErrorHandler : ErrorHandler {
-    init {
-        // Make sure this is loaded before we call into CaptureJniLibrary. Generally this should
-        // already have been loaded.
-        CaptureJniLibrary.load()
-    }
-
     /**
      * Handles a single error.
      * @param detail a string identifying the action that resulted in an error.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -55,7 +55,6 @@ import okhttp3.HttpUrl
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-import kotlin.time.measureTime
 
 typealias LoggerId = Long
 internal typealias InternalFieldsList = List<Field>
@@ -71,7 +70,7 @@ internal class LoggerImpl(
     private val errorHandler: ErrorHandler = ErrorHandler(),
     sessionStrategy: SessionStrategy,
     context: Context,
-    clientAttributes: ClientAttributes =
+    private val clientAttributes: ClientAttributes =
         ClientAttributes(
             context,
             ProcessLifecycleOwner.get(),
@@ -107,166 +106,156 @@ internal class LoggerImpl(
     internal val loggerId: LoggerId
 
     init {
-        val duration =
-            measureTime {
-                setUpInternalLogging(context)
+        setUpInternalLogging(context)
 
-                CaptureJniLibrary.load()
+        this.sessionUrlBase =
+            HttpUrl
+                .Builder()
+                .scheme("https")
+                .host(apiUrl.host.replaceFirst("api.", "timeline."))
+                .addQueryParameter("utm_source", "sdk")
+                .build()
 
-                this.sessionUrlBase =
-                    HttpUrl
-                        .Builder()
-                        .scheme("https")
-                        .host(apiUrl.host.replaceFirst("api.", "timeline."))
-                        .addQueryParameter("utm_source", "sdk")
-                        .build()
+        val networkAttributes = NetworkAttributes(context)
+        val deviceAttributes = DeviceAttributes(context)
 
-                val networkAttributes = NetworkAttributes(context)
-                val deviceAttributes = DeviceAttributes(context)
-
-                metadataProvider =
-                    MetadataProvider(
-                        dateProvider = dateProvider,
-                        // order of providers matters in here, the earlier in the list the higher their priority in
-                        // case of key conflicts.
-                        ootbFieldProviders =
-                            listOf(
-                                clientAttributes,
-                                networkAttributes,
-                                deviceAttributes,
-                            ),
-                        errorHandler = errorHandler,
-                        customFieldProviders = fieldProviders,
-                    )
-
-                val network =
-                    OkHttpNetwork(
-                        apiBaseUrl = apiUrl,
-                    )
-
-                val sdkDirectory = SdkDirectory.getPath(context)
-
-                val localErrorReporter =
-                    errorReporter ?: ErrorReporterService(
-                        listOf(clientAttributes),
-                        apiClient,
-                    )
-
-                diskUsageMonitor =
-                    DiskUsageMonitor(
-                        preferences,
-                        context,
-                    )
-                memoryMetricsProvider = MemoryMetricsProvider(activityManager)
-
-                resourceUtilizationTarget =
-                    ResourceUtilizationTarget(
-                        memoryMetricsProvider,
-                        batteryMonitor,
-                        powerMonitor,
-                        diskUsageMonitor,
-                        errorHandler,
-                        this,
-                        eventListenerDispatcher.executorService,
-                    )
-
-                this.sessionReplayTarget =
-                    SessionReplayTarget(
-                        configuration = configuration.sessionReplayConfiguration,
-                        errorHandler,
-                        context,
-                        logger = this,
-                        windowManager = windowManager,
-                    )
-
-                val loggerId =
-                    bridge.createLogger(
-                        sdkDirectory,
-                        apiKey,
-                        sessionStrategy.createSessionStrategyConfiguration { appExitSaveCurrentSessionId(it) },
-                        metadataProvider,
-                        // TODO(Augustyniak): Pass `resourceUtilizationTarget`, `sessionReplayTarget`,
-                        //  and `eventsListenerTarget` as part of `startLogger` method call instead.
-                        // Pass the event listener target here and finish setting up
-                        // before the logger is actually started.
-                        resourceUtilizationTarget,
-                        sessionReplayTarget,
-                        // Pass the event listener target here and finish setting up
-                        // before the logger is actually started.
-                        eventsListenerTarget,
-                        clientAttributes.appId,
-                        clientAttributes.appVersion,
-                        deviceAttributes.model(),
-                        network,
-                        preferences,
-                        localErrorReporter,
-                        configuration.sleepMode == SleepMode.ACTIVE,
-                    )
-
-                check(loggerId != -1L) { "initialization of the rust logger failed" }
-
-                this.loggerId = loggerId
-
-                runtime = JniRuntime(this.loggerId)
-                sessionReplayTarget.runtime = runtime
-                diskUsageMonitor.runtime = runtime
-                memoryMetricsProvider.runtime = runtime
-
-                eventsListenerTarget.add(
-                    AppLifecycleListenerLogger(
-                        this,
-                        ProcessLifecycleOwner.get(),
-                        activityManager,
-                        runtime,
-                        eventListenerDispatcher.executorService,
-                    ),
-                )
-
-                eventsListenerTarget.add(
-                    DeviceStateListenerLogger(
-                        this,
-                        context,
-                        batteryMonitor,
-                        powerMonitor,
-                        runtime,
-                        eventListenerDispatcher.executorService,
-                    ),
-                )
-
-                eventsListenerTarget.add(
-                    AppUpdateListenerLogger(
-                        this,
+        metadataProvider =
+            MetadataProvider(
+                dateProvider = dateProvider,
+                // order of providers matters in here, the earlier in the list the higher their priority in
+                // case of key conflicts.
+                ootbFieldProviders =
+                    listOf(
                         clientAttributes,
-                        context,
-                        runtime,
-                        eventListenerDispatcher.executorService,
+                        networkAttributes,
+                        deviceAttributes,
                     ),
-                )
+                errorHandler = errorHandler,
+                customFieldProviders = fieldProviders,
+            )
 
-                addJankStatsMonitorTarget(windowManager, context)
+        val network =
+            OkHttpNetwork(
+                apiBaseUrl = apiUrl,
+            )
 
-                appExitLogger =
-                    AppExitLogger(
-                        logger = this,
-                        activityManager,
-                        runtime,
-                        errorHandler,
-                        memoryMetricsProvider = memoryMetricsProvider,
-                        fatalIssueMechanism = fatalIssueReporter.getReportingMechanism(),
-                    )
+        val sdkDirectory = SdkDirectory.getPath(context)
 
-                // Install the app exit logger before the Capture logger is started to ensure
-                // that logs emitted during the installation are the first logs emitted by the
-                // Capture logger.
-                appExitLogger.installAppExitLogger()
+        val localErrorReporter =
+            errorReporter ?: ErrorReporterService(
+                listOf(clientAttributes),
+                apiClient,
+            )
 
-                CaptureJniLibrary.startLogger(this.loggerId)
-            }
+        diskUsageMonitor =
+            DiskUsageMonitor(
+                preferences,
+                context,
+            )
+        memoryMetricsProvider = MemoryMetricsProvider(activityManager)
 
-        val captureStartThread = Thread.currentThread().name
-        eventListenerDispatcher.executorService.execute {
-            writeSdkStartLog(context, clientAttributes, duration, captureStartThread)
-        }
+        resourceUtilizationTarget =
+            ResourceUtilizationTarget(
+                memoryMetricsProvider,
+                batteryMonitor,
+                powerMonitor,
+                diskUsageMonitor,
+                errorHandler,
+                this,
+                eventListenerDispatcher.executorService,
+            )
+
+        this.sessionReplayTarget =
+            SessionReplayTarget(
+                configuration = configuration.sessionReplayConfiguration,
+                errorHandler,
+                context,
+                logger = this,
+                windowManager = windowManager,
+            )
+
+        val loggerId =
+            bridge.createLogger(
+                sdkDirectory,
+                apiKey,
+                sessionStrategy.createSessionStrategyConfiguration { appExitSaveCurrentSessionId(it) },
+                metadataProvider,
+                // TODO(Augustyniak): Pass `resourceUtilizationTarget`, `sessionReplayTarget`,
+                //  and `eventsListenerTarget` as part of `startLogger` method call instead.
+                // Pass the event listener target here and finish setting up
+                // before the logger is actually started.
+                resourceUtilizationTarget,
+                sessionReplayTarget,
+                // Pass the event listener target here and finish setting up
+                // before the logger is actually started.
+                eventsListenerTarget,
+                clientAttributes.appId,
+                clientAttributes.appVersion,
+                deviceAttributes.model(),
+                network,
+                preferences,
+                localErrorReporter,
+                configuration.sleepMode == SleepMode.ACTIVE,
+            )
+
+        check(loggerId != -1L) { "initialization of the rust logger failed" }
+
+        this.loggerId = loggerId
+
+        runtime = JniRuntime(this.loggerId)
+        sessionReplayTarget.runtime = runtime
+        diskUsageMonitor.runtime = runtime
+        memoryMetricsProvider.runtime = runtime
+
+        eventsListenerTarget.add(
+            AppLifecycleListenerLogger(
+                this,
+                ProcessLifecycleOwner.get(),
+                activityManager,
+                runtime,
+                eventListenerDispatcher.executorService,
+            ),
+        )
+
+        eventsListenerTarget.add(
+            DeviceStateListenerLogger(
+                this,
+                context,
+                batteryMonitor,
+                powerMonitor,
+                runtime,
+                eventListenerDispatcher.executorService,
+            ),
+        )
+
+        eventsListenerTarget.add(
+            AppUpdateListenerLogger(
+                this,
+                clientAttributes,
+                context,
+                runtime,
+                eventListenerDispatcher.executorService,
+            ),
+        )
+
+        addJankStatsMonitorTarget(windowManager, context)
+
+        appExitLogger =
+            AppExitLogger(
+                logger = this,
+                activityManager,
+                runtime,
+                errorHandler,
+                memoryMetricsProvider = memoryMetricsProvider,
+                fatalIssueMechanism = fatalIssueReporter.getReportingMechanism(),
+            )
+
+        // Install the app exit logger before the Capture logger is started to ensure
+        // that logs emitted during the installation are the first logs emitted by the
+        // Capture logger.
+        appExitLogger.installAppExitLogger()
+
+        CaptureJniLibrary.startLogger(this.loggerId)
     }
 
     override val sessionId: String
@@ -488,35 +477,44 @@ internal class LoggerImpl(
         appExitLogger.uninstallAppExitLogger()
     }
 
-    private fun writeSdkStartLog(
+    internal data class SdkConfiguredDuration(
+        val wholeStartDuration: Duration,
+        val nativeLoadDuration: Duration,
+        val loggerImplBuildDuration: Duration,
+    )
+
+    /**
+     * Emits the SDKConfigured event with details about its duration, caller thread, etc
+     */
+    internal fun writeSdkStartLog(
         appContext: Context,
-        clientAttributes: ClientAttributes,
-        initDuration: Duration,
+        sdkConfiguredDuration: SdkConfiguredDuration,
         captureStartThread: String,
     ) {
-        val installationSource =
-            clientAttributes
-                .getInstallationSource(appContext, errorHandler)
-                .toFieldValue()
+        eventListenerDispatcher.executorService.execute {
+            val installationSource =
+                clientAttributes
+                    .getInstallationSource(appContext, errorHandler)
+                    .toFieldValue()
 
-        val sdkStartFields =
-            buildMap {
-                put("_app_installation_source", installationSource)
-                put("_capture_start_thread", captureStartThread.toFieldValue())
-                CaptureJniLibrary.getLoadDurationInMillis()?.let {
+            val sdkStartFields =
+                buildMap {
+                    put("_app_installation_source", installationSource)
+                    put("_capture_start_thread", captureStartThread.toFieldValue())
                     put(
                         "_native_load_duration_ms",
-                        it.toFieldValue(),
+                        sdkConfiguredDuration.nativeLoadDuration.toFieldValue(DurationUnit.MILLISECONDS),
                     )
+                    put("_logger_build_duration_ms", sdkConfiguredDuration.loggerImplBuildDuration.toFieldValue(DurationUnit.MILLISECONDS))
+                    putAll(fatalIssueReporter.getLogStatusFieldsMap())
                 }
-                putAll(fatalIssueReporter.getLogStatusFieldsMap())
-            }
 
-        CaptureJniLibrary.writeSDKStartLog(
-            this.loggerId,
-            sdkStartFields,
-            initDuration.toDouble(DurationUnit.SECONDS),
-        )
+            CaptureJniLibrary.writeSDKStartLog(
+                this.loggerId,
+                sdkStartFields,
+                sdkConfiguredDuration.wholeStartDuration.toDouble(DurationUnit.SECONDS),
+            )
+        }
     }
 
     /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
@@ -7,6 +7,9 @@
 
 package io.bitdrift.capture.providers
 
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
 /**
  * A single field.
  * @param key the field key.
@@ -110,6 +113,11 @@ internal fun ByteArray.toFieldValue() =
     with(this@toFieldValue) {
         FieldValue.BinaryField(this)
     }
+
+/**
+ * Converts a [Duration] into a [FieldValue] using the specified [DurationUnit].
+ */
+internal fun Duration.toFieldValue(durationUnit: DurationUnit): FieldValue = this.toDouble(durationUnit).toString().toFieldValue()
 
 /**
  * Converts a Map<String, String> into a List<Field>.

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -48,6 +48,7 @@ import java.util.Date
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 // This should return "2022-07-05T18:55:58.123Z" when formatted.
 private const val TEST_DATE_TIMESTAMP: Long = 1657047358123
@@ -461,16 +462,29 @@ class CaptureLoggerTest {
         sessionStrategy: SessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
     ): LoggerImpl {
         val fieldProviders = fieldProvider?.let { listOf(it) }.orEmpty()
-        return LoggerImpl(
-            apiKey = "test",
-            apiUrl = testServerUrl(),
-            fieldProviders = fieldProviders,
-            sessionStrategy = sessionStrategy,
-            context = ContextHolder.APP_CONTEXT,
-            dateProvider = dateProvider,
-            configuration = Configuration(),
-            fatalIssueReporter = fatalIssueReporter,
+        val loggerImpl =
+            LoggerImpl(
+                apiKey = "test",
+                apiUrl = testServerUrl(),
+                fieldProviders = fieldProviders,
+                sessionStrategy = sessionStrategy,
+                context = ContextHolder.APP_CONTEXT,
+                dateProvider = dateProvider,
+                configuration = Configuration(),
+                fatalIssueReporter = fatalIssueReporter,
+            )
+        val sdkConfiguredDuration =
+            LoggerImpl.SdkConfiguredDuration(
+                wholeStartDuration = Duration.ZERO,
+                nativeLoadDuration = Duration.ZERO,
+                loggerImplBuildDuration = Duration.ZERO,
+            )
+        loggerImpl.writeSdkStartLog(
+            appContext = ContextHolder.APP_CONTEXT,
+            sdkConfiguredDuration = sdkConfiguredDuration,
+            captureStartThread = Thread.currentThread().name,
         )
+        return loggerImpl
     }
 
     private fun getDefaultFields(): Map<String, FieldValue> =

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/FatalIssueReporterTest.kt
@@ -70,7 +70,9 @@ class FatalIssueReporterTest {
         assertThat(state).isInstanceOf(expectedType)
         val expectedMap: Map<String, FieldValue> =
             buildMap {
-                put("_fatal_issue_reporting_duration_ms", getDuration().toFieldValue())
+                getDuration()?.let {
+                    put("_fatal_issue_reporting_duration_ms", it)
+                }
                 put("_fatal_issue_reporting_state", state.readableType.toFieldValue())
             }
         assertThat(duration).isNotNull()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionStrategyTest.kt
@@ -37,30 +37,29 @@ class SessionStrategyTest {
     fun fixedSessionStrategy() {
         val generatedSessionIds = mutableListOf<String>()
 
-        val logger =
-            LoggerImpl(
-                apiKey = "test",
-                apiUrl = testServerUrl(),
-                fieldProviders = listOf(),
-                dateProvider = mock(),
-                context = ContextHolder.APP_CONTEXT,
-                sessionStrategy =
-                    SessionStrategy.Fixed {
-                        val sessionId = UUID.randomUUID().toString()
-                        generatedSessionIds.add(sessionId)
-                        sessionId
-                    },
-                configuration = Configuration(),
-                fatalIssueReporter = fatalIssueReporter,
-            )
+        Capture.Logger.start(
+            apiKey = "test",
+            apiUrl = testServerUrl(),
+            fieldProviders = listOf(),
+            dateProvider = mock(),
+            context = ContextHolder.APP_CONTEXT,
+            sessionStrategy =
+                SessionStrategy.Fixed {
+                    val sessionId = UUID.randomUUID().toString()
+                    generatedSessionIds.add(sessionId)
+                    sessionId
+                },
+            configuration = Configuration(),
+        )
 
-        val sessionId = logger.sessionId
+        val logger = Capture.logger()
+        val sessionId = logger?.sessionId
 
         assertThat(generatedSessionIds.count()).isEqualTo(1)
         assertThat(generatedSessionIds[0]).isEqualTo(sessionId)
 
-        logger.startNewSession()
-        val newSessionId = logger.sessionId
+        logger?.startNewSession()
+        val newSessionId = logger?.sessionId
 
         assertThat(generatedSessionIds.count()).isEqualTo(2)
         assertThat(generatedSessionIds[1]).isEqualTo(newSessionId)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
@@ -10,10 +10,9 @@ package io.bitdrift.capture
 import androidx.test.core.app.ApplicationProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
-import io.bitdrift.capture.reports.FatalIssueReporter
-import io.bitdrift.capture.reports.IFatalIssueReporter
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,8 +22,6 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
 class SessionUrlTest {
-    private val fatalIssueReporter: IFatalIssueReporter = FatalIssueReporter()
-
     @Before
     fun setUp() {
         val initializer = ContextHolder()
@@ -33,42 +30,47 @@ class SessionUrlTest {
 
     @Test
     fun testDefaultSessionUrl() {
-        val logger = createLogger("https://api.bitdrift.io")
-        assertThat(logger.sessionUrl).isEqualTo("https://timeline.bitdrift.io/s/${logger.sessionId}?utm_source=sdk")
+        val logger = startAndReturnLogger("https://api.bitdrift.io")
+        assertThat(logger?.sessionUrl).isEqualTo("https://timeline.bitdrift.io/s/${logger?.sessionId}?utm_source=sdk")
     }
 
     @Test
     fun testCustomSessionUrlWithPath() {
-        val logger = createLogger("https://api.api.mycompany.bitdrift.io/v1/path")
-        assertThat(logger.sessionUrl).isEqualTo("https://timeline.api.mycompany.bitdrift.io/s/${logger.sessionId}?utm_source=sdk")
+        val logger = startAndReturnLogger("https://api.api.mycompany.bitdrift.io/v1/path")
+        assertThat(logger?.sessionUrl).isEqualTo("https://timeline.api.mycompany.bitdrift.io/s/${logger?.sessionId}?utm_source=sdk")
     }
 
     @Test
     fun testCustomSessionUrl1() {
-        val logger = createLogger("https://api.api.mycompany.bitdrift.io")
-        assertThat(logger.sessionUrl).isEqualTo("https://timeline.api.mycompany.bitdrift.io/s/${logger.sessionId}?utm_source=sdk")
+        val logger = startAndReturnLogger("https://api.api.mycompany.bitdrift.io")
+        assertThat(logger?.sessionUrl).isEqualTo("https://timeline.api.mycompany.bitdrift.io/s/${logger?.sessionId}?utm_source=sdk")
     }
 
     @Test
     fun testCustomSessionUrl2() {
-        val logger = createLogger("https://api.myapicompany.bitdrift.io")
-        assertThat(logger.sessionUrl).isEqualTo("https://timeline.myapicompany.bitdrift.io/s/${logger.sessionId}?utm_source=sdk")
+        val logger = startAndReturnLogger("https://api.myapicompany.bitdrift.io")
+        assertThat(logger?.sessionUrl).isEqualTo("https://timeline.myapicompany.bitdrift.io/s/${logger?.sessionId}?utm_source=sdk")
     }
 
     @Test
     fun testCustomSessionUrl3() {
-        val logger = createLogger("https://api.companyapi.bitdrift.io")
-        assertThat(logger.sessionUrl).isEqualTo("https://timeline.companyapi.bitdrift.io/s/${logger.sessionId}?utm_source=sdk")
+        val logger = startAndReturnLogger("https://api.companyapi.bitdrift.io")
+        assertThat(logger?.sessionUrl).isEqualTo("https://timeline.companyapi.bitdrift.io/s/${logger?.sessionId}?utm_source=sdk")
     }
 
     @Test
     fun testInvalidApiUrl() {
-        val logger = createLogger("https://mycustomapiurl.com")
-        assertThat(logger.sessionUrl).isEqualTo("https://mycustomapiurl.com/s/${logger.sessionId}?utm_source=sdk")
+        val logger = startAndReturnLogger("https://mycustomapiurl.com")
+        assertThat(logger?.sessionUrl).isEqualTo("https://mycustomapiurl.com/s/${logger?.sessionId}?utm_source=sdk")
     }
 
-    private fun createLogger(apiUrl: String): LoggerImpl =
-        LoggerImpl(
+    @After
+    fun destroyLogger() {
+        Capture.Logger.resetShared()
+    }
+
+    private fun startAndReturnLogger(apiUrl: String): ILogger? {
+        Capture.Logger.start(
             apiKey = "test",
             apiUrl = apiUrl.toHttpUrl(),
             configuration = Configuration(),
@@ -76,6 +78,7 @@ class SessionUrlTest {
             context = ContextHolder.APP_CONTEXT,
             dateProvider = SystemDateProvider(),
             sessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
-            fatalIssueReporter = fatalIssueReporter,
         )
+        return Capture.logger()
+    }
 }

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/ClockTimeProfiler.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/ClockTimeProfiler.kt
@@ -15,6 +15,7 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import io.bitdrift.capture.Capture
+import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.attributes.IClientAttributes
@@ -52,6 +53,7 @@ class ClockTimeProfiler {
     @Test
     fun loggerStart() {
         benchmarkRule.measureRepeated {
+            CaptureJniLibrary.load()
             LoggerImpl(
                 apiKey = "android-benchmark-test",
                 apiUrl = "https://api-tests.bitdrift.io".toHttpUrl(),


### PR DESCRIPTION
## What

1. For SDKConfigured log we are only measuring duration_ms within internal init constructor block. In this case will be missing duration of other init logic within Capture.Logger.start call (so for example the overall duration_ms doesn't include fatal issue reporting if configured, evaluation and instantiation of constructor arguments or setting the atomic internal variables)

2. We are now loading the native library as part of start call to allow easier measurement and avoid duplicating init calls at LoggerImpl and ErrorHanlder

3. We were incorrectly reporting n/a when crash reporting wasn't configured. This aligns with [suggestion made](https://github.com/bitdriftlabs/capture-sdk/pull/516#discussion_r2222305956) by @kattrali  to not report that duration key at all if not valid

4. There is no need to report initialization thread for fatal issue given we are now initializing inside start call

So in summary SDKConfigured will have these fields related to duration/init

| Status | Field | Context
| -------| -----| --------|
| Existing | _duration_ms | The total duration of Capture.Logger.start internals. This now measures whole instantiation of LoggerImpl and start internals
| Existing | _capture_start_thread | This is the thread name where Capture.Logger.start took place 
| Removed | _fatal_reporter_init_thread | This is redundant given is included as part of _capture_start_thread
| Changed | _fatal_issue_reporting_duration_ms | Only applicable now when customer has configured crash reporting 
| New | _logger_build_duration_ms | The total duration of native logger instance (e.g. LoggerImpl instantiation)
| Existing | _logger_build_duration_ms | The total duration of native so load (e.g.  System.loadLibrary call)

## Verification

Compare the duration now accounts for whole start internals. 

| | main | PR |
| ----------| ------|------|
| Without previous ANR report | <img width="511" height="283" alt="image" src="https://github.com/user-attachments/assets/17a190f7-926e-491d-9bd9-1978e67d7ec5" /> | <img width="486" height="293" alt="image" src="https://github.com/user-attachments/assets/7b9e7c3f-0814-4efd-93c7-52825cf736f4" /> |
| With previous ANR report | <img width="499" height="289" alt="image" src="https://github.com/user-attachments/assets/c02bd795-19ad-44f5-9e23-2c960294eaab" /> | <img width="486" height="288" alt="image" src="https://github.com/user-attachments/assets/eb13d49f-19a0-4da5-848b-3c274923d162" />|
