### PR TITLE
[andr] Instruct gradle to generate usable symbols

### DIFF
--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -111,7 +111,7 @@ cargoNdk {
     targets = arrayListOf("arm64")
     // enable 16 KB ELF alignment on Android to support API 35+
     extraCargoEnv = mapOf(
-      "RUSTFLAGS" to "-C link-args=-Wl,-z,max-page-size=16384",
+      "RUSTFLAGS" to "-C link-args=-Wl,-z,max-page-size=16384,--build-id",
       "RUSTC_BOOTSTRAP" to "1" // Required for using unstable features in the Rust compiler
     )
 }

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -74,6 +74,19 @@ android {
     // This needs to be set to access the strip tools to strip the shared libraries.
     ndkVersion = "27.2.12479018"
 
+    buildTypes {
+        debug {
+            ndk {
+                debugSymbolLevel = "SYMBOL_TABLE" // Using this to reduce output .so size
+            }
+        }
+        release {
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
+        }
+    }
+
     // Run lint checks on every build
     applicationVariants.configureEach {
         val lintTask = tasks.named("lint${name.replaceFirstChar(Char::titlecase)}")


### PR DESCRIPTION
When we build gradle-test-app the cargo gradle plugin will generate additional symbols that can be used to upload to our system for symbolicating libcapture.so

Look for it in `capture-sdk/platform/jvm/gradle-test-app/build/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/arm64-v8a/libcapture.so`

Additionally debug-only files will be generated in `capture-sdk/platform/jvm/gradle-test-app/build/intermediates/native_debug_metadata/release/extractReleaseNativeDebugMetadata/out/arm64-v8a/libcapture.so.dbg`