### PR TITLE
Use resilient storage for globals

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f82c53dbe0d8bcfb4edf75508e8596220b4ff1dc97dd37f49f86e8a61af24c73",
+  "checksum": "17babf02f978c40081fc31e0f9091d487e0424ee0165fa275af861b01fad5a70",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -19146,6 +19146,10 @@
             {
               "id": "bd-bonjson 1.0.0",
               "target": "bd_bonjson"
+            },
+            {
+              "id": "bd-bonjson-ffi 1.0.0",
+              "target": "bd_bonjson_ffi"
             },
             {
               "id": "bd-client-common 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,6 +3138,7 @@ name = "test_swift_bridge"
 version = "1.0.0"
 dependencies = [
  "bd-bonjson",
+ "bd-bonjson-ffi",
  "bd-client-common",
  "bd-error-reporter",
  "bd-key-value",

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -50,7 +50,6 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
      * @param applicationVersion the version of the current app, used to identify with the backend
      * @param model the host device model, used to identify with the backend
      * @param network the network implementation to use to communicate with the backend
-     * @param preferences the preferences storage to use for persistent storage of simple settings and configuration.
      * @param errorReporter the error reporter to use for reporting error to bitdrift services.
      * @param startInSleepMode true to initialize in sleep mode
      */
@@ -66,7 +65,6 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
         applicationVersion: String,
         model: String,
         network: ICaptureNetwork,
-        preferences: IPreferences,
         errorReporter: IErrorReporter,
         startInSleepMode: Boolean,
     ): Long

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IBridge.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IBridge.kt
@@ -24,7 +24,6 @@ internal interface IBridge {
         applicationVersion: String,
         model: String,
         network: ICaptureNetwork,
-        preferences: IPreferences,
         errorReporter: IErrorReporter,
         startInSleepMode: Boolean,
     ): Long

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -201,7 +201,6 @@ internal class LoggerImpl(
                 clientAttributes.appVersion,
                 deviceAttributes.model(),
                 network,
-                preferences,
                 localErrorReporter,
                 configuration.sleepMode == SleepMode.ACTIVE,
             )

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
@@ -86,7 +86,6 @@ class CaptureLoggerNetworkTest {
                 "test",
                 network,
                 mock(),
-                mock(),
                 false,
             )
         CaptureJniLibrary.startLogger(logger)
@@ -169,7 +168,6 @@ class CaptureLoggerNetworkTest {
                 "test",
                 network,
                 mock(),
-                mock(),
                 false,
             )
         CaptureJniLibrary.startLogger(loggerId)
@@ -203,7 +201,6 @@ class CaptureLoggerNetworkTest {
                 network,
                 // this test fails if we pass mock() in here. It has something to do with
                 // jni trying to call methods on Mockito mocks.
-                MockPreferences(),
                 mock(),
                 false,
             )

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
@@ -44,7 +44,6 @@ class ConfigurationTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
-                anyOrNull(),
             ),
         ).thenReturn(-1L)
 
@@ -76,7 +75,6 @@ class ConfigurationTest {
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
-            anyOrNull(),
         )
 
         // We perform another attempt to configure the logger to verify that
@@ -92,7 +90,6 @@ class ConfigurationTest {
 
         // We verify that the second configure call was a no-op.
         verify(bridge, times(1)).createLogger(
-            anyOrNull(),
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -267,8 +267,7 @@ fn parse_address_value(address: &Value) -> anyhow::Result<u64> {
       })
       .ok_or_else(|| anyhow::anyhow!("Address value is negative: {address}")),
     _ => Err(anyhow::anyhow!(
-      "Address value is not a valid number (got {:?})",
-      address
+      "Address value is not a valid number (got {address:?})"
     )),
   }
 }

--- a/test/platform/swift/bridging/Cargo.toml
+++ b/test/platform/swift/bridging/Cargo.toml
@@ -8,6 +8,7 @@ version      = "1.0.0"
 
 [dependencies]
 bd-bonjson                = { workspace = true }
+bd-bonjson-ffi            = { workspace = true }
 bd-client-common          = { workspace = true }
 bd-error-reporter         = { workspace = true }
 bd-key-value              = { workspace = true }


### PR DESCRIPTION
This PR makes use of https://github.com/bitdriftlabs/shared-core/pull/255 to provide alternatives for the current `Storage` implementations for storing global data on mobile.

Instead of `Preferences` (Android) and `UserDefaults` (iOS), we use the crash-resilient KV store, which is stored in the sdk directory as `storage.jrna` and `storage.jrnb`.
