### PR TITLE
Adding capture-react step

### DIFF
--- a/.github/workflows/update_sdk_version.yaml
+++ b/.github/workflows/update_sdk_version.yaml
@@ -40,6 +40,12 @@ jobs:
       version: ${{ inputs.version }}
     needs: public-release
     secrets: inherit
+  capture-react-release:
+    uses: ./.github/workflows/release_capture_react.yaml
+    with:
+      version: ${{ inputs.version }}
+    needs: public-release
+    secrets: inherit
 
   update-sdk-version:
     name: Update SDK version


### PR DESCRIPTION
Depends on https://github.com/bitdriftlabs/capture-sdk/pull/593

Now that this step is verified here https://github.com/bitdriftlabs/capture-sdk/actions/runs/17223177503 and here 

Adding this step as part of release process. For now this will automatically create a PR like  https://github.com/bitdriftlabs/capture-es/pull/106. 

Next goal is to align on react versioning and to automatically trigger react release with latest capture-sdk changes 