### PR TITLE
[andr] Allow Android Studio to run tests locally by suppressing some warnings

### DIFF
--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.rust.android)
@@ -57,12 +60,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    // TODO(murki): consider updating to using kotlin.compilerOptions {} block
-    kotlinOptions {
-        jvmTarget = "1.8"
-        apiVersion = "2.1"
-        languageVersion = "2.1"
-        allWarningsAsErrors = true
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
+            apiVersion = KotlinVersion.KOTLIN_2_1
+            languageVersion = KotlinVersion.KOTLIN_2_1
+            allWarningsAsErrors = true
+            freeCompilerArgs.addAll(listOf("-Xdont-warn-on-error-suppression")) // needed for suppressing INVISIBLE_REFERENCE etc
+        }
     }
 
     // TODO(murki): Move this common configuration to a reusable buildSrc plugin once it's fully supported for kotlin DSL

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ResourceUtilizationTargetTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ResourceUtilizationTargetTest.kt
@@ -58,7 +58,7 @@ class ResourceUtilizationTargetTest {
     }
 
     @Test
-    @Suppress("INVISIBLE_MEMBER")
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
     fun resourceUtilizationTickEmitsLog() {
         whenever(batteryMonitor.batteryPercentageAttribute()).thenReturn(Pair("_battery_val", "0.75"))
         whenever(batteryMonitor.isBatteryChargingAttribute()).thenReturn(Pair("_state", "charging"))


### PR DESCRIPTION
We're using `@Suppress("INVISIBLE_REFERENCE")` in tests which are reported as warnings. We are setting `allWarningsAsErrors = true` in the kotlin compiler but we're opting to bypass these particular warnings via the `-Xdont-warn-on-error-suppression` flag.

Not ideal but we'll have to make due until kotlin has first-class support for "friend" modules to access `internal`, see: https://youtrack.jetbrains.com/issue/KT-67920/K2-Allow-suppression-of-INVISIBLEREFERENCE-errors