### PR TITLE
Prevent ci failures from forked repos

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -132,7 +132,7 @@ jobs:
           git worktree remove temp-worktree --force
 
       - name: Fetch APK size baseline from branch (PR only)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git fetch origin binary-size-baseline
           git worktree add temp-baseline origin/binary-size-baseline
@@ -140,7 +140,7 @@ jobs:
           git worktree remove temp-baseline --force
 
       - name: Compute and compare APK size
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         id: apk_size
         run: |
           APK_PATH=$(find bazel-bin/examples/android -name "android_app.apk" | head -n 1)


### PR DESCRIPTION
At the moment, forked repos can't post comments (e.g. apk size). See https://github.com/bitdriftlabs/capture-sdk/actions/runs/16567424226/job/46850978578?pr=529

For now skipping this step until we provide a token to run this on forked repos