### PR TITLE
[Android] Fix OkHttpClient connection leaked

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpApiClient.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpApiClient.kt
@@ -69,15 +69,16 @@ internal class OkHttpApiClient(
                     response: Response,
                 ) {
                     response.use {
+                        val responseBody = response.body?.string().orEmpty()
+
                         if (response.isSuccessful) {
                             try {
-                                val typedResponse = gson.fromTypedJson<Rp>(response.body?.string().orEmpty())
+                                val typedResponse = gson.fromTypedJson<Rp>(responseBody)
                                 completion(CaptureResult.Success(typedResponse))
                             } catch (e: Exception) {
                                 completion(CaptureResult.Failure(e.toSerializationError()))
                             }
                         } else {
-                            val responseBody = response.body?.string()
                             completion(CaptureResult.Failure(ApiError.ServerError(response.code, responseBody)))
                         }
                     }


### PR DESCRIPTION
## TLDR

Follow up to https://github.com/bitdriftlabs/capture-sdk/pull/180

Prevents `2025-08-05 19:39:00.410 okhttp.OkHttpClient      W  A connection to https://api.bitdrift.io/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: `

<img width="1637" height="181" alt="image" src="https://github.com/user-attachments/assets/fece2833-460e-42bb-814a-81ad770a7a3b" />

## Verification 

Checking logcat on PR, this warning should be gone 

[Network spans](https://timeline.bitdrift.dev/session/0fdac65a-d0cb-429f-af85-992294928a55?utm_source=sdk&pages=1&utilization=0#spans) 