### PR TITLE
fix(andr-replay): Small optimization on determining semantic node rect

### DIFF
--- a/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/ComposeTreeParser.kt
+++ b/platform/jvm/replay/src/main/kotlin/io/bitdrift/capture/replay/internal/compose/ComposeTreeParser.kt
@@ -76,14 +76,16 @@ internal object ComposeTreeParser {
             )
         }
 
+        val nodeBounds = this.unclippedGlobalBounds
+
         return ScannableView.ComposeView(
             replayRect =
                 ReplayRect(
                     type = type,
-                    x = this.unclippedGlobalBounds.left.toInt(),
-                    y = this.unclippedGlobalBounds.top.toInt(),
-                    width = this.unclippedGlobalBounds.width.toInt(),
-                    height = this.unclippedGlobalBounds.height.toInt(),
+                    x = nodeBounds.left.toInt(),
+                    y = nodeBounds.top.toInt(),
+                    width = nodeBounds.width.toInt(),
+                    height = nodeBounds.height.toInt(),
                 ),
             // The display name is not really used for anything
             displayName = "ComposeView",


### PR DESCRIPTION
Our `unclippedGlobalBounds()` calls `SemanticsNode.positionInWindow` property. We assumed this would be a cheap call since it's a property not a method but by looking at the source more closely and also some stack traces it looks like sometimes it could be a little more involved so we'll call it once instead of 4(!) times.

e.g.
```
        at androidx.compose.ui.graphics.Matrix.constructor-impl$default(Matrix.kt:33)
        at androidx.compose.ui.platform.GraphicsLayerOwnerLayer.updateMatrix(GraphicsLayerOwnerLayer.android.kt:402)
        at androidx.compose.ui.platform.GraphicsLayerOwnerLayer.getMatrix-sQKQjiQ(GraphicsLayerOwnerLayer.android.kt:377)
        at androidx.compose.ui.platform.GraphicsLayerOwnerLayer.mapOffset-8S9VItk(GraphicsLayerOwnerLayer.android.kt:317)
        at androidx.compose.ui.node.NodeCoordinator.toParentPosition-8S9VItk(NodeCoordinator.kt:1020)
        at androidx.compose.ui.node.NodeCoordinator.toParentPosition-8S9VItk$default(NodeCoordinator.kt:1015)
        at androidx.compose.ui.node.NodeCoordinator.localToRoot-MK-Hz9U(NodeCoordinator.kt:997)
        at androidx.compose.ui.node.NodeCoordinator.localToWindow-MK-Hz9U(NodeCoordinator.kt:839)
        at androidx.compose.ui.layout.LayoutCoordinatesKt.positionInWindow(LayoutCoordinates.kt:200)
        at androidx.compose.ui.semantics.SemanticsNode.getPositionInWindow-F1C5BW0(SemanticsNode.kt:175)
        at io.bitdrift.capture.replay.internal.compose.ComposeTreeParser.getUnclippedGlobalBounds(ComposeTreeParser.kt:120)
        at io.bitdrift.capture.replay.internal.compose.ComposeTreeParser.toScannableView(ComposeTreeParser.kt:86)
```