### PR TITLE
Bump shared-core for better rate limiting backoff

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "043713ea46019ea30940cd014667eb7fc45cdccd7ac9d394437a444b9343d663",
+  "checksum": "e4d26c19b6b7d731c6688a4e2e0260b9f69a85c5a3155d70bec20f3de937a19f",
   "crates": {
     "addr2line 0.24.2": {
       "name": "addr2line",
@@ -1834,7 +1834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-api"
         }
@@ -1971,7 +1971,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -2100,7 +2100,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -2198,7 +2198,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2270,7 +2270,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2403,7 +2403,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2512,7 +2512,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2637,7 +2637,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2717,7 +2717,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2777,7 +2777,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2914,7 +2914,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-device"
         }
@@ -2986,7 +2986,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3062,7 +3062,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-events"
         }
@@ -3126,7 +3126,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3349,7 +3349,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3424,7 +3424,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3552,7 +3552,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3608,7 +3608,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3684,7 +3684,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-log"
         }
@@ -3764,7 +3764,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3844,7 +3844,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -3912,7 +3912,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -3968,7 +3968,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4028,7 +4028,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4257,7 +4257,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4296,7 +4296,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4335,7 +4335,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4400,7 +4400,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4456,7 +4456,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4554,7 +4554,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4660,7 +4660,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -4754,7 +4754,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -4834,7 +4834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -4923,7 +4923,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5015,7 +5015,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-session"
         }
@@ -5103,7 +5103,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5199,7 +5199,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5251,7 +5251,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -5303,7 +5303,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -5484,7 +5484,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-time"
         }
@@ -5557,7 +5557,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "9db7b41715950050459e89304b5ee32dcb13a70a"
+            "Rev": "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -380,7 +380,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -486,7 +486,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "log",
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -555,7 +555,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "bd-stats-common",
  "bytes",
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "base64",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "log",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "ahash",
  "bd-proto",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -789,17 +789,17 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "color-backtrace",
  "log",
@@ -820,7 +820,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "log",
  "protobuf 4.0.0-alpha.0",
@@ -831,7 +831,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "bd-pgv",
  "bytes",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "bd-proto",
  "cbindgen",
@@ -854,7 +854,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -870,7 +870,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -924,7 +924,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "log",
  "tokio",
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "sketches-rust",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "async-trait",
  "parking_lot",
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=9db7b41715950050459e89304b5ee32dcb13a70a#9db7b41715950050459e89304b5ee32dcb13a70a"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49#4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,29 +18,29 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.99"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a", default-features = false }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "9db7b41715950050459e89304b5ee32dcb13a70a" }
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49", default-features = false }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "4d4873c2d7fac7adaa6ffa0c322692fabb5c2c49" }
 chrono = "0.4.41"
 clap = { version = "4.5.46", features = ["derive", "env"] }
 ctor = "0.5.0"


### PR DESCRIPTION
Bump shared-core for https://github.com/bitdriftlabs/shared-core/pull/224

### Verification

[Android Gradle Test session](https://timeline.bitdrift.dev/session/4fda8892-8e75-47ca-9e28-b2a3e0aa929a?utm_source=sdk&pages=1&utilization=0&expanded=6928725493811316135)

[Android Bazel Test session](https://timeline.bitdrift.dev/session/e79e82ed-1fc7-499f-b79e-c6f47bc0e993?utm_source=sdk&pages=1&utilization=0&expanded=5640934324172272429)

[iOS Test session](https://timeline.bitdrift.dev/session/227C5F17-E663-4BEA-A7E4-6E37282AAF4B?utm_source=sdk) 

<img width="416" height="240" alt="image" src="https://github.com/user-attachments/assets/460d8467-9a96-4b36-bf34-bd3120f09035" />
