### PR TITLE
[Android] Adding os version to fatal issue reports

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
@@ -48,6 +48,9 @@ internal class ClientAttributes(
             return supportedAbis.firstOrNull() ?: "unknown"
         }
 
+    override val osVersion: String
+        get() = Build.VERSION.RELEASE
+
     @Suppress("SwallowedException")
     private val packageInfo: PackageInfo? =
         try {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
@@ -66,7 +66,7 @@ internal class ClientAttributes(
             // Operating system. Always Android for this code path.
             "os" to "Android",
             // The operating system version (e.g. 12.1)
-            "os_version" to Build.VERSION.RELEASE,
+            "os_version" to osVersion,
             // Whether or not the app was in the background by the time the log was fired.
             "foreground" to isForeground(),
             // The version of this package, as specified by the manifest's `versionName` attribute

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/IClientAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/IClientAttributes.kt
@@ -19,6 +19,9 @@ interface IClientAttributes {
     /** A positive integer used as an internal version number. This helps determine version recency. */
     val appVersionCode: Long
 
+    /** The operating system version (e.g. 12.1). */
+    val osVersion: String
+
     /** A list of the currently supported ABIs */
     val supportedAbis: List<String>
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ClientAttributesTest.kt
@@ -223,6 +223,16 @@ class ClientAttributesTest {
         assertThat(fields).containsEntry("_architecture", "armeabi-v7a")
     }
 
+    @Test
+    fun osVersion_withStartedLifecycle_shouldMatchConfigVersion() {
+        val clientAttributes =
+            ClientAttributes(appContext, obtainMockedLifecycleOwnerWith(Lifecycle.State.STARTED))
+
+        val fields = clientAttributes.invoke()
+
+        assertThat(fields).containsEntry("os_version", "7.0")
+    }
+
     private fun assertInstallationSource(
         hasValidInstallationSource: Boolean,
         expectedInstallationSource: String,


### PR DESCRIPTION
## What

Resolves BIT-5976

We weren't passing os version to fatal issue reports

## Verification 

- Verified on this [report](https://explorations.bitdrift.dev/issues/10373950639727864931/e2202fec-e910-4ded-84b2-78e69b2fc51b?utm_source=sdk)

<img width="395" height="167" alt="image" src="https://github.com/user-attachments/assets/8aa7bccb-1623-4cd2-bf50-9d9b87a156d9" />

- Which matches reported with the associated [timeline session of the crash](https://timeline.bitdrift.dev/session/485762d9-0af0-49e0-8143-c77b9e85a2ff?utm_source=sdk&pages=1&utilization=0&expanded=-6379577480046148239)

<img width="373" height="190" alt="image" src="https://github.com/user-attachments/assets/145abee1-a20a-493b-9b05-38f99eb17e38" />
