### PR TITLE
[Android] Reuse OkHttpClient instance

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -53,6 +53,7 @@ import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.BuildTypeChecker
 import io.bitdrift.capture.utils.SdkDirectory
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -77,7 +78,8 @@ internal class LoggerImpl(
             ProcessLifecycleOwner.get(),
         ),
     preferences: IPreferences = Preferences(context),
-    private val apiClient: OkHttpApiClient = OkHttpApiClient(apiUrl, apiKey),
+    sharedOkHttpClient: OkHttpClient = OkHttpClient(),
+    private val apiClient: OkHttpApiClient = OkHttpApiClient(apiUrl, apiKey, client = sharedOkHttpClient),
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
     activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     bridge: IBridge = CaptureJniLibrary,
@@ -140,6 +142,7 @@ internal class LoggerImpl(
         val network =
             OkHttpNetwork(
                 apiBaseUrl = apiUrl,
+                okHttpClient = sharedOkHttpClient,
             )
 
         val sdkDirectory = SdkDirectory.getPath(context)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpApiClient.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpApiClient.kt
@@ -35,8 +35,8 @@ internal class OkHttpApiClient(
     private val apiBaseUrl: HttpUrl,
     private val apiKey: String,
     private val gson: Gson = Gson(),
+    private val client: OkHttpClient,
 ) {
-    private val client: OkHttpClient = OkHttpClient()
     private val jsonContentType: MediaType = "application/json".toMediaType()
 
     inline fun <Rq, reified Rp> perform(

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpNetwork.kt
@@ -76,11 +76,12 @@ internal fun newDuplexRequestBody(contentType: MediaType): PipeDuplexRequestBody
 internal class OkHttpNetwork(
     apiBaseUrl: HttpUrl,
     timeoutSeconds: Long = 2L * 60,
+    private val okHttpClient: OkHttpClient,
     private val networkDispatcher: CaptureDispatchers.Network = CaptureDispatchers.Network,
 ) : ICaptureNetwork {
     private val client: OkHttpClient =
         run {
-            val builder = OkHttpClient().newBuilder()
+            val builder = okHttpClient.newBuilder()
             // Certain other libraries will manipulate the bytecode to have the OkHttpClientBuilder
             // constructor automatically add interceptors which tend to not work well with our bespoke
             // client implementation. Remove these extra interceptors here to ensure that we are using

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
@@ -14,6 +14,7 @@ import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
 import io.bitdrift.capture.threading.CaptureDispatchers
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -35,6 +36,7 @@ class CaptureLoggerNetworkTest {
     private var streamTimeoutSeconds: Long = 1
     private var logger: Long? = null
     private var testServerPort: Int? = null
+    private val okHttpClient = OkHttpClient()
 
     class TestMetadataProvider : IMetadataProvider {
         override fun timestamp(): Long = Date().time
@@ -70,6 +72,7 @@ class CaptureLoggerNetworkTest {
             OkHttpNetwork(
                 apiBaseUrl = testServerUrl(testServerPort!!),
                 timeoutSeconds = streamTimeoutSeconds,
+                okHttpClient = okHttpClient,
             )
 
         val logger =
@@ -151,6 +154,7 @@ class CaptureLoggerNetworkTest {
             OkHttpNetwork(
                 apiBaseUrl = testServerUrl(50051),
                 timeoutSeconds = 1,
+                okHttpClient = okHttpClient,
             )
         val loggerId =
             CaptureJniLibrary.createLogger(
@@ -186,6 +190,7 @@ class CaptureLoggerNetworkTest {
             OkHttpNetwork(
                 apiBaseUrl = testServerUrl(port),
                 timeoutSeconds = 1,
+                okHttpClient = okHttpClient,
             )
 
         val logger =

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
@@ -19,6 +19,7 @@ import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.FatalIssueReporter
 import io.bitdrift.capture.reports.IFatalIssueReporter
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -46,7 +47,7 @@ class ErrorReporterTest {
         server = MockWebServer()
         server.start()
 
-        val apiClient = OkHttpApiClient(server.url(""), "api-key")
+        val apiClient = OkHttpApiClient(server.url(""), "api-key", client = OkHttpClient())
 
         reporter =
             ErrorReporterService(

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/OkHttpApiClientTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/OkHttpApiClientTest.kt
@@ -11,6 +11,7 @@ import io.bitdrift.capture.ApiError
 import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.DeviceCodeRequest
 import io.bitdrift.capture.DeviceCodeResponse
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -30,7 +31,7 @@ class OkHttpApiClientTest {
     fun setup() {
         server = MockWebServer()
         server.start()
-        apiClient = OkHttpApiClient(server.url(""), "api-key")
+        apiClient = OkHttpApiClient(server.url(""), "api-key", client = OkHttpClient())
     }
 
     @After


### PR DESCRIPTION
Avoid creating 2 OkHttpClient instances

See https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html

<img width="927" height="115" alt="Screenshot 2025-10-14 at 00 13 50" src="https://github.com/user-attachments/assets/f8517a5c-c44f-4707-8d97-3bef3b2c1745" />

## Verification 

- Tested on gradle-test-app. See [session with triggered OkHttp requests](https://timeline.bitdrift.dev/session/e579889c-07dc-410d-a4b1-8f640464eb50?utm_source=sdk&utilization=0&expanded=-6676247007083727923#timeline)

- Verify threads via profiler