### PR TITLE
[iOS] Provide custom fields to network requests

### DIFF
--- a/examples/swift/hello_world/LoggerCustomer.swift
+++ b/examples/swift/hello_world/LoggerCustomer.swift
@@ -96,10 +96,10 @@ final class LoggerCustomer: NSObject, URLSessionDelegate {
                 apiURL: apiURL
             )?
             .enableIntegrations(
-                [.urlSession(requestFieldProvider: CustomNetworkFieldProvider())], 
+                [.urlSession(requestFieldProvider: CustomNetworkFieldProvider())],
                 disableSwizzling: true
-        )
-        
+            )
+
         Logger.addField(withKey: "field_container_field_key", value: "field_container_value")
         Logger.logInfo("App launched. Logger configured.")
 

--- a/examples/swift/hello_world/LoggerCustomer.swift
+++ b/examples/swift/hello_world/LoggerCustomer.swift
@@ -95,8 +95,11 @@ final class LoggerCustomer: NSObject, URLSessionDelegate {
                 fieldProviders: [CustomFieldProvider()],
                 apiURL: apiURL
             )?
-            .enableIntegrations([.urlSession()], disableSwizzling: true)
-
+            .enableIntegrations(
+                [.urlSession(requestFieldProvider: CustomNetworkFieldProvider())], 
+                disableSwizzling: true
+        )
+        
         Logger.addField(withKey: "field_container_field_key", value: "field_container_value")
         Logger.logInfo("App launched. Logger configured.")
 
@@ -211,6 +214,15 @@ final class CustomFieldProvider: FieldProvider {
             "app": "hello_world",
             "user_id": self.userID,
             "invalid_utf8": invalidUTF8String,
+        ]
+    }
+}
+
+// Provides additional fields for each network request
+struct CustomNetworkFieldProvider: URLSessionRequestFieldProvider {
+    func provideExtraFields(for request: URLRequest) -> [String: String] {
+        return [
+            "additional_network_request_field": request.debugDescription,
         ]
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -38,6 +38,7 @@ import io.bitdrift.capture.apollo.CaptureApolloInterceptor
 import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.capture.network.okhttp.CaptureOkHttpEventListenerFactory
+import io.bitdrift.capture.network.okhttp.OkHttpRequestFieldProvider
 import io.bitdrift.gradletestapp.databinding.FragmentFirstBinding
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -155,8 +156,19 @@ class FirstFragment : Fragment() {
         okHttpClient =
             OkHttpClient
                 .Builder()
-                .eventListenerFactory(CaptureOkHttpEventListenerFactory())
-                .build()
+                .eventListenerFactory(
+                    CaptureOkHttpEventListenerFactory(
+                        extraFieldsProvider =
+                            OkHttpRequestFieldProvider { request ->
+                                mapOf(
+                                    "_additional_extra_field" to
+                                        System
+                                            .currentTimeMillis()
+                                            .toString(),
+                                )
+                            },
+                    ),
+                ).build()
 
         apolloClient =
             ApolloClient

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/FirstFragment.kt
@@ -161,10 +161,8 @@ class FirstFragment : Fragment() {
                         extraFieldsProvider =
                             OkHttpRequestFieldProvider { request ->
                                 mapOf(
-                                    "_additional_extra_field" to
-                                        System
-                                            .currentTimeMillis()
-                                            .toString(),
+                                    "additional_network_request_field" to
+                                        request.url.host,
                                 )
                             },
                     ),

--- a/platform/swift/source/LoggerIntegrator.swift
+++ b/platform/swift/source/LoggerIntegrator.swift
@@ -55,8 +55,8 @@ public final class LoggerIntegrator {
     /// - important: The SDK doesn't do any swizzling unless the `Integration.urlSession` integration is
     ///              enabled.
     ///
-    /// - parameter integrations:     The list of integrations to enable.
-    /// - parameter disableSwizzling: Whether integrations is allowed to do swizzling.
+    /// - parameter integrations:         The list of integrations to enable.
+    /// - parameter disableSwizzling:     Whether integrations is allowed to do swizzling.
     /// - parameter requestFieldProvider: Provider for extra fields appended to HTTP requests.
     ///
     /// - returns: The configured logger. This is the same instance that can be accessed via the

--- a/platform/swift/source/LoggerIntegrator.swift
+++ b/platform/swift/source/LoggerIntegrator.swift
@@ -57,6 +57,7 @@ public final class LoggerIntegrator {
     ///
     /// - parameter integrations:     The list of integrations to enable.
     /// - parameter disableSwizzling: Whether integrations is allowed to do swizzling.
+    /// - parameter requestFieldProvider: Provider for extra fields appended to HTTP requests.
     ///
     /// - returns: The configured logger. This is the same instance that can be accessed via the
     ///            `Logger.shared` property, but it's returned in a non-optional form here.

--- a/platform/swift/source/LoggerIntegrator.swift
+++ b/platform/swift/source/LoggerIntegrator.swift
@@ -9,14 +9,14 @@
 /// (e.g., URL APIs) or a third-party library (e.g., `CocoaLumberjack`).
 public final class Integration {
     private var isStarted = false
-    let start: (_ logger: Logging, _ disableSwizzling: Bool, _ requestFieldProvider: URLSessionRequestFieldProvider) -> Void
+    let start: (_ logger: Logging, _ disableSwizzling: Bool, _ requestFieldProvider: URLSessionRequestFieldProvider?) -> Void
 
     /// Creates a new integration.
     ///
     /// - parameter start: A closure that is called by the Capture SDK to notify the receiver that a given
     ///                    integration should start. The `Logging` instance passed as an argument to the
     ///                    closure should be used by the integration to emit Capture SDK logs.
-    public init(start: @escaping (_ logger: Logging, _ disableSwizzling: Bool, _ requestFieldProvider: URLSessionRequestFieldProvider) -> Void) {
+    public init(start: @escaping (_ logger: Logging, _ disableSwizzling: Bool, _ requestFieldProvider: URLSessionRequestFieldProvider?) -> Void) {
         self.start = start
     }
 
@@ -25,11 +25,11 @@ public final class Integration {
     /// - parameter logger:               The logger instance that should be used by the integration being
     ///                                   started to emit Capture SDK logs.
     /// - parameter disableSwizzling:     Whether the integration is allowed to do swizzling.
-    /// - parameter requestFieldProvider: Provider for extra request fields.
+    /// - parameter requestFieldProvider: Provider for extra fields appended to HTTP requests.
     public func start(
         with logger: Logging,
         disableSwizzling: Bool = false,
-        requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()
+        requestFieldProvider: URLSessionRequestFieldProvider? = nil
     ) {
         if self.isStarted {
             // TODO(Augustyniak): Log something here.
@@ -66,7 +66,7 @@ public final class LoggerIntegrator {
     public func enableIntegrations(
         _ integrations: [Integration],
         disableSwizzling: Bool = false,
-        requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()
+        requestFieldProvider: URLSessionRequestFieldProvider?=nil
     ) -> Logging {
         if self.enabled {
             return self.logger

--- a/platform/swift/source/LoggerIntegrator.swift
+++ b/platform/swift/source/LoggerIntegrator.swift
@@ -1,5 +1,6 @@
 // capture-sdk - bitdrift's client SDK
 // Copyright Bitdrift, Inc. All rights reserved.
+//
 // Use of this source code is governed by a source available license that can be found in the
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt

--- a/platform/swift/source/LoggerIntegrator.swift
+++ b/platform/swift/source/LoggerIntegrator.swift
@@ -1,6 +1,5 @@
 // capture-sdk - bitdrift's client SDK
 // Copyright Bitdrift, Inc. All rights reserved.
-//
 // Use of this source code is governed by a source available license that can be found in the
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
@@ -9,14 +8,14 @@
 /// (e.g., URL APIs) or a third-party library (e.g., `CocoaLumberjack`).
 public final class Integration {
     private var isStarted = false
-    let start: (_ logger: Logging, _ disableSwizzling: Bool) -> Void
+    let start: (_ logger: Logging, _ disableSwizzling: Bool, _ requestFieldProvider: URLSessionRequestFieldProvider) -> Void
 
     /// Creates a new integration.
     ///
     /// - parameter start: A closure that is called by the Capture SDK to notify the receiver that a given
     ///                    integration should start. The `Logging` instance passed as an argument to the
     ///                    closure should be used by the integration to emit Capture SDK logs.
-    public init(start: @escaping (_ logger: Logging, _ disableSwizzling: Bool) -> Void) {
+    public init(start: @escaping (_ logger: Logging, _ disableSwizzling: Bool, _ requestFieldProvider: URLSessionRequestFieldProvider) -> Void) {
         self.start = start
     }
 
@@ -25,14 +24,19 @@ public final class Integration {
     /// - parameter logger:           The logger instance that should be used by the integration being
     ///                               started to emit Capture SDK logs.
     /// - parameter disableSwizzling: Whether the integration is allowed to do swizzling.
-    public func start(with logger: Logging, disableSwizzling: Bool = false) {
+    /// - parameter requestFieldProvider: Provider for extra request fields.
+    public func start(
+        with logger: Logging,
+        disableSwizzling: Bool = false,
+        requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()
+    ) {
         if self.isStarted {
             // TODO(Augustyniak): Log something here.
             return
         }
 
         self.isStarted = true
-        self.start(logger, disableSwizzling)
+        self.start(logger, disableSwizzling, requestFieldProvider)
     }
 }
 
@@ -59,16 +63,16 @@ public final class LoggerIntegrator {
     @discardableResult
     public func enableIntegrations(
         _ integrations: [Integration],
-        disableSwizzling: Bool = false
-    ) -> Logging
-    {
+        disableSwizzling: Bool = false,
+        requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()
+    ) -> Logging {
         if self.enabled {
             return self.logger
         }
 
         self.enabled = true
         for integration in integrations {
-            integration.start(self.logger, disableSwizzling)
+            integration.start(self.logger, disableSwizzling, requestFieldProvider)
         }
 
         return self.logger

--- a/platform/swift/source/LoggerIntegrator.swift
+++ b/platform/swift/source/LoggerIntegrator.swift
@@ -21,9 +21,9 @@ public final class Integration {
 
     /// Starts the integration.
     ///
-    /// - parameter logger:           The logger instance that should be used by the integration being
-    ///                               started to emit Capture SDK logs.
-    /// - parameter disableSwizzling: Whether the integration is allowed to do swizzling.
+    /// - parameter logger:               The logger instance that should be used by the integration being
+    ///                                   started to emit Capture SDK logs.
+    /// - parameter disableSwizzling:     Whether the integration is allowed to do swizzling.
     /// - parameter requestFieldProvider: Provider for extra request fields.
     public func start(
         with logger: Logging,

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -49,7 +49,7 @@ final class URLSessionIntegration {
     private let underlyingLogger = Atomic<Logging?>(nil)
     /// The field provider for adding custom fields to request logs
     private let underlyingRequestFieldProvider = Atomic<URLSessionRequestFieldProvider>(
-      DefaultURLSessionRequestFieldProvider()
+        DefaultURLSessionRequestFieldProvider()
     )
     fileprivate static var swizzled = Atomic(false)
     static let shared = URLSessionIntegration()
@@ -57,7 +57,7 @@ final class URLSessionIntegration {
     var logger: Logging? {
         return self.underlyingLogger.load()
     }
-    
+
     var requestFieldProvider: URLSessionRequestFieldProvider {
         return self.underlyingRequestFieldProvider.load()
     }

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -28,12 +28,11 @@ extension Integration {
     ///              `URLSession.capture_makeSession(configuration:delegate:delegateQueue:)` method to create
     ///              `URLSession` instances.
     ///
-    /// - parameter requestFieldProvider: A provider that supplies additional key-value fields for each `URLRequest` logged by the integration.
-    ///                                   Defaults to `DefaultURLSessionRequestFieldProvider()` if not specified.
+    /// - parameter requestFieldProvider: An optional provider that supplies additional key-value fields for each `URLRequest` logged by the integration.
     ///
     /// - returns: The `URLSession` integration.
     ///
-    public static func urlSession(requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()) -> Integration {
+    public static func urlSession(requestFieldProvider: URLSessionRequestFieldProvider?=nil) -> Integration {
         .init { logger, disableSwizzling, _ in
             URLSessionIntegration.shared.start(
                 logger: logger,
@@ -48,9 +47,7 @@ final class URLSessionIntegration {
     /// The instance of Capture logger the library should use for logging.
     private let underlyingLogger = Atomic<Logging?>(nil)
     /// The field provider for adding custom fields to request logs
-    private let underlyingRequestFieldProvider = Atomic<URLSessionRequestFieldProvider>(
-        DefaultURLSessionRequestFieldProvider()
-    )
+    private let underlyingRequestFieldProvider = Atomic<URLSessionRequestFieldProvider?>(nil)
     fileprivate static var swizzled = Atomic(false)
     static let shared = URLSessionIntegration()
 
@@ -58,11 +55,11 @@ final class URLSessionIntegration {
         return self.underlyingLogger.load()
     }
 
-    var requestFieldProvider: URLSessionRequestFieldProvider {
+    var requestFieldProvider: URLSessionRequestFieldProvider? {
         return self.underlyingRequestFieldProvider.load()
     }
 
-    func start(logger: Logging, disableSwizzling: Bool, requestFieldProvider: URLSessionRequestFieldProvider) {
+    func start(logger: Logging, disableSwizzling: Bool, requestFieldProvider: URLSessionRequestFieldProvider?) {
         self.underlyingLogger.update { $0 = logger }
         self.underlyingRequestFieldProvider.update { $0 = requestFieldProvider }
         if disableSwizzling || Self.swizzled.load() {

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -27,6 +27,7 @@ extension Integration {
     ///              the integration as early in the app's lifecycle as possible, or use the
     ///              `URLSession.capture_makeSession(configuration:delegate:delegateQueue:)` method to create
     ///              `URLSession` instances.
+    ///
     /// - parameter requestFieldProvider: A provider that supplies additional key-value fields for each `URLRequest` logged by the integration.
     ///                                   Defaults to `DefaultURLSessionRequestFieldProvider()` if not specified.
     ///

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -31,6 +31,7 @@ extension Integration {
     ///                                   Defaults to `DefaultURLSessionRequestFieldProvider()` if not specified.
     ///
     /// - returns: The `URLSession` integration.
+    ///
     public static func urlSession(requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()) -> Integration {
         .init { logger, disableSwizzling, _ in
             URLSessionIntegration.shared.start(

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -27,6 +27,8 @@ extension Integration {
     ///              the integration as early in the app's lifecycle as possible, or use the
     ///              `URLSession.capture_makeSession(configuration:delegate:delegateQueue:)` method to create
     ///              `URLSession` instances.
+    /// - parameter requestFieldProvider: A provider that supplies additional key-value fields for each `URLRequest` logged by the integration.
+    ///                                   Defaults to `DefaultURLSessionRequestFieldProvider()` if not specified.
     ///
     /// - returns: The `URLSession` integration.
     public static func urlSession(requestFieldProvider: URLSessionRequestFieldProvider = DefaultURLSessionRequestFieldProvider()) -> Integration {

--- a/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
@@ -18,17 +18,3 @@ public protocol URLSessionRequestFieldProvider {
     ///            that will be sent by the URLSession integration.
     func provideExtraFields(for request: URLRequest) -> [String: String]
 }
-
-/// Default implementation that provides no extra fields.
-public struct DefaultURLSessionRequestFieldProvider: URLSessionRequestFieldProvider {
-    public init() {}
-
-    /// Always returns an empty dictionary, meaning no extra fields are added.
-    ///
-    /// - parameter _: The `URLRequest` being logged (unused in this implementation).
-    ///
-    /// - returns: An empty dictionary.
-    public func provideExtraFields(for _: URLRequest) -> [String: String] {
-        return [:]
-    }
-}

--- a/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
@@ -6,20 +6,26 @@
 
 import Foundation
 
-/// Provides additional custom fields to add to http request logs automatically sent
+/// Provides additional custom fields to add to HTTP request logs automatically sent
 /// by using the URLSession integration.
 public protocol URLSessionRequestFieldProvider {
-    /// @return a map of fields to add to the http request log that will be sent
-    /// by the URLSession integration for this request.
+    /// Provides extra fields for a given request.
+    ///
+    /// - Parameter request: The `URLRequest` being logged.
+    /// - Returns: A dictionary of key-value pairs to add to the request log
+    ///            that will be sent by the URLSession integration.
     func provideExtraFields(for request: URLRequest) -> [String: String]
 }
 
-/// Default implementation that provides no extra fields
+/// Default implementation that provides no extra fields.
 public struct DefaultURLSessionRequestFieldProvider: URLSessionRequestFieldProvider {
     public init() {}
-    
-    public func provideExtraFields(for request: URLRequest) -> [String: String] {
+
+    /// Always returns an empty dictionary, meaning no extra fields are added.
+    ///
+    /// - Parameter request: The `URLRequest` being logged.
+    /// - Returns: An empty dictionary.
+    public func provideExtraFields(for _: URLRequest) -> [String: String] {
         return [:]
     }
 }
-

--- a/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
@@ -1,0 +1,25 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import Foundation
+
+/// Provides additional custom fields to add to http request logs automatically sent
+/// by using the URLSession integration.
+public protocol URLSessionRequestFieldProvider {
+    /// @return a map of fields to add to the http request log that will be sent
+    /// by the URLSession integration for this request.
+    func provideExtraFields(for request: URLRequest) -> [String: String]
+}
+
+/// Default implementation that provides no extra fields
+public struct DefaultURLSessionRequestFieldProvider: URLSessionRequestFieldProvider {
+    public init() {}
+    
+    public func provideExtraFields(for request: URLRequest) -> [String: String] {
+        return [:]
+    }
+}
+

--- a/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
@@ -11,8 +11,8 @@ import Foundation
 public protocol URLSessionRequestFieldProvider {
     /// Provides extra fields for a given request.
     ///
-    /// - Parameter request: The `URLRequest` being logged.
-    /// - Returns: A dictionary of key-value pairs to add to the request log
+    /// - parameter request: The `URLRequest` being logged.
+    /// - returns: A dictionary of key-value pairs to add to the request log
     ///            that will be sent by the URLSession integration.
     func provideExtraFields(for request: URLRequest) -> [String: String]
 }
@@ -23,8 +23,8 @@ public struct DefaultURLSessionRequestFieldProvider: URLSessionRequestFieldProvi
 
     /// Always returns an empty dictionary, meaning no extra fields are added.
     ///
-    /// - Parameter request: The `URLRequest` being logged.
-    /// - Returns: An empty dictionary.
+    /// - parameter request: The `URLRequest` being logged.
+    /// - returns: An empty dictionary.
     public func provideExtraFields(for _: URLRequest) -> [String: String] {
         return [:]
     }

--- a/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
@@ -1,5 +1,6 @@
 // capture-sdk - bitdrift's client SDK
 // Copyright Bitdrift, Inc. All rights reserved.
+//
 // Use of this source code is governed by a source available license that can be found in the
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt

--- a/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionRequestFieldProvider.swift
@@ -12,6 +12,7 @@ public protocol URLSessionRequestFieldProvider {
     /// Provides extra fields for a given request.
     ///
     /// - parameter request: The `URLRequest` being logged.
+    ///
     /// - returns: A dictionary of key-value pairs to add to the request log
     ///            that will be sent by the URLSession integration.
     func provideExtraFields(for request: URLRequest) -> [String: String]
@@ -23,7 +24,8 @@ public struct DefaultURLSessionRequestFieldProvider: URLSessionRequestFieldProvi
 
     /// Always returns an empty dictionary, meaning no extra fields are added.
     ///
-    /// - parameter request: The `URLRequest` being logged.
+    /// - parameter _: The `URLRequest` being logged (unused in this implementation).
+    ///
     /// - returns: An empty dictionary.
     public func provideExtraFields(for _: URLRequest) -> [String: String] {
         return [:]

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -67,12 +67,11 @@ final class URLSessionTaskTracker {
             guard let requestInfo = HTTPRequestInfo(task: task, extraFields: extraFields) else {
                 return
             }
-            
+
             task.cap_requestInfo = requestInfo
             URLSessionIntegration.shared.logger?.log(requestInfo, file: nil, line: nil, function: nil)
         }
     }
-    
 
     // Observation: This method is called on `URLSession` delegate queue.
     func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -58,14 +58,21 @@ final class URLSessionTaskTracker {
                 return
             }
 
-            guard let requestInfo = HTTPRequestInfo(task: task) else {
+            let extraFields: [String: String]
+            if let originalRequest = task.originalRequest {
+                extraFields = URLSessionIntegration.shared.requestFieldProvider.provideExtraFields(for: originalRequest)
+            } else {
+                extraFields = [:]
+            }
+            guard let requestInfo = HTTPRequestInfo(task: task, extraFields: extraFields) else {
                 return
             }
-
+            
             task.cap_requestInfo = requestInfo
             URLSessionIntegration.shared.logger?.log(requestInfo, file: nil, line: nil, function: nil)
         }
     }
+    
 
     // Observation: This method is called on `URLSession` delegate queue.
     func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -58,11 +58,9 @@ final class URLSessionTaskTracker {
                 return
             }
 
-            let extraFields: [String: String]
+            var extraFields: Fields?
             if let originalRequest = task.originalRequest {
-                extraFields = URLSessionIntegration.shared.requestFieldProvider.provideExtraFields(for: originalRequest)
-            } else {
-                extraFields = [:]
+                extraFields = URLSessionIntegration.shared.requestFieldProvider?.provideExtraFields(for: originalRequest)
             }
             guard let requestInfo = HTTPRequestInfo(task: task, extraFields: extraFields) else {
                 return

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -129,7 +129,7 @@ public struct HTTPRequestInfo {
         if let extraFields = self.extraFields {
             fields.merge(extraFields) { old, _ in old }
         }
-        
+
         return fields
     }
 
@@ -154,6 +154,8 @@ extension HTTPRequestInfo {
     /// - parameter bytesExpectedToSendCount: The number of bytes the task expects to send in request body.
     ///                                       If not provided, the implementation uses to the number of
     ///                                       bytes of request's `httpBody`.
+    /// - parameter extraFields:              Additional custom fields to append to the request log.
+    // 
     public init(urlRequest: URLRequest, bytesExpectedToSendCount: Int64? = nil, extraFields: Fields?) {
         let bytesExpectedToSendCount =
             bytesExpectedToSendCount ?? urlRequest.httpBody.flatMap { Int64($0.count) }

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -178,8 +178,8 @@ extension HTTPRequestInfo {
     /// Initializes a new instance of the receiver using a provided `URLSessionTask`. The initialization
     /// succeeds as long as `originalRequest` property of the passed task is not equal to `nil`.
     ///
-    /// - parameter task: The task to initialize the request info with.
-    /// - parameter extraFields: Additional fields user may want to append to Requests
+    /// - parameter task:        The task to initialize the request info with.
+    /// - parameter extraFields: Additional fields user may want to append to requests.
     public init?(task: URLSessionTask, extraFields: Fields? = nil) {
         if let request = task.originalRequest {
             if task is URLSessionDataTask {

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -155,7 +155,7 @@ extension HTTPRequestInfo {
     ///                                       If not provided, the implementation uses to the number of
     ///                                       bytes of request's `httpBody`.
     /// - parameter extraFields:              Additional custom fields to append to the request log.
-    // 
+    //
     public init(urlRequest: URLRequest, bytesExpectedToSendCount: Int64? = nil, extraFields: Fields?) {
         let bytesExpectedToSendCount =
             bytesExpectedToSendCount ?? urlRequest.httpBody.flatMap { Int64($0.count) }

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -178,7 +178,7 @@ extension HTTPRequestInfo {
     ///
     /// - parameter task: The task to initialize the request info with.
     /// - parameter extraFields: Additional fields user may want to append to Requests
-    public init?(task: URLSessionTask, extraFields: Fields?) {
+    public init?(task: URLSessionTask, extraFields: Fields? = nil) {
         if let request = task.originalRequest {
             if task is URLSessionDataTask {
                 // For basic data tasks we just use `countOfBytesExpectedToSend` for request body estimate.

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -129,7 +129,7 @@ public struct HTTPRequestInfo {
         if let extraFields = self.extraFields {
             fields.merge(extraFields) { old, _ in old }
         }
-
+        
         return fields
     }
 
@@ -154,7 +154,7 @@ extension HTTPRequestInfo {
     /// - parameter bytesExpectedToSendCount: The number of bytes the task expects to send in request body.
     ///                                       If not provided, the implementation uses to the number of
     ///                                       bytes of request's `httpBody`.
-    public init(urlRequest: URLRequest, bytesExpectedToSendCount: Int64? = nil) {
+    public init(urlRequest: URLRequest, bytesExpectedToSendCount: Int64? = nil, extraFields: Fields?) {
         let bytesExpectedToSendCount =
             bytesExpectedToSendCount ?? urlRequest.httpBody.flatMap { Int64($0.count) }
         self.init(
@@ -168,7 +168,8 @@ extension HTTPRequestInfo {
             },
             query: urlRequest.url?.query,
             headers: urlRequest.allHTTPHeaderFields,
-            bytesExpectedToSendCount: bytesExpectedToSendCount
+            bytesExpectedToSendCount: bytesExpectedToSendCount,
+            extraFields: extraFields
         )
     }
 
@@ -176,11 +177,16 @@ extension HTTPRequestInfo {
     /// succeeds as long as `originalRequest` property of the passed task is not equal to `nil`.
     ///
     /// - parameter task: The task to initialize the request info with.
-    public init?(task: URLSessionTask) {
+    /// - parameter extraFields: Additional fields user may want to append to Requests
+    public init?(task: URLSessionTask, extraFields: Fields?) {
         if let request = task.originalRequest {
             if task is URLSessionDataTask {
                 // For basic data tasks we just use `countOfBytesExpectedToSend` for request body estimate.
-                self.init(urlRequest: request, bytesExpectedToSendCount: task.countOfBytesExpectedToSend)
+                self.init(
+                    urlRequest: request,
+                    bytesExpectedToSendCount: task.countOfBytesExpectedToSend,
+                    extraFields: extraFields
+                )
             } else {
                 // Task types such as upload tasks are a bit more tricky since they do not have `httpBody`
                 // property set and their value of `countOfBytesExpectedToSend` may be equal to 0 even if
@@ -188,7 +194,11 @@ extension HTTPRequestInfo {
                 // only if it's greater than 0.
                 let bytesExpectedToSendCount =
                     task.countOfBytesExpectedToSend > 0 ? task.countOfBytesExpectedToSend : nil
-                self.init(urlRequest: request, bytesExpectedToSendCount: bytesExpectedToSendCount)
+                self.init(
+                    urlRequest: request,
+                    bytesExpectedToSendCount: bytesExpectedToSendCount,
+                    extraFields: extraFields
+                )
             }
         } else {
             return nil

--- a/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
@@ -52,9 +52,7 @@ final class LoggerIntegratorTests: XCTestCase {
     func testCustomRequestFieldProviderIsPassed() throws {
         var receivedFields: [String: String]?
         let fakeProvider = FakeURLSessionRequestFieldProvider()
-
         let integration = Integration { _, _, provider in
-            // Call provider manually to simulate usage
             let request = URLRequest(url: URL(string: "https://example.com")!)
             receivedFields = provider.provideExtraFields(for: request)
         }
@@ -65,7 +63,7 @@ final class LoggerIntegratorTests: XCTestCase {
         XCTAssertEqual(receivedFields?["mock_field"], "mock_value")
     }
 
-    func testDefaultRequestFieldProviderIsUsedWhenNoneProvided() throws {
+    func testDefaultRequestFieldProviderShouldReturnEmptyExtraFields() throws {
         var receivedFields: [String: String]?
         let integration = Integration { _, _, provider in
             let request = URLRequest(url: URL(string: "https://example.com")!)
@@ -73,10 +71,8 @@ final class LoggerIntegratorTests: XCTestCase {
         }
 
         let integrator = LoggerIntegrator(logger: MockLogging())
-        // Don’t pass custom provider → should fallback to DefaultURLSessionRequestFieldProvider
         integrator.enableIntegrations([integration])
 
-        // DefaultURLSessionRequestFieldProvider returns an empty dictionary by default
         XCTAssertTrue(receivedFields?.isEmpty ?? false)
     }
 }

--- a/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
@@ -1,5 +1,6 @@
 // capture-sdk - bitdrift's client SDK
-// Copyright Bitdrift, Inc.
+// Copyright Bitdrift, Inc. All rights reserved.
+//
 // Use of this source code is governed by a source available license that can be found in the
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt

--- a/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
@@ -55,7 +55,7 @@ final class LoggerIntegratorTests: XCTestCase {
         let fakeProvider = FakeURLSessionRequestFieldProvider()
         let integration = Integration { _, _, provider in
             let request = URLRequest(url: URL(string: "https://example.com")!)
-            receivedFields = provider.provideExtraFields(for: request)
+            receivedFields = provider?.provideExtraFields(for: request)
         }
 
         let integrator = LoggerIntegrator(logger: MockLogging())
@@ -68,7 +68,7 @@ final class LoggerIntegratorTests: XCTestCase {
         var receivedFields: [String: String]?
         let integration = Integration { _, _, provider in
             let request = URLRequest(url: URL(string: "https://example.com")!)
-            receivedFields = provider.provideExtraFields(for: request)
+            receivedFields = provider?.provideExtraFields(for: request)
         }
 
         let integrator = LoggerIntegrator(logger: MockLogging())

--- a/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerIntegratorTests.swift
@@ -74,7 +74,7 @@ final class LoggerIntegratorTests: XCTestCase {
         let integrator = LoggerIntegrator(logger: MockLogging())
         integrator.enableIntegrations([integration])
 
-        XCTAssertTrue(receivedFields?.isEmpty ?? false)
+        XCTAssertNil(receivedFields)
     }
 }
 

--- a/test/platform/swift/unit_integration/core/LoggerSharedTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerSharedTests.swift
@@ -22,7 +22,7 @@ final class LoggerSharedTests: XCTestCase {
 
     func testIntegrationsAreEnabledOnlyOnce() throws {
         var integrationStartsCount = 0
-        let integration = Integration { _, _ in
+        let integration = Integration { _, _, _ in
             integrationStartsCount += 1
         }
 

--- a/test/platform/swift/unit_integration/core/bindings/HTTPRequestInfo+ExtensionsTests.swift
+++ b/test/platform/swift/unit_integration/core/bindings/HTTPRequestInfo+ExtensionsTests.swift
@@ -15,7 +15,7 @@ final class HTTPRequestInfoExtensionsTests: XCTestCase {
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData, timeoutInterval: 15.0)
         request.httpMethod = "POST"
 
-        let requestInfo = HTTPRequestInfo(urlRequest: request)
+        let requestInfo = HTTPRequestInfo(urlRequest: request, extraFields: nil)
 
         XCTAssertEqual("foo.com", requestInfo.host)
         XCTAssertEqual("/ping", requestInfo.path?.value)

--- a/test/platform/swift/unit_integration/core/logging/HTTPRequestInfoTests.swift
+++ b/test/platform/swift/unit_integration/core/logging/HTTPRequestInfoTests.swift
@@ -66,7 +66,7 @@ final class HTTPRequestInfoTests: XCTestCase {
         request.addValue("value", forHTTPHeaderField: "key")
         request.addValue("/test/{explicit_id}", forHTTPHeaderField: kCapturePathTemplateHeaderKey)
 
-        let info = HTTPRequestInfo(urlRequest: request)
+        let info = HTTPRequestInfo(urlRequest: request, extraFields: nil)
         var fields = try XCTUnwrap(info.toFields() as? [String: String])
 
         XCTAssertNotNil(fields.removeValue(forKey: "_span_id"))


### PR DESCRIPTION
### What

Resolves BIT-6252

Bring parity on iOS with the recent Android addition added in https://github.com/bitdriftlabs/capture-sdk/pull/540 which support adding custom fields to network requests

### Verification

Check sample app session below with network requests /responses that now contains `additional_network_request_field`

| OS type | Image |
|-----|-------|
| [iOS Session](https://timeline.bitdrift.dev/session/DC632123-8838-4B27-A917-72B0CDEEF010?utm_source=sdk&pages=1&utilization=0&expanded=7272735427352928998) | <img width="422" height="87" alt="image" src="https://github.com/user-attachments/assets/0988c60a-c88b-4ca1-94d1-82bd794182fe" /> |
| [Android Session](https://timeline.bitdrift.dev/session/a8b42467-fd68-4e4c-8535-1adbd049f79b?utm_source=sdk&pages=1&utilization=0&expanded=-930040541736966171) | <img width="253" height="144" alt="image" src="https://github.com/user-attachments/assets/385c3d02-aa58-41fb-b4a8-dd08d82cc5e7" /> |

