### PR TITLE
[andr][examples] Use bitdrift plugin from maven central

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -1,8 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        // TODO: Start publishing plugin to gradlePluginPortal
+        classpath 'io.bitdrift:capture-plugin:0.18.0'
+    }
+}
 plugins {
     id 'com.android.application' version '8.8.0' apply false
     id 'com.android.library' version '8.8.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
-    id 'io.bitdrift.capture-plugin' version '0.18.0' apply false
 }

--- a/gradle/settings.gradle
+++ b/gradle/settings.gradle
@@ -3,9 +3,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            url 'https://dl.bitdrift.io/sdk/android-maven'
-        }
     }
 }
 dependencyResolutionManagement {


### PR DESCRIPTION
Until we publish our plugin to [gradle plugin portal](https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html) this is the format customers need to follow in order to consume our plugin via maven central