### PR TITLE
Revert "strip out Debug impls in release (#510)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -82,8 +82,6 @@ build:release-android --config=release-common
 build:release-android --copt=-flto=thin --linkopt=-flto=thin
 build:release-android --config=android
 build:release-android --linkopt=-Wl,--pack-dyn-relocs=android
-build:release-common --@rules_rust//rust/settings:extra_rustc_flag='-Zfmt-debug=none'
-build:release-android --config=fake-nightly
 # build:release-android --linkopt=-Wl,--use-android-relr-tags
 
 # Custom iOS release configuration

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check for workflow file changes
         id: workflow_check
-        run: ./ci/files_changed.sh .github/workflows/android.yaml .bazelrc
+        run: ./ci/files_changed.sh .github/workflows/android.yaml
         continue-on-error: true
 
       - name: Check for relevant Gradle changes


### PR DESCRIPTION
This reverts commit 3fe3e2edf539deecdd2d5c1cfc3a94a75ba53188 to allow release

See [thread](https://bitdrift.slack.com/archives/C058ZD2M2CQ/p1753874835998939)