### PR TITLE
Update developers list

### DIFF
--- a/bazel/pom_template.xml
+++ b/bazel/pom_template.xml
@@ -32,42 +32,6 @@
             <email>info@bitdrift.io</email>
             <url>https://github.com/bitdriftlabs</url>
         </developer>
-        <developer>
-            <id>kattrali</id>
-            <name>Delisa Fuller</name>
-            <email>dfuller@bitdrift.io</email>
-            <url>https://github.com/kattrali</url>
-        </developer>
-        <developer>
-            <id>FranAguilera</id>
-            <name>Fran Aguilera</name>
-            <email>faguilera@bitdrift.io</email>
-            <url>https://github.com/FranAguilera</url>
-        </developer>
-        <developer>
-            <id>kstenerud</id>
-            <name>Karl Stenerud</name>
-            <email>kstenerud@bitdrift.io</email>
-            <url>https://github.com/kstenerud</url>
-        </developer>
-        <developer>
-            <id>mattklein123</id>
-            <name>Matt Klein</name>
-            <email>mklein@bitdrift.io</email>
-            <url>https://github.com/mattklein123</url>
-        </developer>
-        <developer>
-            <id>murki</id>
-            <name>Miguel Angel Juárez López</name>
-            <email>miguel@bitdrift.io</email>
-            <url>https://github.com/murki</url>
-        </developer>
-        <developer>
-            <id>snowp</id>
-            <name>Snow Pettersen</name>
-            <email>snow@bitdrift.io</email>
-            <url>https://github.com/snowp</url>
-        </developer>
     </developers>
     <scm>
         <connection>scm:git:git://github.com/bitdriftlabs/capture-sdk.git</connection>

--- a/platform/jvm/capture-timber/build.gradle.kts
+++ b/platform/jvm/capture-timber/build.gradle.kts
@@ -92,18 +92,6 @@ mavenPublishing {
                 url.set("https://github.com/bitdriftlabs")
                 email.set("info@bitdrift.io")
             }
-            developer {
-                id.set("Augustyniak")
-                name.set("Rafał Augustyniak")
-                url.set("https://github.com/Augustyniak")
-                email.set("rafal@bitdrift.io")
-            }
-            developer {
-                id.set("murki")
-                name.set("Miguel Angel Juárez López")
-                url.set("https://github.com/murki")
-                email.set("miguel@bitdrift.io")
-            }
             scm {
                 connection.set("scm:git:git://github.com/bitdriftlabs/capture-sdk.git")
                 developerConnection.set("scm:git:ssh://git@github.com:bitdriftlabs/capture-sdk.git")


### PR DESCRIPTION
Looks like the recently published version to [maven central](https://central.sonatype.com/artifact/io.bitdrift/capture/0.18.0) has an outdated list of developers 
