### PR TITLE
Fix non-task custom delegate

### DIFF
--- a/platform/swift/source/integrations/url_session/ProxyURLSessionDelegate.swift
+++ b/platform/swift/source/integrations/url_session/ProxyURLSessionDelegate.swift
@@ -17,9 +17,9 @@ class ProxyURLSessionDelegate: NSObject {
     /// `URLSession`'s `delegate` property is a `strong` reference. It's uncommon for delegates on iOS to be
     /// `strong` references but to make our delegate mimic the behavior of `URLSession`'s delegate we hold
     /// a strong reference to the underlying delegate.
-    fileprivate let target: URLSessionTaskDelegate?
+    fileprivate let target: URLSessionDelegate?
 
-    init(target: URLSessionTaskDelegate?) {
+    init(target: URLSessionDelegate?) {
         self.target = target
     }
 
@@ -40,7 +40,9 @@ extension ProxyURLSessionDelegate: URLSessionTaskDelegate {
     )
     {
         URLSessionTaskTracker.shared.task(task, didFinishCollecting: metrics)
-        self.target?.urlSession?(session, task: task, didFinishCollecting: metrics)
+        if let delegate = self.target as? URLSessionTaskDelegate {
+            delegate.urlSession?(session, task: task, didFinishCollecting: metrics)
+        }
     }
 }
 
@@ -54,7 +56,7 @@ final class ProxyURLSessionTaskDelegate: ProxyURLSessionDelegate {
     {
         URLSessionTaskTracker.shared.task(task, didFinishCollecting: metrics)
 
-        if let delegate = self.target, delegate.responds(to: kFinishedCollectingMetrics) {
+        if let delegate = self.target as? URLSessionTaskDelegate, delegate.responds(to: kFinishedCollectingMetrics) {
             delegate.urlSession?(session, task: task, didFinishCollecting: metrics)
             return
         }

--- a/platform/swift/source/integrations/url_session/extensions/URLSession+Extensions.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSession+Extensions.swift
@@ -34,7 +34,7 @@ extension URLSession {
         if delegate?.isKind(of: ProxyURLSessionDelegate.self) == true {
             newDelegate = delegate
         } else {
-            newDelegate = ProxyURLSessionDelegate(target: delegate as? URLSessionTaskDelegate)
+            newDelegate = ProxyURLSessionDelegate(target: delegate)
         }
 
         if var protocolClasses = configuration.protocolClasses {


### PR DESCRIPTION
When a `delegate` is provided while using our `URLSession(instrumentedSessionWithConfiguration:delegate:delegateQueue:)` integration, we were assuming the delegate will always be a `URLSessionTaskDelegate` which fails silently if the provided delegate is a bare `URLSessionDelegate`.

This change proxies the events to `URLSessionDelegate`s too.