### PR TITLE
log failure reason if JNI_OnLoad fails

### DIFF
--- a/platform/jvm/src/jni.rs
+++ b/platform/jvm/src/jni.rs
@@ -193,7 +193,7 @@ static STACK_TRACE_PROVIDER_INVOKE: OnceLock<CachedMethod> = OnceLock::new();
 pub(crate) fn initialize_method_handle<
   'local,
   'other_local,
-  T: Desc<'local, JClass<'other_local>> + std::fmt::Debug + Copy,
+  T: Desc<'local, JClass<'other_local>>,
 >(
   env: &mut JNIEnv<'local>,
   class: T,
@@ -204,7 +204,6 @@ pub(crate) fn initialize_method_handle<
   let method_id = CachedMethod::new(env, class, method_name, signature);
 
   let Ok(cached_id) = method_id else {
-    log::error!("failed to resolve {class:?}::{method_name} with signature {signature}");
     check_exception(env);
     bail!("failed to resolve method");
   };


### PR DESCRIPTION
This logs an error log with the cause whenever JNI_OnLoad fails. This should never fail on real devices so this is meant mostly to help debugging this in test.

This now logs something like 

```
2025-10-02 11:37:45.404 26684-26684 capture::jni            io.bitdrift.gradletestapp            E  failed with exception java.lang.NoSuchMethodError: no non-static method "Lio/bitdrift/capture/providers/Field;.getKe()Ljava/lang/String;"
2025-10-02 11:37:45.404 26684-26684 capture::jni            io.bitdrift.gradletestapp            E  JNI_OnLoad failed: failed to resolve method
````