### PR TITLE
[Android] Prevent potential ConcurrentCrashModification

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -458,32 +458,37 @@ internal class LoggerImpl(
         fields: Map<String, String>?,
         throwable: Throwable?,
     ): InternalFieldsMap {
-        // Maintainer note: keep initialCapacity in sync with the code adding fields to the map.
-        val initialCapacity = (fields?.size ?: 0) + (throwable?.let { 2 } ?: 0)
-        if (initialCapacity == 0) {
-            // If throwable is null AND fields is either null or empty, no need to create a HashMap.
-            return emptyMap()
-        }
-        // Create a hashmap of the exact target size and with the right final value type, instead
-        // of creating a temporary map and then converting it with Map.toFields()
-        val extractedFields = HashMap<String, FieldValue>(initialCapacity)
-        fields?.let {
-            for ((key, value) in it) {
-                // Java interop: clients could have passed in null keys or values.
-                @Suppress("SENSELESS_COMPARISON")
-                if (key != null && value != null) {
-                    extractedFields[key] = value.toFieldValue()
+        return runCatching {
+            // Maintainer note: keep initialCapacity in sync with the code adding fields to the map.
+            val initialCapacity = (fields?.size ?: 0) + (throwable?.let { 2 } ?: 0)
+            if (initialCapacity == 0) {
+                // If throwable is null AND fields is either null or empty, no need to create a HashMap.
+                return emptyMap()
+            }
+            // Create a hashmap of the exact target size and with the right final value type, instead
+            // of creating a temporary map and then converting it with Map.toFields()
+            val extractedFields = HashMap<String, FieldValue>(initialCapacity)
+            fields?.let {
+                for ((key, value) in it) {
+                    // Java interop: clients could have passed in null keys or values.
+                    @Suppress("SENSELESS_COMPARISON")
+                    if (key != null && value != null) {
+                        extractedFields[key] = value.toFieldValue()
+                    }
                 }
             }
+            throwable?.let {
+                extractedFields["_error"] =
+                    it.javaClass.name
+                        .orEmpty()
+                        .toFieldValue()
+                extractedFields["_error_details"] = it.message.orEmpty().toFieldValue()
+            }
+            extractedFields
+        }.getOrElse {
+            errorHandler.handleError("extractFields error", it)
+            emptyMap()
         }
-        throwable?.let {
-            extractedFields["_error"] =
-                it.javaClass.name
-                    .orEmpty()
-                    .toFieldValue()
-            extractedFields["_error_details"] = it.message.orEmpty().toFieldValue()
-        }
-        return extractedFields
     }
 
     internal fun flush(blocking: Boolean) {


### PR DESCRIPTION
## What

Resolves BIT-5948

`LoggedImpl.extractFields()` could potentially throw a `ConcurrentModificationException`, given that it is currently used in the following places:

1) LoggerImpl log implementation 

```
override fun log(
    level: LogLevel,
    fields: Map<String, String>?,
    throwable: Throwable?,
    message: () -> String,
) {
    log(
        LogType.NORMAL,
        level,
        extractFields(fields, throwable), ----> Can crash here
        null,
        null,
        false,
        message,
    )
}

// Current internal LoggerImpl.log 
@JvmName("logFields")
@Suppress("TooGenericExceptionCaught")
internal fun log(
    type: LogType,
    level: LogLevel,
    fields: InternalFieldsMap? = null,
    matchingFields: InternalFieldsMap? = null,
    attributesOverrides: LogAttributesOverrides? = null,
    blocking: Boolean = false,
    message: () -> String,
) {
    if (type == LogType.INTERNALSDK && !runtime.isEnabled(RuntimeFeature.INTERNAL_LOGS)) {
        return
    }
    try {
        // ....
        CaptureJniLibrary.writeLog(
            this.loggerId,
            type.value,
            level.value,
            message(),
            fields ?: mapOf(),
            matchingFields ?: mapOf(),
            expectedPreviousProcessSessionId,
            occurredAtTimestampMs,
            blocking,
        )
    } catch (e: Throwable) {
        errorHandler.handleError("write log", e)
    }
}
```

2. SessionReplayTarget.kt

```
override fun logErrorInternal(
    message: String,
    e: Throwable?,
    fields: Map<String, String>?,
) {
    logger.log(LogType.INTERNALSDK, LogLevel.ERROR, logger.extractFields(fields, e)) { message }
}
```
## Verification

On the gradle test app, passed a map modified from different threads into Logger.debug call. See captured [crash reports here](https://explorations.bitdrift.dev/issues/3067057896427644325/61105c08-960e-4987-b564-5a61dd3ef210?index=0&range=1h )

See this session [session](https://timeline.bitdrift.dev/session/2ace06da-b548-4dcc-98c3-864b89b401e4?pages=1-2&utilization=0&expanded=-2434620287688361876) with crash prior to change.

After change, the error is sent via errorHandler and no crashing upon app launch occur. See [session](https://timeline.bitdrift.dev/session/2ace06da-b548-4dcc-98c3-864b89b401e4?pages=1-2&utilization=0&expanded=1436997519567066176)