### PR TITLE
bring in global state changes

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "15be8eba02ae4bd774b4b50552c1edea1289fc7f77ff53fe21d8547c089b1516",
+  "checksum": "958e5765d46dcf989b59e54f5966c064d32ebcc1c9b8ad064efef534134d05ba",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -1834,7 +1834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-api"
         }
@@ -1971,7 +1971,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -2100,7 +2100,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -2194,7 +2194,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2266,7 +2266,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2399,7 +2399,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2508,7 +2508,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2633,7 +2633,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2713,7 +2713,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2773,7 +2773,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2910,7 +2910,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-device"
         }
@@ -2982,7 +2982,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3058,7 +3058,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-events"
         }
@@ -3122,7 +3122,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3345,7 +3345,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3420,7 +3420,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3548,7 +3548,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3604,7 +3604,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3680,7 +3680,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-log"
         }
@@ -3760,7 +3760,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3840,7 +3840,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -3908,7 +3908,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -3964,7 +3964,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4024,7 +4024,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4253,7 +4253,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4292,7 +4292,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4331,7 +4331,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4396,7 +4396,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4452,7 +4452,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4550,7 +4550,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4656,7 +4656,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -4750,7 +4750,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -4830,7 +4830,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -4919,7 +4919,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5011,7 +5011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-session"
         }
@@ -5099,7 +5099,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5195,7 +5195,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5247,7 +5247,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -5299,7 +5299,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -5480,7 +5480,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-time"
         }
@@ -5553,7 +5553,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+            "Rev": "586bbfdb4267c928103cf4b824d837848958710d"
           },
           "strip_prefix": "bd-workflows"
         }
@@ -6252,7 +6252,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "clap 4.5.45",
+              "id": "clap 4.5.46",
               "target": "clap"
             },
             {
@@ -6697,14 +6697,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "clap 4.5.45": {
+    "clap 4.5.46": {
       "name": "clap",
-      "version": "4.5.45",
+      "version": "4.5.46",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap/4.5.45/download",
-          "sha256": "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+          "url": "https://static.crates.io/crates/clap/4.5.46/download",
+          "sha256": "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
         }
       },
       "targets": [
@@ -6751,14 +6751,14 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.5.44",
+              "id": "clap_builder 4.5.46",
               "target": "clap_builder"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.5.45"
+        "version": "4.5.46"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -6767,14 +6767,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "clap_builder 4.5.44": {
+    "clap_builder 4.5.46": {
       "name": "clap_builder",
-      "version": "4.5.44",
+      "version": "4.5.46",
       "package_url": "https://github.com/clap-rs/clap",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/clap_builder/4.5.44/download",
-          "sha256": "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+          "url": "https://static.crates.io/crates/clap_builder/4.5.46/download",
+          "sha256": "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
         }
       },
       "targets": [
@@ -6851,7 +6851,7 @@
           }
         },
         "edition": "2021",
-        "version": "4.5.44"
+        "version": "4.5.46"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -7455,7 +7455,7 @@
               "target": "ciborium"
             },
             {
-              "id": "clap 4.5.45",
+              "id": "clap 4.5.46",
               "target": "clap"
             },
             {
@@ -8570,7 +8570,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.60.2",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
@@ -16914,7 +16914,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.60.2",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ],
@@ -18957,7 +18957,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.60.2",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]
@@ -22566,7 +22566,7 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.60.2",
+                "id": "windows-sys 0.52.0",
                 "target": "windows_sys"
               }
             ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "cbindgen",
  "libc",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -393,7 +393,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -443,7 +443,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -469,7 +469,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "log",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "bd-stats-common",
  "bytes",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -645,7 +645,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "base64",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "log",
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "ahash",
  "bd-proto",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -788,17 +788,17 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -809,7 +809,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "color-backtrace",
  "log",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "log",
  "protobuf 4.0.0-alpha.0",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "bd-proto",
  "cbindgen",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -869,7 +869,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "log",
  "tokio",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "sketches-rust",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1001,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -1014,7 +1014,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=b10c06f4a217e4a50f90073d1f496ad2d547f6ec#b10c06f4a217e4a50f90073d1f496ad2d547f6ec"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=586bbfdb4267c928103cf4b824d837848958710d#586bbfdb4267c928103cf4b824d837848958710d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1213,18 +1213,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1492,7 +1492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2768,7 +2768,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3677,7 +3677,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,31 +18,31 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.99"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec", default-features = false }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "b10c06f4a217e4a50f90073d1f496ad2d547f6ec" }
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d", default-features = false }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "586bbfdb4267c928103cf4b824d837848958710d" }
 chrono = "0.4.41"
-clap = { version = "4.5.45", features = ["derive", "env"] }
+clap = { version = "4.5.46", features = ["derive", "env"] }
 ctor = "0.5.0"
 env_logger = { version = "0.11.8", default-features = false }
 futures-util = "0.3.31"


### PR DESCRIPTION
Updates shared-core to bring in global state changes

The crash log now has all fields set via providers/addField

https://timeline.bitdrift.dev/session/365a0cd7-8ce9-483f-a875-a299a5a43e74?utm_source=sdk&expanded=4261826404135680677