### PR TITLE
andr: Make gradle-test-app `release` builds profileable

### DIFF
--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -79,11 +79,6 @@ android {
             ndk {
                 debugSymbolLevel = "SYMBOL_TABLE" // Using this to reduce output .so size
             }
-            packaging {
-                jniLibs {
-                    keepDebugSymbols += "**/*.so"
-                }
-            }
         }
         release {
             ndk {


### PR DESCRIPTION
This is necessary to attach the profiler and see symbolicated names in flamegraph when using `Find CPU Hotspots (Callstack Sample)", e.g. 

---
before:
<img width="1855" height="700" alt="Screenshot 2025-10-08 at 11 08 34 AM" src="https://github.com/user-attachments/assets/f5285998-d334-4669-83c3-5df0c19b6abd" />


---
after:
<img width="1924" height="708" alt="Screenshot 2025-10-08 at 11 34 40 AM" src="https://github.com/user-attachments/assets/65c15109-0d7e-4c74-858d-cad353cb9b70" />


Needs to make sure to run the `release` variants:
<img width="467" height="537" alt="Screenshot 2025-10-08 at 11 27 40 AM" src="https://github.com/user-attachments/assets/5e4fac9f-2877-48dc-82ca-9e5c69e0b8f9" />
