### PR TITLE
[Android] Harden FatalIssueReporter

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -264,6 +264,13 @@ internal class LoggerImpl(
         CaptureJniLibrary.processCrashReports(this.loggerId)
     }
 
+    override fun onReportProcessingError(
+        message: String,
+        throwable: Throwable,
+    ) {
+        errorHandler.handleError(message, throwable)
+    }
+
     override val sessionId: String
         get() = CaptureJniLibrary.getSessionId(this.loggerId) ?: "unknown"
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/ICompletedReportsProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/ICompletedReportsProcessor.kt
@@ -14,4 +14,12 @@ interface ICompletedReportsProcessor {
      * To be called when we are ready to process existing fatal issue reports stored on disk
      */
     fun processCrashReports()
+
+    /**
+     * Will be called if there is an issue while processing reports
+     */
+    fun onReportProcessingError(
+        message: String,
+        throwable: Throwable,
+    )
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/FatalIssueReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/FatalIssueReporterTest.kt
@@ -14,6 +14,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.ContextHolder
 import io.bitdrift.capture.ContextHolder.Companion.APP_CONTEXT
 import io.bitdrift.capture.attributes.ClientAttributes
@@ -82,6 +83,20 @@ class FatalIssueReporterTest {
         assertThat(duration).isNotNull()
         assertThat(buildFieldsMap()).isEqualTo(expectedMap)
         assertCrashFile(crashFileExist)
+    }
+
+    @Test
+    fun initBuiltInMode_whenAppExitInfoFails_shouldCallOnErrorOccurred() {
+        val exception = RuntimeException("test error")
+        whenever(latestAppExitInfoProvider.get(any()))
+            .thenThrow(exception)
+
+        fatalIssueReporter.initBuiltInMode(appContext, clientAttributes, completedReportsProcessor)
+
+        verify(completedReportsProcessor).onReportProcessingError(
+            any(),
+            eq(exception),
+        )
     }
 
     private fun assertCrashFile(crashFileExist: Boolean) {


### PR DESCRIPTION
Now that since https://github.com/bitdriftlabs/capture-sdk/pull/551 `persistLastExitReasonIfNeeded` runs on a separate thread, we could potentially crash the app if there was an issue within that method given the current runCatching runs on separate thread.

Will also rely now on errorHandler to notify of potential errors during that init

Verified with artificial crashes internally added at processing [session](https://timeline.bitdrift.dev/session/89708a1d-b7ac-4241-b8ec-232a41b05e2a?utm_source=sdk&pages=1&utilization=0&type=2&expanded=-7896467945657903928)

<img width="505" height="202" alt="image" src="https://github.com/user-attachments/assets/2589a957-547a-49a4-b114-f431cfc5ce62" />

And success init [session](https://timeline.bitdrift.dev/session/89708a1d-b7ac-4241-b8ec-232a41b05e2a?utm_source=sdk&pages=1&utilization=0&type=2&expanded=459450365904853198)

<img width="549" height="299" alt="image" src="https://github.com/user-attachments/assets/0e8825d6-5971-4439-858d-cc06b5690ca2" />
