### PR TITLE
[Android] Fix JankStats memory leak due to picking Dialog window

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -132,8 +132,8 @@ internal class JankStatsMonitor(
             return
         }
         if (event == Lifecycle.Event.ON_CREATE) {
-            windowManager.getCurrentWindow()?.let {
-                setJankStatsForCurrentWindow(it)
+            windowManager.findCurrentActivity()?.let {
+                setJankStatsForCurrentWindow(it.window)
                 // We are done detecting initial Application ON_CREATE, we don't need to listen anymore
                 processLifecycleOwner.lifecycle.removeObserver(this)
             }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -134,9 +134,9 @@ internal class JankStatsMonitor(
         if (event == Lifecycle.Event.ON_CREATE) {
             windowManager.findFirstValidActivity()?.let {
                 setJankStatsForCurrentWindow(it.window)
-                // We are done detecting initial Application ON_CREATE, we don't need to listen anymore
-                processLifecycleOwner.lifecycle.removeObserver(this)
             }
+            // We are done detecting initial Application ON_CREATE, we don't need to listen anymore
+            processLifecycleOwner.lifecycle.removeObserver(this)
         }
     }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -132,7 +132,7 @@ internal class JankStatsMonitor(
             return
         }
         if (event == Lifecycle.Event.ON_CREATE) {
-            windowManager.findCurrentActivity()?.let {
+            windowManager.findFirstValidActivity()?.let {
                 setJankStatsForCurrentWindow(it.window)
                 // We are done detecting initial Application ON_CREATE, we don't need to listen anymore
                 processLifecycleOwner.lifecycle.removeObserver(this)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
@@ -69,7 +69,7 @@ class JankStatsMonitorTest {
         window = activity.window
 
         whenever(processLifecycleOwner.lifecycle).thenReturn(lifecycle)
-        whenever(windowManager.getCurrentWindow()).thenReturn(window)
+        whenever(windowManager.findCurrentActivity()).thenReturn(activity)
         whenever(windowManager.getFirstRootView()).thenReturn(window.decorView)
 
         whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
@@ -70,7 +70,6 @@ class JankStatsMonitorTest {
 
         whenever(processLifecycleOwner.lifecycle).thenReturn(lifecycle)
         whenever(windowManager.findFirstValidActivity()).thenReturn(activity)
-        whenever(windowManager.getFirstRootView()).thenReturn(window.decorView)
 
         whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)
         whenever(runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)).thenReturn(16)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
@@ -69,7 +69,7 @@ class JankStatsMonitorTest {
         window = activity.window
 
         whenever(processLifecycleOwner.lifecycle).thenReturn(lifecycle)
-        whenever(windowManager.findCurrentActivity()).thenReturn(activity)
+        whenever(windowManager.findFirstValidActivity()).thenReturn(activity)
         whenever(windowManager.getFirstRootView()).thenReturn(window.decorView)
 
         whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)

--- a/platform/jvm/common/build.gradle.kts
+++ b/platform/jvm/common/build.gradle.kts
@@ -13,6 +13,11 @@ android {
 
     compileSdk = 36
 
+    defaultConfig {
+        minSdk = 23
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/IWindowManager.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/IWindowManager.kt
@@ -7,20 +7,13 @@
 
 package io.bitdrift.capture.common
 
+import android.app.Activity
 import android.view.View
-import android.view.Window
 
 /**
  * Provides access the Global Window Views, or `null` if no window is available.
  */
 interface IWindowManager {
-    /**
-     * Returns the current [Window] if available.
-     *
-     * @return The current [Window], or `null` if no window is available.
-     */
-    fun getCurrentWindow(): Window?
-
     /**
      * Returns the root view of the current window if available.
      *
@@ -34,4 +27,11 @@ interface IWindowManager {
      * @return The root views of the current hierarchy, or an empty list if not available.
      */
     fun getAllRootViews(): List<View>
+
+    /**
+     * Finds the current Activity
+     *
+     * @return The current [Activity], or `null` if none found.
+     */
+    fun findCurrentActivity(): Activity?
 }

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/IWindowManager.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/IWindowManager.kt
@@ -29,9 +29,14 @@ interface IWindowManager {
     fun getAllRootViews(): List<View>
 
     /**
-     * Finds the current Activity
+     * Finds the first valid (non-destroyed) activity from all available root views.
      *
-     * @return The current [Activity], or `null` if none found.
+     * For most cases, this returns the currently visible activity.
+     *
+     * When multiple activities are present (split-screen, PiP, etc), this returns
+     * the first valid activity found in the iteration order.
+     *
+     * @return The first valid [android.app.Activity], or `null` if none found
      */
-    fun findCurrentActivity(): Activity?
+    fun findFirstValidActivity(): Activity?
 }

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/WindowManager.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/WindowManager.kt
@@ -65,7 +65,6 @@ class WindowManager(
     override fun findFirstValidActivity(): Activity? =
         getAllRootViews().firstNotNullOfOrNull { view ->
             val activity = view.unwrapToActivity()
-            //noinspection NewApi
             if (activity != null && !activity.isDestroyed) {
                 activity
             } else {

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/WindowManager.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/WindowManager.kt
@@ -62,7 +62,7 @@ class WindowManager(
         }
     }
 
-    override fun findCurrentActivity(): Activity? =
+    override fun findFirstValidActivity(): Activity? =
         getAllRootViews().firstNotNullOfOrNull { view ->
             val activity = view.unwrapToActivity()
             //noinspection NewApi

--- a/platform/jvm/gradle-test-app/src/main/res/values/bools.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="leak_canary_watcher_watch_dismissed_dialogs">true</bool>
+</resources>


### PR DESCRIPTION
Resolves BIT-6673

Big shout out to @pyricau for the help with the investigation, repro steps and suggestions for fix!

### What

Fixes a memory leak in JankStats monitoring that can occur when the SDK is initialized after UI is already displayed and there are multiple root views present (including dialogs). The SDK could attach to a dialog window instead of an activity window, causing the JankStats instance to leak when the dialog is dismissed.

The solution for now will be to pick the first valid activity window instead (as a follow up will explore into updating the product to track multiple windows)

Below the original leaktrace report

```
┬───
│ GC Root: Global variable in native code
│
├─ io.bitdrift.capture.events.SessionReplayTarget instance
│    Leaking: UNKNOWN
│    Retaining 3.1 kB in 104 objects
│    ↓ SessionReplayTarget.logger
│                          ~~~~~~
├─ io.bitdrift.capture.LoggerImpl instance
│    Leaking: UNKNOWN
│    Retaining 293 B in 9 objects
│    ↓ LoggerImpl.jankStatsMonitor
│                 ~~~~~~~~~~~~~~~~
├─ io.bitdrift.capture.events.performance.JankStatsMonitor instance
│    Leaking: UNKNOWN
│    Retaining 38.7 kB in 705 objects
│    application instance of com.squareup.superpos.development.T2SuperPosDevApp
│    ↓ JankStatsMonitor.jankStats
│                       ~~~~~~~~~
├─ androidx.metrics.performance.JankStats instance
│    Leaking: UNKNOWN
│    Retaining 38.5 kB in 694 objects
│    ↓ JankStats.implementation
│                ~~~~~~~~~~~~~~
├─ androidx.metrics.performance.JankStatsApi26Impl instance
│    Leaking: UNKNOWN
│    Retaining 38.5 kB in 693 objects
│    ↓ JankStatsApi24Impl.window
│                         ~~~~~~
├─ com.android.internal.policy.PhoneWindow instance
│    Leaking: YES (Window#mDestroyed is true)
│    Retaining 38.2 kB in 686 objects
│    mContext instance of com.squareup.ui.main.MainActivity with mDestroyed = true
│    mOnWindowDismissedCallback instance of com.squareup.ui.main.MainActivity with mDestroyed = true
│    mWindowControllerCallback instance of com.squareup.ui.main.MainActivity with mDestroyed = true
│    ↓ PhoneWindow.mDecor
╰→ com.android.internal.policy.DecorView instance
     Leaking: YES (ObjectWatcher was watching this because com.android.internal.policy.DecorView received View#onDetachedFromWindow() callback and View.mContext references a destroyed activity)
     Retaining 4.6 kB in 92 objects
     key = 7eaef5ab-b2b1-4c84-a9ab-abf4f4779801
     watchDurationMillis = 5268
     retainedDurationMillis = 263
     View not part of a window view hierarchy
     View.mAttachInfo is null (view detached)
     View.mWindowAttachCount = 1
     mContext instance of com.android.internal.policy.DecorContext, wrapping activity com.squareup.ui.main.MainActivity with mDestroyed = true
```

### Verification

Test steps

- Verify the leak no longer reproduces on the [leaky app repo](https://github.com/pyricau/bitdrift-leak-repro/blob/main/app/src/main/java/com/example/leakrepro/MainActivity.kt) provided by @pyricau . For setup; I've used maven local to point to a local version of capture-sdk (see [instructions here](https://github.com/bitdriftlabs/capture-sdk/wiki/Using-Maven-Local-for-Testing))
- On our gradle-test-app. Added a new SecondActivity that mimic setup from the repo above, this will setup jank instance on SecondActivity. When we navigate back to MainActivity, we can verify that the we detach and retach for the proper activity now using the proper onActivityResumed/onActivityPaused callbacks

e.g. logs

```
2025-10-20 12:24:41.999 11220-11220 JankStatsLeakFix        io.bitdrift.gradletestapp            D  should start now with enableLeakFix=true
2025-10-20 12:24:42.145 11220-11220 JankStatsLeakFix        io.bitdrift.gradletestapp            D  LeakFix Enabled. Attempting to resolve current Activity from root views
2025-10-20 12:24:42.145 11220-11220 JankStatsLeakFix        io.bitdrift.gradletestapp            D  Current window is com.android.internal.policy.PhoneWindow@d3f0366 and activity name SecondActivity
2025-10-20 12:24:43.978 11220-11220 JankStatsLeakFix        io.bitdrift.gradletestapp            D  SecondActivityPaused detaching JankStats
2025-10-20 12:24:43.991 11220-11220 JankStatsLeakFix        io.bitdrift.gradletestapp            D MainActivityResumed attaching JankStats
```

### Follow-up

BIT-6709. We'll explore updating the product to track multiple windows
