### PR TITLE
[andr] Bump support to API 36 (Android 16)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ KOTLIN_STD_VERSION = KOTLIN_COMPILE_VERSION
 
 NDK_API_LEVEL = 21
 
-SDK_API_LEVEL = 35
+SDK_API_LEVEL = 36
 
 ####################
 # Bazel dependencies

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -524,7 +524,7 @@
     "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "NAy+0M15JNVEBb8Tny6t7j3lKqTnsAMjoBB6LJ+C370=",
-        "usagesDigest": "W+8syyFLk94cueK2fcfPjuVHZ1ii2/3RjuNzn3Z3vVI=",
+        "usagesDigest": "ub4KGmkmDByybraYL+KDWQyaftUT9fwi/16EryjDh4A=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -532,7 +532,7 @@
           "androidsdk": {
             "repoRuleId": "@@rules_android+//rules/android_sdk_repository:rule.bzl%_android_sdk_repository",
             "attributes": {
-              "api_level": 35,
+              "api_level": 36,
               "build_tools_version": "",
               "path": ""
             }

--- a/platform/jvm/AndroidManifest.xml
+++ b/platform/jvm/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="24"
-        android:targetSdkVersion="35"
+        android:targetSdkVersion="36"
         />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/platform/jvm/capture-apollo/build.gradle.kts
+++ b/platform/jvm/capture-apollo/build.gradle.kts
@@ -15,7 +15,7 @@ group = "io.bitdrift"
 
 android {
     namespace = "io.bitdrift.capture.apollo"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/platform/jvm/capture-timber/build.gradle.kts
+++ b/platform/jvm/capture-timber/build.gradle.kts
@@ -15,7 +15,7 @@ group = "io.bitdrift"
 
 android {
     namespace = "io.bitdrift.capture.timber"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -59,7 +59,7 @@ protobuf {
 android {
     namespace = "io.bitdrift.capture"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/NetworkAttributes.kt
@@ -19,13 +19,7 @@ import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
 import android.net.NetworkCapabilities.TRANSPORT_ETHERNET
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.telephony.TelephonyManager
-import android.telephony.TelephonyManager.NETWORK_TYPE_1xRTT
-import android.telephony.TelephonyManager.NETWORK_TYPE_CDMA
 import android.telephony.TelephonyManager.NETWORK_TYPE_EDGE
-import android.telephony.TelephonyManager.NETWORK_TYPE_EHRPD
-import android.telephony.TelephonyManager.NETWORK_TYPE_EVDO_0
-import android.telephony.TelephonyManager.NETWORK_TYPE_EVDO_A
-import android.telephony.TelephonyManager.NETWORK_TYPE_EVDO_B
 import android.telephony.TelephonyManager.NETWORK_TYPE_GPRS
 import android.telephony.TelephonyManager.NETWORK_TYPE_GSM
 import android.telephony.TelephonyManager.NETWORK_TYPE_HSDPA
@@ -54,13 +48,7 @@ internal class NetworkAttributes(
     @SuppressLint("InlinedApi")
     private val radioTypeNameMap =
         hashMapOf(
-            NETWORK_TYPE_1xRTT to "onExRtt",
-            NETWORK_TYPE_CDMA to "cdma",
             NETWORK_TYPE_EDGE to "edge",
-            NETWORK_TYPE_EHRPD to "ehrpd",
-            NETWORK_TYPE_EVDO_0 to "evdo0",
-            NETWORK_TYPE_EVDO_A to "evdoA",
-            NETWORK_TYPE_EVDO_B to "evdoB",
             NETWORK_TYPE_GPRS to "gprs",
             NETWORK_TYPE_GSM to "gsm",
             NETWORK_TYPE_HSDPA to "hsdpa",

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/JvmCrashProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/JvmCrashProcessor.kt
@@ -35,12 +35,13 @@ internal object JvmCrashProcessor {
         val errors = buildErrors(builder, throwable)
         val threadList =
             allThreads?.map { (thread, frames) ->
-                val threadId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
-                    thread.threadId()
-                } else {
-                    @Suppress("deprecation")
-                    thread.id
-                }
+                val threadId =
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+                        thread.threadId()
+                    } else {
+                        @Suppress("deprecation")
+                        thread.id
+                    }
                 val threadStack = frames.map { e -> getFrameDetails(builder, e) }.toIntArray()
                 io.bitdrift.capture.reports.binformat.v1.Thread.createThread(
                     builder,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/JvmCrashProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/JvmCrashProcessor.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture.reports.processor
 
+import android.os.Build
 import com.google.flatbuffers.FlatBufferBuilder
 import io.bitdrift.capture.reports.binformat.v1.Error
 import io.bitdrift.capture.reports.binformat.v1.ErrorRelation
@@ -34,12 +35,18 @@ internal object JvmCrashProcessor {
         val errors = buildErrors(builder, throwable)
         val threadList =
             allThreads?.map { (thread, frames) ->
+                val threadId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+                    thread.threadId()
+                } else {
+                    @Suppress("deprecation")
+                    thread.id
+                }
                 val threadStack = frames.map { e -> getFrameDetails(builder, e) }.toIntArray()
                 io.bitdrift.capture.reports.binformat.v1.Thread.createThread(
                     builder,
                     builder.createString(thread.name),
                     thread == callerThread,
-                    thread.id.toUInt(),
+                    threadId.toUInt(),
                     builder.createString(thread.state.name),
                     thread.priority.toFloat(),
                     -1, // default value for quality of service (unused on Android)

--- a/platform/jvm/common/AndroidManifest.xml
+++ b/platform/jvm/common/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="24"
-        android:targetSdkVersion="35"
+        android:targetSdkVersion="36"
         />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/platform/jvm/common/build.gradle.kts
+++ b/platform/jvm/common/build.gradle.kts
@@ -11,7 +11,7 @@ group = "io.bitdrift"
 android {
     namespace = "io.bitdrift.capture.common"
 
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 
 android {
     namespace = "io.bitdrift.gradletestapp"
-    compileSdk = 35
+    compileSdk = 36
 
     buildFeatures {
         compose = true
@@ -65,7 +65,7 @@ android {
     defaultConfig {
         applicationId = "io.bitdrift.gradletestapp"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 66
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/platform/jvm/microbenchmark/build.gradle.kts
+++ b/platform/jvm/microbenchmark/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "io.bitdrift.microbenchmark"
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -25,7 +25,7 @@ android {
     }
 
     testOptions {
-        targetSdk = 35
+        targetSdk = 36
     }
 
     testBuildType = "release"

--- a/platform/jvm/replay/AndroidManifest.xml
+++ b/platform/jvm/replay/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="24"
-        android:targetSdkVersion="35"
+        android:targetSdkVersion="36"
         />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/platform/jvm/replay/build.gradle.kts
+++ b/platform/jvm/replay/build.gradle.kts
@@ -26,7 +26,7 @@ group = "io.bitdrift"
 android {
     namespace = "io.bitdrift.capture.replay"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/tools/android_sdk_wrapper.sh
+++ b/tools/android_sdk_wrapper.sh
@@ -34,8 +34,8 @@ readonly install_android_sdk_packages_command=(
   "--install"
   "platform-tools"
   "ndk;$ndk_version"
-  "platforms;android-35"
-  "build-tools;35.0.0"
+  "platforms;android-36"
+  "build-tools;36.0.0"
 )
 
 function download_android_sdk() {


### PR DESCRIPTION
Only meaningful change is thread.id deprecation.

Verifications:
gradle-test-app
- session: https://timeline.bitdrift.dev/session/6ecb0d66-651a-492f-93f0-5562019fd437
- crash: https://explorations.bitdrift.dev/issues/9071216148438387721/4d316b88-ecf6-4428-ba9f-8e06af629969
bazel hello-world
- session: https://timeline.bitdrift.dev/session/d38adcd3-7c40-4034-a858-e13d580e996c
- crash: https://explorations.bitdrift.dev/issues/13877890032708306952/09d11014-de09-47d5-8225-fe279d7dc256

Fixes BIT-5560