### PR TITLE
Add OkHttpRequestFieldProvider to CaptureOkHttpEventListenerFactory

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
@@ -32,7 +32,7 @@ internal class CaptureOkHttpEventListener internal constructor(
     private val logger: ILogger?,
     private val clock: IClock,
     private val targetEventListener: EventListener?,
-    private val extraFieldsProvider:  OkHttpRequestFieldProvider
+    private val extraFieldsProvider: OkHttpRequestFieldProvider,
 ) : EventListener() {
     private var requestBodyBytesSentCount: Long = 0
     private var responseBodyBytesReceivedCount: Long = 0
@@ -126,7 +126,7 @@ internal class CaptureOkHttpEventListener internal constructor(
                 query = request.url.query,
                 headers = request.headers.toMap(),
                 bytesExpectedToSendCount = bytesExpectedToSendCount,
-                extraFields = extraFieldsProvider.provideExtraFields(request)
+                extraFields = extraFieldsProvider.provideExtraFields(request),
             )
 
         this.requestInfo = requestInfo

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
@@ -32,6 +32,7 @@ internal class CaptureOkHttpEventListener internal constructor(
     private val logger: ILogger?,
     private val clock: IClock,
     private val targetEventListener: EventListener?,
+    private val extraFieldsProvider:  OkHttpRequestFieldProvider
 ) : EventListener() {
     private var requestBodyBytesSentCount: Long = 0
     private var responseBodyBytesReceivedCount: Long = 0
@@ -125,6 +126,7 @@ internal class CaptureOkHttpEventListener internal constructor(
                 query = request.url.query,
                 headers = request.headers.toMap(),
                 bytesExpectedToSendCount = bytesExpectedToSendCount,
+                extraFields = extraFieldsProvider.provideExtraFields(request)
             )
 
         this.requestInfo = requestInfo

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
@@ -32,17 +32,19 @@ class CaptureOkHttpEventListenerFactory internal constructor(
     private val targetEventListenerCreator: ((call: Call) -> EventListener)? = null,
     private val logger: ILogger? = Capture.logger(),
     private val clock: IClock = DefaultClock.getInstance(),
-    private val extraFieldsProvider: OkHttpRequestFieldProvider = OkHttpRequestFieldProvider {
-        emptyMap()
-    }
+    private val extraFieldsProvider: OkHttpRequestFieldProvider =
+        OkHttpRequestFieldProvider {
+            emptyMap()
+        },
 ) : EventListener.Factory {
     /**
      * Initializes a new instance of the Capture event listener.
      */
     constructor(
-        extraFieldsProvider: OkHttpRequestFieldProvider = OkHttpRequestFieldProvider {
-            emptyMap()
-        }
+        extraFieldsProvider: OkHttpRequestFieldProvider =
+            OkHttpRequestFieldProvider {
+                emptyMap()
+            },
     ) : this(null, extraFieldsProvider = extraFieldsProvider)
 
     /**
@@ -54,9 +56,10 @@ class CaptureOkHttpEventListenerFactory internal constructor(
      */
     constructor(
         targetEventListener: EventListener,
-        extraFieldsProvider: OkHttpRequestFieldProvider = OkHttpRequestFieldProvider {
-            emptyMap()
-        }
+        extraFieldsProvider: OkHttpRequestFieldProvider =
+            OkHttpRequestFieldProvider {
+                emptyMap()
+            },
     ) : this({ targetEventListener }, extraFieldsProvider = extraFieldsProvider)
 
     /**
@@ -68,20 +71,22 @@ class CaptureOkHttpEventListenerFactory internal constructor(
      */
     constructor(
         targetEventListenerFactory: EventListener.Factory,
-        extraFieldsProvider: OkHttpRequestFieldProvider = OkHttpRequestFieldProvider {
-            emptyMap()
-        }
+        extraFieldsProvider: OkHttpRequestFieldProvider =
+            OkHttpRequestFieldProvider {
+                emptyMap()
+            },
     ) : this(
         targetEventListenerCreator = { targetEventListenerFactory.create(it) },
-        extraFieldsProvider = extraFieldsProvider
+        extraFieldsProvider = extraFieldsProvider,
     )
 
-    override fun create(call: Call): EventListener = CaptureOkHttpEventListener(
-        logger = getLogger(),
-        clock = clock,
-        targetEventListener = targetEventListenerCreator?.invoke(call),
-        extraFieldsProvider = extraFieldsProvider
-    )
+    override fun create(call: Call): EventListener =
+        CaptureOkHttpEventListener(
+            logger = getLogger(),
+            clock = clock,
+            targetEventListener = targetEventListenerCreator?.invoke(call),
+            extraFieldsProvider = extraFieldsProvider,
+        )
 
     // attempts to get the latest logger if one wasn't found at construction time
     private fun getLogger(): ILogger? = logger ?: Capture.logger()

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpRequestFieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpRequestFieldProvider.kt
@@ -1,0 +1,15 @@
+package io.bitdrift.capture.network.okhttp
+
+import okhttp3.Request
+
+/**
+ * Provides additional custom fields to add to http logs automatically sent
+ * by using [CaptureOkHttpEventListenerFactory].
+ */
+fun interface OkHttpRequestFieldProvider {
+    /**
+     * @return a map of fields to add to the http log that will be sent
+     * by [CaptureOkHttpEventListenerFactory] for this [request].
+     */
+    fun provideExtraFields(request: Request): Map<String, String>
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpRequestFieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpRequestFieldProvider.kt
@@ -1,3 +1,10 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 package io.bitdrift.capture.network.okhttp
 
 import okhttp3.Request

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
@@ -561,28 +561,29 @@ class CaptureOkHttpEventListenerFactoryTest {
 
         val request =
             Request
-              .Builder()
-              .url(endpoint)
-              .post("test".toRequestBody())
-              .tag(requestMetadata)
-              .build()
+                .Builder()
+                .url(endpoint)
+                .post("test".toRequestBody())
+                .tag(requestMetadata)
+                .build()
 
         val response =
             Response
-              .Builder()
-              .request(request)
-              .protocol(Protocol.HTTP_2)
-              .code(200)
-              .message("message")
-              .header("response_header", "response_header_value")
-              .build()
+                .Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("message")
+                .header("response_header", "response_header_value")
+                .build()
 
         val call: Call = mock()
         whenever(call.request()).thenReturn(request)
 
-        val extraFieldProvider = OkHttpRequestFieldProvider {
-            mapOf("requestMetadata" to it.tag() as String)
-        }
+        val extraFieldProvider =
+            OkHttpRequestFieldProvider {
+                mapOf("requestMetadata" to it.tag() as String)
+            }
 
         // ACT
         val factory = CaptureOkHttpEventListenerFactory(null, logger, clock, extraFieldProvider)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureOkHttpEventListenerFactoryTest.kt
@@ -16,6 +16,7 @@ import io.bitdrift.capture.common.IClock
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
 import io.bitdrift.capture.network.okhttp.CaptureOkHttpEventListenerFactory
+import io.bitdrift.capture.network.okhttp.OkHttpRequestFieldProvider
 import okhttp3.Call
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.Protocol
@@ -551,5 +552,57 @@ class CaptureOkHttpEventListenerFactoryTest {
                 .entries
                 .containsAll(expectedFields.entries),
         ).isTrue()
+    }
+
+    @Test
+    fun testCustomFieldProviderAddsExtraFields() {
+        // ARRANGE
+        val requestMetadata = "1234"
+
+        val request =
+            Request
+              .Builder()
+              .url(endpoint)
+              .post("test".toRequestBody())
+              .tag(requestMetadata)
+              .build()
+
+        val response =
+            Response
+              .Builder()
+              .request(request)
+              .protocol(Protocol.HTTP_2)
+              .code(200)
+              .message("message")
+              .header("response_header", "response_header_value")
+              .build()
+
+        val call: Call = mock()
+        whenever(call.request()).thenReturn(request)
+
+        val extraFieldProvider = OkHttpRequestFieldProvider {
+            mapOf("requestMetadata" to it.tag() as String)
+        }
+
+        // ACT
+        val factory = CaptureOkHttpEventListenerFactory(null, logger, clock, extraFieldProvider)
+        val listener = factory.create(call)
+
+        listener.callStart(call)
+
+        listener.responseHeadersEnd(call, response)
+        listener.responseBodyEnd(call, 234)
+
+        listener.callEnd(call)
+
+        // ASSERT
+        val httpRequestInfoCapture = argumentCaptor<HttpRequestInfo>()
+        verify(logger).log(httpRequestInfoCapture.capture())
+        val httpResponseInfoCapture = argumentCaptor<HttpResponseInfo>()
+        verify(logger).log(httpResponseInfoCapture.capture())
+
+        val httpRequestInfo = httpRequestInfoCapture.firstValue
+
+        assertThat(httpRequestInfo.fields["requestMetadata"].toString()).isEqualTo(requestMetadata)
     }
 }


### PR DESCRIPTION
This allows SDK consumers to inspect OkHttp requests right before they get logged to Bitdrift and provide extra fields to log.

Some notes & feedback on the code:

- I added a OkHttpRequestFieldProvider for extra fields on the request logs, but I didn't create a `OkHttpResponseFieldProvider`, because I have no use for that. You might want to do that, or merge those 2 and have one method for request and one for response (ideally I'd stick to 2 interfaces though, so that you can implement only what you need)
- CaptureOkHttpEventListenerFactory has 3 public constructors, which forced me to add this new param to all 3, with a default value. Ideally there would have been a single constructor, taking a `EventListener.Factory` defaulting to `{ NoOpEventListener }` (or accepting null but that's not super great). The constructor that takes `EventListener` isn't necessary, it's easy enough for one to pass in `{ mySingletonListener }` anyway.
- I opened the project in IJ and my default formatting settings (2 spaces indentation) applied, so I had to manually handle indentation. You should provide instructions for how to set up formatting that matches your project.
- I wasn't able to run the tests, I'm getting a bunch of Kotlin compile errors (e.g. calling `Duration()` or suppressing `INVISIBLE_REFERENCE`.  Not sure why my Kotlin compiler seems stricter than yours, I ran tests with `./gradlew test` as running them from the IDE did not find the tests. Maybe add more info on how one is supposed to set up the dev env?
- This means I did not actually run the test I wrote. Hopefully you get the idea though, and can straighten it out.
- The test I wrote has a bunch of *antipatterns* in it because I tried to adhere to the style of the other tests in that class. Here's what I'd change:
  - Test names should never start with `testXX`, that's a really old practice from before Java had annotation support and Junit would pick up tests by looking at method names that start with `test`. Junit4, *released in 2006*, introduced `@Test`. `@Test fun testApolloHeadersSendGraphQlSpans()` => `@Test fun apolloHeadersSendGraphQlSpans()`
  - Kotlin supports method names with spaces in backticks, which allows for more readable test names. So, instead of `@Test fun testApolloHeadersSendGraphQlSpans()` this could be ``@Test fun `apollo headers send GraphQL spans`()``.
  - Aim for a single assert per test, at the end of the test. I loved seeing the "ARRANGE ACT ASSERT" comments in the test, that structure is definitely good. However, whenever I see multiple assertions at the end of a test I treat that as a design clue ("design clue" is a nicer way of saying "code smell" :P) that indicate that test likely tests several things and could be split into several parts (e.g. "validate all the extra headers are present as properly formatted fields" and "validate all request fields are present in response" should likely be two tests)
  - Stop using mocks. Create a test implementation of `ILogger` that keeps a list of the logs its been passed, then pull these and assert against these logs.