### PR TITLE
Small optimization in LoggerImpl.extractFields

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -488,7 +488,10 @@ internal class LoggerImpl(
             }
         }
         throwable?.let {
-            extractedFields["_error"] = it.javaClass.name.orEmpty().toFieldValue()
+            extractedFields["_error"] =
+                it.javaClass.name
+                    .orEmpty()
+                    .toFieldValue()
             extractedFields["_error_details"] = it.message.orEmpty().toFieldValue()
         }
         return extractedFields

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -468,16 +468,31 @@ internal class LoggerImpl(
     internal fun extractFields(
         fields: Map<String, String>?,
         throwable: Throwable?,
-    ): InternalFieldsMap? =
-        buildMap {
-            fields?.let {
-                putAll(it)
+    ): InternalFieldsMap {
+        // Maintainer note: keep initialCapacity in sync with the code adding fields to the map.
+        val initialCapacity = (fields?.size ?: 0) + (throwable?.let { 2 } ?: 0)
+        if (initialCapacity == 0) {
+            // If throwable is null AND fields is either null or empty, no need to create a HashMap.
+            return emptyMap()
+        }
+        // Create a hashmap of the exact target size and with the right final value type, instead
+        // of creating a temporary map and then converting it with Map.toFields()
+        val extractedFields = HashMap<String, FieldValue>(initialCapacity)
+        fields?.let {
+            for ((key, value) in it) {
+                // Java interop: clients could have passed in null keys or values.
+                @Suppress("SENSELESS_COMPARISON")
+                if (key != null && value != null) {
+                    extractedFields[key] = value.toFieldValue()
+                }
             }
-            throwable?.let {
-                put("_error", it.javaClass.name.orEmpty())
-                put("_error_details", it.message.orEmpty())
-            }
-        }.toFields()
+        }
+        throwable?.let {
+            extractedFields["_error"] = it.javaClass.name.orEmpty().toFieldValue()
+            extractedFields["_error_details"] = it.message.orEmpty().toFieldValue()
+        }
+        return extractedFields
+    }
 
     internal fun flush(blocking: Boolean) {
         CaptureJniLibrary.flush(this.loggerId, blocking)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
@@ -119,7 +119,7 @@ internal fun ByteArray.toFieldValue() =
  */
 @Suppress("SENSELESS_COMPARISON")
 internal fun Map<String, String>?.toFields(): Map<String, FieldValue> {
-    if (this == null) return emptyMap()
+    if (isNullOrEmpty()) return emptyMap()
 
     val result = HashMap<String, FieldValue>(size)
     for ((key, value) in this) {


### PR DESCRIPTION
- In `LoggerImpl.extractFields`, skip creating a MapBuilder (capacity 8) and a HashMap(0) if throwable is null and fields is null or empty
- In `LoggerImpl.extractFields`, skip creating a MapBuilder AND a HashMap for every log with fields, directly create the target HashMap with the right capacity.
- In `Map.toFields()`, skip creating a HashMap(0) is map is empty.