### PR TITLE
Do not run heavy workflows on main merge

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -1,8 +1,5 @@
 name: android
 on:
-  push:
-    branches:
-      - main
   pull_request:
 # Cancel in-progress CI jobs when a new commit is pushed to a PR.
 concurrency:

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,8 +1,5 @@
 name: format_check
 on:
-  push:
-    branches:
-      - main
   pull_request:
 # Cancel in-progress CI jobs when a new commit is pushed to a PR.
 concurrency:

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -1,8 +1,5 @@
 name: ios
 on:
-  push:
-    branches:
-      - main
   pull_request:
 # Cancel in-progress CI jobs when a new commit is pushed to a PR.
 concurrency:

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -1,8 +1,5 @@
 name: linux_test
 on:
-  push:
-    branches:
-      - main
   pull_request:
 # Cancel in-progress CI jobs when a new commit is pushed to a PR.
 concurrency:


### PR DESCRIPTION
When releasing we build the application again, this seems just wasteful just to catch merge conflicts that very rarely happen. And if they do, next PR/release will be red so no real risk
