### PR TITLE
rerun build.rs when .sdk_version changes

### DIFF
--- a/platform/shared/build.rs
+++ b/platform/shared/build.rs
@@ -16,4 +16,5 @@ fn main() {
 
   fs::write(&dest_path, format!("\"{version}\"")).unwrap();
   println!("cargo::rerun-if-changed=build.rs");
+  println!("cargo::rerun-if-changed=.sdk_version");
 }


### PR DESCRIPTION
This invalidates the output of the build.rs when .sdk_version changes