### PR TITLE
include all binary images from android tombstones

### DIFF
--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/NativeCrashProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/NativeCrashProcessorTest.kt
@@ -17,7 +17,7 @@ import java.io.ByteArrayOutputStream
 
 class NativeCrashProcessorTest {
     @Test
-    fun `dedupes by build-id and picks the lowest address memory map for report`() {
+    fun `populates buildId for binary images`() {
         val tombstone =
             TombstoneProtos.Tombstone
                 .newBuilder()
@@ -31,34 +31,112 @@ class NativeCrashProcessorTest {
                             .addCurrentBacktrace(
                                 TombstoneProtos.BacktraceFrame
                                     .newBuilder()
-                                    .setBuildId("build-id"),
+                                    .also {
+                                        it.fileName = "file1"
+                                        it.buildId = "build-id"
+                                        it.pc = 110
+                                    },
                             ).build(),
                     )
-
                     it.addMemoryMappings(
                         TombstoneProtos.MemoryMapping
                             .newBuilder()
-                            .setBuildId("build-id")
-                            .setBeginAddress(200),
+                            .also {
+                                it.mappingName = "file1"
+                                it.buildId = "build-id"
+                                it.beginAddress = 100
+                                it.endAddress = 149
+                            },
                     )
                     it.addMemoryMappings(
                         TombstoneProtos.MemoryMapping
                             .newBuilder()
-                            .setBuildId("build-id")
-                            .setBeginAddress(150),
+                            .also {
+                                it.mappingName = "file1"
+                                it.buildId = "build-id"
+                                it.beginAddress = 150
+                                it.beginAddress = 199
+                            },
                     )
                     it.addMemoryMappings(
                         TombstoneProtos.MemoryMapping
                             .newBuilder()
-                            .setBuildId("build-id")
-                            .setBeginAddress(100),
+                            .also {
+                                it.mappingName = "file1"
+                                it.buildId = "build-id"
+                                it.beginAddress = 200
+                                it.endAddress = 250
+                            },
                     )
                 }.build()
 
         val report = makeReport(tombstone)
 
         assertThat(report.binaryImagesLength).isEqualTo(1)
-        assertThat(report.binaryImages(0)?.loadAddress).isEqualTo(100.toULong())
+
+        val file1 = report.binaryImages(0)!!
+        assertThat(file1.loadAddress).isEqualTo(100.toULong())
+        assertThat(file1.path).isEqualTo("file1")
+        assertThat(file1.id).isEqualTo("build-id")
+    }
+
+    @Test
+    fun `handles missing buildId in binary images`() {
+        val tombstone =
+            TombstoneProtos.Tombstone
+                .newBuilder()
+                .setTid(1)
+                .also {
+                    it.putThreads(
+                        1,
+                        TombstoneProtos.Thread
+                            .newBuilder()
+                            .setId(1)
+                            .addCurrentBacktrace(
+                                TombstoneProtos.BacktraceFrame
+                                    .newBuilder()
+                                    .also {
+                                        it.fileName = "file"
+                                        it.pc = 410
+                                    },
+                            ).build(),
+                    )
+                    it.addMemoryMappings(
+                        TombstoneProtos.MemoryMapping
+                            .newBuilder()
+                            .also {
+                                it.mappingName = "file"
+                                it.beginAddress = 400
+                                it.endAddress = 449
+                            },
+                    )
+                    it.addMemoryMappings(
+                        TombstoneProtos.MemoryMapping
+                            .newBuilder()
+                            .also {
+                                it.mappingName = "file"
+                                it.beginAddress = 450
+                                it.endAddress = 499
+                            },
+                    )
+                    it.addMemoryMappings(
+                        TombstoneProtos.MemoryMapping
+                            .newBuilder()
+                            .also {
+                                it.mappingName = "file"
+                                it.beginAddress = 500
+                                it.endAddress = 505
+                            },
+                    )
+                }.build()
+
+        val report = makeReport(tombstone)
+
+        assertThat(report.binaryImagesLength).isEqualTo(1)
+
+        val file = report.binaryImages(0)!!
+        assertThat(file.loadAddress).isEqualTo(400.toULong())
+        assertThat(file.path).isEqualTo("file")
     }
 
     fun makeReport(tombstone: TombstoneProtos.Tombstone): Report {
@@ -67,7 +145,8 @@ class NativeCrashProcessorTest {
         val tombstoneStream = ByteArrayInputStream(out.toByteArray())
 
         val flatBufferBuilder = FlatBufferBuilder()
-        val reportOffset = NativeCrashProcessor.process(flatBufferBuilder, 0, 0, 0, "description", tombstoneStream)
+        val reportOffset =
+            NativeCrashProcessor.process(flatBufferBuilder, 0, 0, 0, "description", tombstoneStream)
 
         flatBufferBuilder.finish(reportOffset)
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/NativeCrashProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/NativeCrashProcessorTest.kt
@@ -92,11 +92,11 @@ class NativeCrashProcessorTest {
         assertThat(report.binaryImagesLength).isEqualTo(1)
         val file = report.binaryImages(0)!!
         assertThat(file.loadAddress).isEqualTo(400.toULong())
-        assertThat(file.path).isEqualTo("anonymous")
+        assertThat(file.path).isEqualTo("<anonymous:190>")
 
         val frame =
             report.threadDetails!!.threads(0)!!.stackTrace(0)!!
-        assertThat(frame.imageId).isEqualTo("anonymous")
+        assertThat(frame.imageId).isEqualTo("<anonymous:190>")
     }
 
     data class SimpleMapping(


### PR DESCRIPTION
Instead of only including binary images with a valid build ID, synthesize a binary image for each mapped region referred to by the stack trace. This ensures that we have all the information we need for all frames, even if they don't have a build ID