### PR TITLE
Update to latest KSCrash

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -75,7 +75,7 @@ new_git_repository(
 new_git_repository(
     name = "kscrash",
     build_file = "//bazel:BUILD.kscrash",
-    commit = "f81af773ae3172718a03bdcb89359bb9e6f34c08",
+    commit = "f0241a44f723a6b29c9db2a303917e89256a2557",
     remote = "https://github.com/kstenerud/KSCrash.git",
 )
 


### PR DESCRIPTION
I've updated KSCrash to make it play nicer with other crash handlers:

* [698](https://github.com/kstenerud/KSCrash/pull/698): Be more conservative when uninstalling after a crash. There were edge cases where it could end up calling an already uninstalled handler, leading to undefined behavior.
* [699](https://github.com/kstenerud/KSCrash/pull/699): Namespace any public facing strings (such as thread names) so that it's clear which library they belong to.
