### PR TITLE
Add applicatinIdSuffix to `Logger.start`

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -127,6 +127,10 @@ object Capture {
          *               Compose API base URL.
          * @param context an optional context reference. You should provide the context if called from
          * a [android.content.ContentProvider]
+         * @param applicationIdSuffix A suffix that will be added to the representation of the
+         * application id (aka package name) in Bitdrift. This is useful if you have different
+         * build flavors with the same application id and you want a way to apply entire workflows
+         * only to a subset of those.
          */
         @Synchronized
         @JvmStatic
@@ -139,16 +143,18 @@ object Capture {
             dateProvider: DateProvider? = null,
             apiUrl: HttpUrl = defaultCaptureApiUrl,
             context: Context? = null,
+            applicationIdSuffix: String = ""
         ) {
             start(
-                apiKey,
-                sessionStrategy,
-                configuration,
-                fieldProviders,
-                dateProvider,
-                apiUrl,
-                CaptureJniLibrary,
-                context,
+                apiKey = apiKey,
+                sessionStrategy = sessionStrategy,
+                configuration = configuration,
+                fieldProviders = fieldProviders,
+                dateProvider = dateProvider,
+                apiUrl = apiUrl,
+                bridge = CaptureJniLibrary,
+                context = context,
+                applicationIdSuffix = applicationIdSuffix,
             )
         }
 
@@ -164,6 +170,7 @@ object Capture {
             apiUrl: HttpUrl = defaultCaptureApiUrl,
             bridge: IBridge,
             context: Context? = null,
+            applicationIdSuffix: String = ""
         ) {
             // Note that we need to use @Synchronized to prevent multiple loggers from being initialized,
             // while subsequent logger access relies on volatile reads.
@@ -188,6 +195,7 @@ object Capture {
                     apiUrl = apiUrl,
                     bridge = bridge,
                     context = context,
+                    applicationIdSuffix = applicationIdSuffix
                 )
             } else {
                 Log.w(LOG_TAG, "Multiple attempts to start Capture")
@@ -508,6 +516,7 @@ object Capture {
         apiUrl: HttpUrl,
         bridge: IBridge,
         context: Context?,
+        applicationIdSuffix: String,
     ) {
         try {
             val startSdkTimer = TimeSource.Monotonic.markNow()
@@ -516,8 +525,9 @@ object Capture {
 
             val clientAttributes =
                 ClientAttributes(
-                    appContext,
-                    ProcessLifecycleOwner.get(),
+                    context = appContext,
+                    processLifecycleOwner = ProcessLifecycleOwner.get(),
+                    applicationIdSuffix = applicationIdSuffix
                 )
 
             val nativeLoadDuration =

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Configuration.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Configuration.kt
@@ -15,6 +15,10 @@ import io.bitdrift.capture.replay.SessionReplayConfiguration
  * @param enableFatalIssueReporting When set to true wil capture Fatal Issues automatically [JVM crash, ANR, etc] and without requiring
  * any external 3rd party library integration
  * @param sleepMode SleepMode.ACTIVE if Capture should initialize in minimal activity mode
+ * @param applicationIdSuffix An optional suffix that will be appended to the representation of the
+ * application id (aka package name) in bitdrift. This is useful if you have different
+ * build flavors with the same application id and you want a way to apply workflows
+ * only to a subset of those.
  */
 data class Configuration
     @JvmOverloads
@@ -22,4 +26,5 @@ data class Configuration
         val sessionReplayConfiguration: SessionReplayConfiguration = SessionReplayConfiguration(),
         val enableFatalIssueReporting: Boolean = false,
         val sleepMode: SleepMode = SleepMode.INACTIVE,
+        val applicationIdSuffix: String = "",
     )

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -47,6 +47,7 @@ import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.reports.FatalIssueReporter
 import io.bitdrift.capture.reports.IFatalIssueReporter
 import io.bitdrift.capture.reports.processor.ICompletedReportsProcessor
 import io.bitdrift.capture.threading.CaptureDispatchers
@@ -75,6 +76,7 @@ internal class LoggerImpl(
         ClientAttributes(
             context,
             ProcessLifecycleOwner.get(),
+            configuration.applicationIdSuffix,
         ),
     preferences: IPreferences = Preferences(context),
     private val apiClient: OkHttpApiClient = OkHttpApiClient(apiUrl, apiKey),
@@ -83,7 +85,7 @@ internal class LoggerImpl(
     bridge: IBridge = CaptureJniLibrary,
     private val eventListenerDispatcher: CaptureDispatchers.CommonBackground = CaptureDispatchers.CommonBackground,
     windowManager: IWindowManager = WindowManager(errorHandler),
-    private val fatalIssueReporter: IFatalIssueReporter?,
+    private val fatalIssueReporter: IFatalIssueReporter? = if (configuration.enableFatalIssueReporting) FatalIssueReporter() else null,
 ) : ILogger,
     ICompletedReportsProcessor {
     private val metadataProvider: MetadataProvider
@@ -249,7 +251,7 @@ internal class LoggerImpl(
                 runtime,
                 errorHandler,
                 memoryMetricsProvider = memoryMetricsProvider,
-                fatalIssueReporter = fatalIssueReporter,
+                isFatalIssueReporterEnabled = configuration.enableFatalIssueReporting,
             )
 
         // Install the app exit logger before the Capture logger is started to ensure
@@ -258,6 +260,9 @@ internal class LoggerImpl(
         appExitLogger.installAppExitLogger()
 
         CaptureJniLibrary.startLogger(this.loggerId)
+
+        // fatalIssueReporter must be initialized after the appExitLogger and the logger
+        fatalIssueReporter?.initBuiltInMode(context, clientAttributes, this)
     }
 
     override fun processCrashReports() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
@@ -21,9 +21,10 @@ import io.bitdrift.capture.utils.BuildTypeChecker
 internal class ClientAttributes(
     context: Context,
     private val processLifecycleOwner: LifecycleOwner,
+    applicationIdSuffix: String = "",
 ) : IClientAttributes,
     FieldProvider {
-    override val appId = context.packageName ?: UNKNOWN_FIELD_VALUE
+    override val appId = context.packageName?.plus(applicationIdSuffix) ?: UNKNOWN_FIELD_VALUE
 
     override val appVersion by lazy {
         packageInfo?.versionName ?: "?.?.?"

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -26,8 +26,6 @@ import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
 import io.bitdrift.capture.providers.toFields
-import io.bitdrift.capture.reports.FatalIssueMechanism
-import io.bitdrift.capture.reports.IFatalIssueReporter
 import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitReasonResult
@@ -49,7 +47,7 @@ internal class AppExitLogger(
     private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider = LatestAppExitInfoProvider,
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = CaptureUncaughtExceptionHandler,
-    private val fatalIssueReporter: IFatalIssueReporter?,
+    private val isFatalIssueReporterEnabled: Boolean,
 ) : IJvmCrashListener {
     companion object {
         private const val APP_EXIT_EVENT_NAME = "AppExit"
@@ -138,8 +136,7 @@ internal class AppExitLogger(
         throwable: Throwable,
     ) {
         // When FatalIssueMechanism.BuiltIn is configured will rely on shared-core to emit the related JVM crash log
-        if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS) ||
-            fatalIssueReporter?.getReportingMechanism() == FatalIssueMechanism.BuiltIn
+        if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS) || isFatalIssueReporterEnabled
         ) {
             return
         }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -25,7 +25,6 @@ import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
-import io.bitdrift.capture.fakes.FakeFatalIssueReporter
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.FAKE_EXCEPTION
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.SESSION_ID
@@ -34,7 +33,6 @@ import io.bitdrift.capture.fakes.FakeMemoryMetricsProvider
 import io.bitdrift.capture.fakes.FakeMemoryMetricsProvider.Companion.DEFAULT_MEMORY_ATTRIBUTES_MAP
 import io.bitdrift.capture.providers.FieldValue
 import io.bitdrift.capture.providers.toFields
-import io.bitdrift.capture.reports.FatalIssueMechanism
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider.EXIT_REASON_EMPTY_LIST_MESSAGE
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider.EXIT_REASON_EXCEPTION_MESSAGE
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider.EXIT_REASON_UNMATCHED_PROCESS_NAME_MESSAGE
@@ -283,7 +281,7 @@ class AppExitLoggerTest {
 
     @Test
     fun onJvmCrash_whenBuiltInFatalIssueMechanism_shouldNotSendAppExitCrashLog() {
-        val appExitLogger = buildAppExitLogger(FatalIssueMechanism.BuiltIn)
+        val appExitLogger = buildAppExitLogger(true)
         whenever(runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_CRASH)).thenReturn(true)
 
         appExitLogger.onJvmCrash(Thread.currentThread(), IllegalStateException("Simulated Crash"))
@@ -300,7 +298,7 @@ class AppExitLoggerTest {
         verify(logger, never()).flush(any())
     }
 
-    private fun buildAppExitLogger(fatalIssueMechanism: FatalIssueMechanism = FatalIssueMechanism.None) =
+    private fun buildAppExitLogger(isFatalIssueReporterEnabled: Boolean = false) =
         AppExitLogger(
             logger,
             activityManager,
@@ -311,7 +309,7 @@ class AppExitLoggerTest {
             backgroundThreadHandler,
             lastExitInfo,
             captureUncaughtExceptionHandler,
-            FakeFatalIssueReporter(fatalIssueMechanism),
+            isFatalIssueReporterEnabled,
         )
 
     private fun buildExpectedAnrFields(): Map<String, FieldValue> =


### PR DESCRIPTION
applicatinIdSuffix is a suffix that will be added to the representation of the application id (aka package name) in Bitdrift. This is useful if you have differe