### PR TITLE
[DO NOT REVIEW YET] [Android] Avoid allocating lambda message unless SDK is initialized

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -295,7 +295,7 @@ object Capture {
             throwable: Throwable? = null,
             message: () -> String,
         ) {
-            logger()?.log(level = LogLevel.TRACE, fields = fields, throwable = throwable, message = message)
+            logger()?.logInline(level = LogLevel.TRACE, fields = fields, throwable = throwable, message = message)
         }
 
         /**
@@ -312,7 +312,7 @@ object Capture {
             throwable: Throwable? = null,
             message: () -> String,
         ) {
-            logger()?.log(level = LogLevel.DEBUG, fields = fields, throwable = throwable, message = message)
+            logger()?.logInline(level = LogLevel.DEBUG, fields = fields, throwable = throwable, message = message)
         }
 
         /**
@@ -329,7 +329,7 @@ object Capture {
             throwable: Throwable? = null,
             message: () -> String,
         ) {
-            logger()?.log(level = LogLevel.INFO, fields = fields, throwable = throwable, message = message)
+            logger()?.logInline(level = LogLevel.INFO, fields = fields, throwable = throwable, message = message)
         }
 
         /**
@@ -346,7 +346,7 @@ object Capture {
             throwable: Throwable? = null,
             message: () -> String,
         ) {
-            logger()?.log(level = LogLevel.WARNING, fields = fields, throwable = throwable, message = message)
+            logger()?.logInline(level = LogLevel.WARNING, fields = fields, throwable = throwable, message = message)
         }
 
         /**
@@ -363,7 +363,7 @@ object Capture {
             throwable: Throwable? = null,
             message: () -> String,
         ) {
-            logger()?.log(level = LogLevel.ERROR, fields = fields, throwable = throwable, message = message)
+            logger()?.logInline(level = LogLevel.ERROR, fields = fields, throwable = throwable, message = message)
         }
 
         /**
@@ -382,7 +382,7 @@ object Capture {
             throwable: Throwable? = null,
             message: () -> String,
         ) {
-            logger()?.log(level = level, fields = fields, throwable = throwable, message = message)
+            logger()?.logInline(level = level, fields = fields, throwable = throwable, message = message)
         }
 
         /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ILogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ILogger.kt
@@ -16,7 +16,7 @@ import kotlin.time.Duration
 /**
  * A Capture SDK logger interface.
  */
-interface ILogger {
+interface ILogger : IMessageLogger {
     /**
      * The identifier for the current ongoing session.
      */
@@ -74,21 +74,6 @@ interface ILogger {
      * @param key the name of the field to remove.
      */
     fun removeField(key: String)
-
-    /**
-     * Logs a message at a specified level.
-     *
-     * @param level the severity of the log.
-     * @param fields and optional collection of key-value pairs to be added to the log line.
-     * @param throwable an optional throwable to include in the log line.
-     * @param message the main message of the log line, the lambda gets evaluated lazily.
-     */
-    fun log(
-        level: LogLevel,
-        fields: Map<String, String>? = null,
-        throwable: Throwable? = null,
-        message: () -> String,
-    )
 
     /**
      * Writes an app launch TTI log event. This event should be logged only once per Logger configuration.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IMessageLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IMessageLogger.kt
@@ -1,0 +1,50 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+/**
+ * A lightweight logging interface designed for efficient lambda usage.
+ *
+ * Implementers should define how to handle log messages with a deferred message block.
+ * This interface supports lambda inlining optimizations to avoid allocations when logging is disabled.
+ */
+fun interface IMessageLogger {
+    /**
+     * Logs a message at a specified level.
+     *
+     * @param level the severity of the log.
+     * @param fields and optional collection of key-value pairs to be added to the log line.
+     * @param throwable an optional throwable to include in the log line.
+     * @param message the main message of the log line, the lambda gets evaluated lazily.
+     */
+    fun log(
+        level: LogLevel,
+        fields: Map<String, String>?,
+        throwable: Throwable?,
+        message: () -> String,
+    )
+}
+
+/**
+ * Inline extension for [IMessageLogger] that defers lambda allocation until necessary.
+ *
+ * Use this method to log messages efficiently when the logger might not be active.
+ *
+ * @param level the severity level of the log.
+ * @param fields optional map of additional context fields.
+ * @param throwable optional throwable to include.
+ * @param message the log message, evaluated lazily.
+ */
+inline fun IMessageLogger.logInline(
+    level: LogLevel,
+    fields: Map<String, String>? = null,
+    throwable: Throwable? = null,
+    crossinline message: () -> String,
+) {
+    log(level, fields, throwable) { message() }
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/BitdriftInit.java
@@ -7,18 +7,26 @@
 
 package io.bitdrift.gradletestapp;
 
+import static io.bitdrift.gradletestapp.VerificationUtils.getDeferredMessage;
+
 import android.content.Context;
+import android.util.Log;
 
 import io.bitdrift.capture.Capture;
 import io.bitdrift.capture.Configuration;
+import io.bitdrift.capture.LogLevel;
 import io.bitdrift.capture.providers.FieldProvider;
 import io.bitdrift.capture.providers.session.SessionStrategy;
 import io.bitdrift.gradletestapp.ConfigurationSettingsFragment.SessionStrategyPreferences;
+
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 import okhttp3.HttpUrl;
 
 public class BitdriftInit {
@@ -37,13 +45,19 @@ public class BitdriftInit {
         });
 
         Capture.Logger.start(
-            apiKey,
-            sessionStrategy,
-            configuration,
-            fieldProviders,
-            null,
-            apiUrl,
-            context
+                apiKey,
+                sessionStrategy,
+                configuration,
+                fieldProviders,
+                null,
+                apiUrl,
+                context
+        );
+
+        Capture.Logger.logInfo(
+                null,
+                null,
+                () -> getDeferredMessage("java")
         );
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -51,8 +51,8 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import com.bugsnag.android.Bugsnag
-import com.bugsnag.android.Logger
 import io.bitdrift.capture.Capture
+import io.bitdrift.capture.Capture.Logger.logInfo
 import io.bitdrift.capture.Capture.Logger.sessionUrl
 import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.LogLevel
@@ -120,6 +120,10 @@ class GradleTestApp : Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+
+        // Just to confirm message is only generated upon successful Capture.Logger.start
+        logInfo { VerificationUtils.getDeferredMessage("kotlin") }
+
         Timber.plant(CaptureTree())
         Timber.i("Bitdrift Logger initialized with session_url=$sessionUrl")
     }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/VerificationUtils.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/VerificationUtils.kt
@@ -1,0 +1,30 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.gradletestapp
+
+import android.util.Log
+
+/**
+ * Utility functions for verifying SDK behavior in test applications.
+ */
+object VerificationUtils {
+    /**
+     * Intended to confirm the SDK is evaluating the passed message lambda
+     * into Capture.Logger.log calls only when the SDK is properly initialized
+     *
+     *
+     * @param calledFrom a tag or source identifier used for logging.
+     * @return a lambda that logs and returns a predefined verification message when invoked.
+     */
+    @JvmStatic
+    fun getDeferredMessage(calledFrom: String): String {
+        val message = "This message should only be created upon successful bitdrift init. Called from $calledFrom"
+        Log.i("GradleTestApp lambda verification", message)
+        return message
+    }
+}


### PR DESCRIPTION
## What

TBF
 
## Verification

With the gradle test app, set incorrect Api key, url. Lambda shouldn't be evaluated if sdk is not properly started

