### PR TITLE
Remove sha input for all releases

### DIFF
--- a/.github/workflows/example_apps_android.yaml
+++ b/.github/workflows/example_apps_android.yaml
@@ -1,28 +1,9 @@
 name: Build Android example apps
 on:
   workflow_dispatch:
-    inputs:
-      sha:
-        description: '[Optional] Commit SHA1, branch or tag to build. The latest SHA1 on a given branch is used if no value is provided.'
-        required: false
-        type: string
   workflow_call:
-    inputs:
-      sha:
-        description: '[Optional] Commit SHA1, branch or tag to build. The latest SHA1 on a given branch is used if no value is provided.'
-        required: false
-        type: string
 
 jobs:
-  print_arguments:
-    name: Print arguments
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print entered "sha"
-        run: echo "$SHA"
-    env:
-      SHA: ${{ inputs.sha }}
-
   build:
     name: Build & upload
     runs-on: ubuntu-latest
@@ -39,7 +20,7 @@ jobs:
     - name: Setup Android cmd line tools + NDK
       uses: ./.github/actions/common-android-setup
     - name: Accept Android SDK licenses
-      run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses    
+      run: yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
     - name: Install Rust target
       run: rustup update && rustup target add aarch64-linux-android && rustup target add x86_64-linux-android
     - name: Build Android example app

--- a/.github/workflows/example_apps_ios.yaml
+++ b/.github/workflows/example_apps_ios.yaml
@@ -1,28 +1,9 @@
 name: Build iOS example apps
 on:
   workflow_dispatch:
-    inputs:
-      sha:
-        description: '[Optional] Commit SHA1, branch or tag to build. The latest SHA1 on a given branch is used if no value is provided.'
-        required: false
-        type: string
   workflow_call:
-    inputs:
-      sha:
-        description: '[Optional] Commit SHA1, branch or tag to build. The latest SHA1 on a given branch is used if no value is provided.'
-        required: false
-        type: string
 
 jobs:
-  print_arguments:
-    name: Print arguments
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print entered "sha"
-        run: echo "$SHA"
-    env:
-      SHA: ${{ inputs.sha }}
-
   build:
     name: Build & upload
     permissions:

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -21,11 +21,8 @@ jobs:
         run: |
           echo "$VERSION"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$ ]]; then exit 1; fi
-      - name: Print entered "sha"
-        run: echo "$SHA"
     env:
       VERSION: ${{ inputs.version }}
-      SHA: ${{ inputs.sha }}
   # The iOS release build builds the xcframework in release mode and uploads it to the artifact store for later use.
   ios-release-build:
     name: Capture.xcframework with artifacts
@@ -33,8 +30,6 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha }}
       - name: 'Update the content of platform/shared/.sdk_version'
         run: echo -n "${{ inputs.version }}" > platform/shared/.sdk_version
       - name: 'Install dependencies'
@@ -57,8 +52,6 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/example_apps_ios.yaml
-    with:
-      sha: ${{ inputs.sha }}
     secrets: inherit
 
   # The Android release build builds capture.aar and accompanying artifacts, like the .pom xml and the symbols corresponding to the .so.
@@ -69,8 +62,6 @@ jobs:
     steps:
       # Checkout repo to Github Actions runner
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha }}
       - name: 'Update the content of platform/shared/.sdk_version'
         run: echo -n "${{ inputs.version }}" > platform/shared/.sdk_version
       - name: Install Clang
@@ -88,8 +79,6 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/example_apps_android.yaml
-    with:
-      sha: ${{ inputs.sha }}
     secrets: inherit
   build-android-integrations:
     name: Build Android Integrations
@@ -115,8 +104,6 @@ jobs:
     ]
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha }}
       # Download all artifacts to current working directory
       - name: Download Android Capture artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/update_sdk_version.yaml
+++ b/.github/workflows/update_sdk_version.yaml
@@ -7,10 +7,6 @@ on:
         description: 'The new version to release, ex: 0.12.0'
         required: true
         type: string
-      sha:
-        description: '[Optional] Commit SHA1, branch or tag to build. The latest SHA1 on a given branch is used if no value is provided.'
-        required: false
-        type: string
       emergency:
         type: boolean
         description: Ignore main branch requirement (SOC2 compliance)
@@ -22,7 +18,6 @@ jobs:
     uses: ./.github/workflows/release_gh.yaml
     with:
       version: ${{ inputs.version }}
-      sha: ${{ inputs.sha }}
     secrets: inherit
   public-release:
     permissions:


### PR DESCRIPTION
We don't want to allow this, also github lets you pick a different branch from the input, we should enable it that way in the future if this is needed, but seems safer to not allow it at all.