### PR TITLE
use Thread.setName to update tokio thread name

### DIFF
--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTokioThreadTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTokioThreadTest.kt
@@ -1,0 +1,55 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+import androidx.test.core.app.ApplicationProvider
+import io.bitdrift.capture.Capture.Logger
+import io.bitdrift.capture.providers.FieldProvider
+import io.bitdrift.capture.providers.session.SessionStrategy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class CaptureTokioThreadTest {
+    @Test
+    fun `tokio thread is correctly named`() {
+        // In order to test that the tokio event loop thread is correctly named, we initialize the logger
+        // with a field provider that captures the thread name of the calling thread.
+        val latch = CountDownLatch(1)
+        val threadName = AtomicReference<String?>(null)
+
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+
+        Logger.start(
+            apiKey = "test1",
+            sessionStrategy = SessionStrategy.Fixed(),
+            dateProvider = null,
+            fieldProviders =
+                listOf(
+                    FieldProvider {
+                        threadName.set(Thread.currentThread().name)
+                        latch.countDown()
+                        mapOf()
+                    },
+                ),
+        )
+
+        Logger.logInfo { "Test log message" }
+
+        latch.await(5, TimeUnit.SECONDS)
+        assertThat(threadName.get()).isEqualTo("bd-tokio")
+    }
+}

--- a/platform/jvm/src/jni.rs
+++ b/platform/jvm/src/jni.rs
@@ -51,7 +51,7 @@ use platform_shared::metadata::Mobile;
 use platform_shared::{read_global_state_snapshot, LoggerHolder, LoggerId};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
-use std::ffi::{c_void, CString};
+use std::ffi::c_void;
 use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -694,14 +694,15 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
         LoggerHolder::new(
           logger,
           async move {
-            executor.with_attached(|_| {
-              // When we first attach the runtime thread the JVM will rename the thread since
-              // the jni crate won't let us pass a thread name through to the attach function.
-              // To work around this we attach and then immediately rename the thread again.
-              set_thread_name("bd-tokio");
-
-              Ok::<(), anyhow::Error>(())
-            })?;
+            handle_unexpected(
+              executor.with_attached(|env| {
+                // When we first attach the runtime thread the JVM will rename the thread since
+                // the jni crate won't let us pass a thread name through to the attach function.
+                // To work around this we attach and then immediately rename the thread again.
+                set_thread_name(env, "bd-tokio")
+              }),
+              "jni set thread name",
+            );
             future.await
           }
           .boxed(),
@@ -716,33 +717,23 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
   )
 }
 
-// On Android pthread_setname_np in the libc crate takes two arguments so we need to use a different
-// implementation for Android and other platforms.
-#[cfg(any(target_os = "android", target_os = "linux"))]
-fn set_thread_name(name: &str) {
-  debug_assert!(
-    name.len() <= 15,
-    "Thread name must be at most 15 characters long, got: {name}"
-  );
-  unsafe {
-    let thread = libc::pthread_self();
-    if let Ok(name) = CString::new(name) {
-      libc::pthread_setname_np(thread, name.as_ptr());
-    }
-  }
-}
+fn set_thread_name(env: &mut JNIEnv<'_>, name: &str) -> anyhow::Result<()> {
+  let thread = env.call_static_method(
+    "java/lang/Thread",
+    "currentThread",
+    "()Ljava/lang/Thread;",
+    &[],
+  )?;
 
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
-fn set_thread_name(name: &str) {
-  debug_assert!(
-    name.len() <= 15,
-    "Thread name must be at most 15 characters long, got: {name}"
-  );
-  if let Ok(name) = CString::new(name) {
-    unsafe {
-      libc::pthread_setname_np(name.as_ptr());
-    }
-  }
+  let name = env.new_string(name)?;
+  env.call_method(
+    thread.l()?,
+    "setName",
+    "(Ljava/lang/String;)V",
+    &[JValueGen::Object(&name)],
+  )?;
+
+  Ok(())
 }
 
 #[no_mangle]


### PR DESCRIPTION
Previously we attempted to fix an issue where the JVM would override the name that we assigned to the tokio event loop thread by updating the name of the native thread. This would leave the JVM thread name unchanged, resulting in an unnamed thread from the perspective of the JVM.

To fix this, use the JVM Thread.setName function to update both the JVM and native thred name

Fixes BIT-6500