### PR TITLE
Install NDK for release scripts

### DIFF
--- a/.github/workflows/example_apps_android.yaml
+++ b/.github/workflows/example_apps_android.yaml
@@ -1,3 +1,6 @@
+env:
+  NDK_VERSION: 27.2.12479018
+
 name: Build Android example apps
 on:
   workflow_dispatch:
@@ -36,6 +39,31 @@ jobs:
         distribution: 'zulu'
         java-version: '17'
         cache: gradle
+    - name: Cache Android NDK
+      id: ndk-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.ANDROID_SDK_ROOT }}/ndk/${{ env.NDK_VERSION }}
+        key: ${{ runner.os }}-android-ndk-${{ env.NDK_VERSION }}
+    - name: Verify cmdline-tools
+      run: |
+        CMDLINE_TOOLS_DIR="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+        if [ ! -x "$CMDLINE_TOOLS_DIR/sdkmanager" ]; then
+          echo "cmdline-tools not found or incomplete. Installing..."
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+          cd $ANDROID_SDK_ROOT/cmdline-tools
+          curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -o cmdline-tools.zip
+          unzip -q cmdline-tools.zip
+          mv cmdline-tools latest
+        else
+          echo "cmdline-tools already installed."
+        fi
+    - name: Install Android NDK
+      if: steps.ndk-cache.outputs.cache-hit != 'true'
+      run: |
+        export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH
+        yes | sdkmanager "ndk;${NDK_VERSION}"
+
     - name: Install Rust target
       run: rustup update && rustup target add aarch64-linux-android && rustup target add x86_64-linux-android
     - name: Build Android example app

--- a/.github/workflows/integrations_android.yaml
+++ b/.github/workflows/integrations_android.yaml
@@ -1,3 +1,6 @@
+env:
+  NDK_VERSION: 27.2.12479018
+
 name: Build Android Integrations
 on:
   workflow_call:
@@ -29,6 +32,30 @@ jobs:
         distribution: 'zulu'
         java-version: '17'
         cache: gradle
+    - name: Cache Android NDK
+      id: ndk-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.ANDROID_SDK_ROOT }}/ndk/${{ env.NDK_VERSION }}
+        key: ${{ runner.os }}-android-ndk-${{ env.NDK_VERSION }}
+    - name: Verify cmdline-tools
+      run: |
+        CMDLINE_TOOLS_DIR="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+        if [ ! -x "$CMDLINE_TOOLS_DIR/sdkmanager" ]; then
+          echo "cmdline-tools not found or incomplete. Installing..."
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+          cd $ANDROID_SDK_ROOT/cmdline-tools
+          curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -o cmdline-tools.zip
+          unzip -q cmdline-tools.zip
+          mv cmdline-tools latest
+        else
+          echo "cmdline-tools already installed."
+        fi
+    - name: Install Android NDK
+      if: steps.ndk-cache.outputs.cache-hit != 'true'
+      run: |
+        export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH
+        yes | sdkmanager "ndk;${NDK_VERSION}"
     - name: Install Rust target
       run: rustup update && rustup target add aarch64-linux-android && rustup target add x86_64-linux-android
     - name: Build Timber artifacts with Gradle


### PR DESCRIPTION
TDLR We can't release due to missing NDK https://github.com/bitdriftlabs/capture-sdk/actions/runs/16620259183/job/47022691775

Similar to https://github.com/bitdriftlabs/capture-sdk/pull/521 we need to install NDK for release scripts as well 

See https://github.com/actions/runner-images/pull/12630/files#diff-cc12e5c5d005932feaacf280af949d83e2cb6020dff8203d9ead2e00c30e8b7fL238