### PR TITLE
Client attributes perf improvements

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/attributes/ClientAttributes.kt
@@ -76,21 +76,25 @@ internal class ClientAttributes(
         )
     }
 
+    private val foregroundAttributes: Fields by lazy { constantAttributesMap + (FOREGROUND_FIELD_KEY to "1") }
+    private val backgroundAttributes: Fields by lazy { constantAttributesMap + (FOREGROUND_FIELD_KEY to "0") }
+
     override fun invoke(): Fields =
-        constantAttributesMap.toMutableMap().apply {
-            // Whether or not the app was in the background by the time the log was fired.
-            this["foreground"] = isForeground()
+        if (isForeground()) {
+            foregroundAttributes
+        } else {
+            backgroundAttributes
         }
 
-    private fun isForeground(): String {
+    private fun isForeground(): Boolean {
         // refer to lifecycle states https://developer.android.com/topic/libraries/architecture/lifecycle#lc
         val appState = processLifecycleOwner.lifecycle.currentState
         return if (appState.isAtLeast(Lifecycle.State.STARTED)) {
             // onStart call happened - app is in foreground
-            "1"
+            true
         } else {
             // onStop call happened - app is in background
-            "0"
+            false
         }
     }
 
@@ -141,5 +145,7 @@ internal class ClientAttributes(
         private const val UNKNOWN_FIELD_VALUE = "unknown"
 
         private const val DEBUG_BUILD_INSTALLATION_MESSAGE = "Debug build installation"
+
+        private const val FOREGROUND_FIELD_KEY = "foreground"
     }
 }


### PR DESCRIPTION
### What

Follow up to https://github.com/bitdriftlabs/capture-sdk/pull/558

In this case we avoid creating new map upon each `invoke` call and use the priorly cache map with foreground/background event

### Benchmark Comparison

| Main | PR |
| ------| ------|
| <img width="1205" height="171" alt="image" src="https://github.com/user-attachments/assets/02005868-5162-449b-b580-3cacf596eff3" /> | <img width="1194" height="184" alt="image" src="https://github.com/user-attachments/assets/2433dc85-2429-48dc-ab11-d88405f404e2" /> |
| 10999 allocs | 0 allocs |

