### PR TITLE
[DO NOT REVIEW YET] Exclude protobuf-javalite

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -199,6 +199,9 @@ maven.install(
         "androidx.compose.runtime:runtime:{}".format(COMPOSE_VERSION),
         "androidx.annotation:annotation-jvm:1.9.1",
     ],
+    exclusions = {
+        "com.google.protobuf:protobuf-kotlin-lite": ["com.google.protobuf:protobuf-javalite"],
+    },
     repositories = [
         "https://repo1.maven.org/maven2",
         "https://maven.google.com",

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -31,7 +31,9 @@ dependencies {
     implementation(libs.jsr305)
     implementation(libs.gson)
     implementation(libs.performance)
-    implementation(libs.protobuf.kotlinlite)
+    implementation(libs.protobuf.kotlinlite) {
+        exclude(group = "com.google.protobuf", module = "protobuf-javalite")
+    }
 
     testImplementation(libs.junit)
     testImplementation(libs.assertj.core)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Configuration.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Configuration.kt
@@ -13,8 +13,8 @@ import io.bitdrift.capture.replay.SessionReplayConfiguration
  * A configuration object representing the feature set enabled for Capture.
  * @param sessionReplayConfiguration The resource reporting configuration to use. Passing `null` disables the feature.
  * @param enableFatalIssueReporting When set to true wil capture Fatal Issues automatically [JVM crash, ANR, etc] and without requiring
- * any external 3rd party library integration
- * @param sleepMode SleepMode.ACTIVE if Capture should initialize in minimal activity mode
+ * any external 3rd party library integration.
+ * @param sleepMode SleepMode.ACTIVE if Capture should initialize in minimal activity mode.
  */
 data class Configuration
     @JvmOverloads


### PR DESCRIPTION
Exclude protobuf-javalite from protobuf-kotlin-lite to prevent class duplication errors when consumers use protobuf-java.

This avoids transitive conflicts with apps relying on com.google.protobuf:protobuf-java and ensures compatibility without forcing consumers to exclude on their end

Kudos to @pyricau for the investigation and link to existing issue: https://github.com/protocolbuffers/protobuf/issues/8104