### PR TITLE
Avoid creating a CaptureOkHttpEventListener if SDK is not initialized

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
@@ -7,7 +7,6 @@
 
 package io.bitdrift.capture.network.okhttp
 
-import androidx.annotation.VisibleForTesting
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.ILogger
 import io.bitdrift.capture.common.DefaultClock
@@ -38,8 +37,6 @@ class CaptureOkHttpEventListenerFactory internal constructor(
             emptyMap()
         },
 ) : EventListener.Factory {
-    private val noOpEventListener: NoOpEventListener by lazy { NoOpEventListener() }
-
     /**
      * Initializes a new instance of the Capture event listener.
      */
@@ -87,7 +84,7 @@ class CaptureOkHttpEventListenerFactory internal constructor(
         val currentLogger = getLogger()
         val targetEventListener = targetEventListenerCreator?.invoke(call)
         if (currentLogger == null) {
-            return targetEventListener ?: noOpEventListener
+            return targetEventListener ?: EventListener.NONE
         }
         return CaptureOkHttpEventListener(
             logger = currentLogger,
@@ -96,9 +93,6 @@ class CaptureOkHttpEventListenerFactory internal constructor(
             extraFieldsProvider = extraFieldsProvider,
         )
     }
-
-    @VisibleForTesting
-    internal class NoOpEventListener : EventListener()
 
     // attempts to get the latest logger if one wasn't found at construction time
     private fun getLogger(): ILogger? = logger ?: Capture.logger()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -620,7 +620,7 @@ class CaptureOkHttpEventListenerFactoryTest {
 
         val noOpEventListener = factory.create(call)
 
-        assertThat(noOpEventListener).isInstanceOf(CaptureOkHttpEventListenerFactory.NoOpEventListener::class.java)
+        assertThat(noOpEventListener).isInstanceOf(EventListener.NONE::class.java)
     }
 
     @Test

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -17,6 +17,7 @@ import io.bitdrift.capture.common.IClock
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
 import okhttp3.Call
+import okhttp3.EventListener
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.Protocol
 import okhttp3.Request
@@ -33,6 +34,8 @@ class CaptureOkHttpEventListenerFactoryTest {
     private val endpoint = "https://api.bitdrift.io/my_path/12345?my_query=my_value"
     private val clock: IClock = mock()
     private val logger: ILogger = mock()
+
+    private val call: Call = mock()
 
     @Test
     fun testRequestAndResponseReuseCommonInfo() {
@@ -604,5 +607,35 @@ class CaptureOkHttpEventListenerFactoryTest {
         val httpRequestInfo = httpRequestInfoCapture.firstValue
 
         assertThat(httpRequestInfo.fields["requestMetadata"].toString()).isEqualTo(requestMetadata)
+    }
+
+    @Test
+    fun create_withNullLoggerAndNullTargetListener_whenNoLoggerAndNoTarget() {
+        val factory =
+            CaptureOkHttpEventListenerFactory(
+                targetEventListenerCreator = null,
+                logger = null,
+                clock = clock,
+            )
+
+        val noOpEventListener = factory.create(call)
+        val listener2 = factory.create(call)
+
+        assertThat(noOpEventListener).isInstanceOf(CaptureOkHttpEventListenerFactory.NoOpEventListener::class.java)
+    }
+
+    @Test
+    fun create_withNullLogAndValidTargetListener_returnsTargetListener() {
+        val targetEventListener: EventListener = mock()
+        val factory =
+            CaptureOkHttpEventListenerFactory(
+                targetEventListenerCreator = { targetEventListener },
+                logger = null,
+                clock = clock,
+            )
+
+        val listener = factory.create(call)
+
+        assertThat(listener).isSameAs(targetEventListener)
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -610,7 +610,7 @@ class CaptureOkHttpEventListenerFactoryTest {
     }
 
     @Test
-    fun create_withNullLoggerAndNullTargetListener_whenNoLoggerAndNoTarget() {
+    fun create_withNullLoggerAndNullTargetListener_shouldReturnNoOpListener() {
         val factory =
             CaptureOkHttpEventListenerFactory(
                 targetEventListenerCreator = null,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -619,7 +619,6 @@ class CaptureOkHttpEventListenerFactoryTest {
             )
 
         val noOpEventListener = factory.create(call)
-        val listener2 = factory.create(call)
 
         assertThat(noOpEventListener).isInstanceOf(CaptureOkHttpEventListenerFactory.NoOpEventListener::class.java)
     }


### PR DESCRIPTION
Resolves BIT-6600

For cases where the customer doesn't initialize SDK we shouldn't create CaptureOkHttpEventListener 

### Verification

- Use gradle-test-app with `Deferred SDK Start` setting and verify that OkHttp event listener events starts getting collected upon initialization. See [session here ](https://timeline.bitdrift.dev/session/640abab9-ce4d-4bd2-b9f6-0e6545f3cef5?utm_source=sdk&utilization=0&expanded=-1422884516528367511#timeline)

- Once SDK initialized verify network spans are correctly captured

