### PR TITLE
android: reorder logger init

### DIFF
--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -100,7 +100,15 @@ cargoNdk {
                 "-Z", "build-std=std,panic_abort",
                 "-Z", "build-std-features=optimize_for_size,panic_immediate_abort",
             )
-        }
+            // Annoyingly we have to repeat all the flags for the release build as
+            // the RUSTFLAGS values are not added together.
+            // TODO(snowp): See if we can make this a bit better
+            // enable 16 KB ELF alignment on Android to support API 35+
+            extraCargoEnv = mapOf(
+              "RUSTFLAGS" to "-C link-args=-Wl,-z,max-page-size=16384,--build-id -C codegen-units=1 -C embed-bitcode -C lto=fat -C opt-level=z",
+              "RUSTC_BOOTSTRAP" to "1" // Required for using unstable features in the Rust compiler
+            )
+          }
 
         getByName("debug") {
             buildType = "dev"
@@ -113,7 +121,7 @@ cargoNdk {
     targets = arrayListOf("arm64")
     // enable 16 KB ELF alignment on Android to support API 35+
     extraCargoEnv = mapOf(
-      "RUSTFLAGS" to "-C codegen-units=1 -C embed-bitcode -C lto=fat -C opt-level=z -C link-args=-Wl,-z,max-page-size=16384,--build-id",
+      "RUSTFLAGS" to "-C link-args=-Wl,-z,max-page-size=16384,--build-id",
       "RUSTC_BOOTSTRAP" to "1" // Required for using unstable features in the Rust compiler
     )
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -7,7 +7,9 @@
 
 package io.bitdrift.capture
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.system.Os
 import android.util.Log
 import io.bitdrift.capture.Capture.Logger.startSpan
 import io.bitdrift.capture.LoggerImpl.SdkConfiguredDuration
@@ -21,6 +23,7 @@ import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.utils.BuildTypeChecker
 import okhttp3.HttpUrl
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -11,7 +11,6 @@ import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
-import android.system.Os
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner


### PR DESCRIPTION
Now that we initialize logging during JNI_OnLoad we need to configure RUST_LOG early enough in order to be picked up by this initialization code

This also changes the build configuration so that we only optimize the release build, as setting opt-level=z seems to disable debug_assertions which compiles out low level logging. As a bonus this should speed up dev builds