### PR TITLE
[andr] Downgrade kotlin to 1.9

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -152,7 +152,7 @@ kt_compiler_plugin(
     target_embedded_compiler = True,
     visibility = ["//visibility:public"],
     deps = [
-        "@maven//:org_jetbrains_kotlin_kotlin_compose_compiler_plugin_embeddable",
+        "@maven//:androidx_compose_compiler_compiler",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,9 +12,11 @@ LIFECYCLE_VERSION = "2.8.7"
 
 COMPOSE_VERSION = "1.7.0"
 
-KOTLIN_COMPILE_VERSION = "2.1.21"
+COMPOSE_COMPILER_VERSION = "1.5.15"
 
-KOTLIN_COMPILER_SHA = "1ba08a8b45da99339a0601134cc037b54cf85e9bc0edbe76dcbd27c2d684a977"
+KOTLIN_COMPILE_VERSION = "1.9.25"
+
+KOTLIN_COMPILER_SHA = "6ab72d6144e71cbbc380b770c2ad380972548c63ab6ed4c79f11c88f2967332e"
 
 KOTLIN_STD_VERSION = KOTLIN_COMPILE_VERSION
 
@@ -188,7 +190,7 @@ maven.install(
         "com.google.protobuf:protobuf-kotlin-lite:3.24.2",
 
         # Compose
-        "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:{}".format(KOTLIN_COMPILE_VERSION),
+        "androidx.compose.compiler:compiler:{}".format(COMPOSE_COMPILER_VERSION),
         "org.jetbrains:annotations:26.0.1",
         "androidx.core:core-ktx:1.13.1",
         "androidx.appcompat:appcompat:1.7.0",

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -64,8 +64,8 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_1_8
-            apiVersion = KotlinVersion.KOTLIN_2_1
-            languageVersion = KotlinVersion.KOTLIN_2_1
+            apiVersion = KotlinVersion.KOTLIN_1_9
+            languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = true
             freeCompilerArgs.addAll(listOf("-Xdont-warn-on-error-suppression")) // needed for suppressing INVISIBLE_REFERENCE etc
         }

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.apollo.graphql)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.compose.compiler)
 }
 
 dependencies {
@@ -73,6 +72,10 @@ android {
 
     // This needs to be set to access the strip tools to strip the shared libraries.
     ndkVersion = "27.2.12479018"
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
+    }
 
     buildTypes {
         debug {

--- a/platform/jvm/gradle/libs.versions.toml
+++ b/platform/jvm/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ flatbuffers             = "25.2.10"
 gson                    = "2.10.1"
 jsr305                  = "3.0.2"
 junit                   = "4.13.2"
-kotlin                  = "2.1.21"
+kotlin                  = "1.9.25"
 kotlinResultJvm         = "1.1.18"
 lifecycleCommon         = "2.8.7"
 material3Android        = "1.2.1"
@@ -63,7 +63,6 @@ android-application = { id = "com.android.application", version.ref = "androidGr
 android-benchmark   = { id = "androidx.benchmark", version.ref = "androidBenchkmarkPlugin" }
 android-library     = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 apollo-graphql      = { id = "com.apollographql.apollo", version.ref = "apollo" }
-compose-compiler    = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt              = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektPlugin" }
 dokka               = { id = "org.jetbrains.dokka", version.ref = "dokkaPlugin" }
 kotlin              = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
RN customers might not have upgraded to kotlin 2+ so we'll try downgrading our sdk, see: https://github.com/bitdriftlabs/capture-es/pull/100