### PR TITLE
Use mach_continuous_time() for calculating uptime

### DIFF
--- a/test/platform/swift/unit_integration/mocks/MockTimingProvider.swift
+++ b/test/platform/swift/unit_integration/mocks/MockTimingProvider.swift
@@ -21,7 +21,7 @@ public final class MockTimeProvider {
 }
 
 extension MockTimeProvider: TimeProvider {
-    public func uptime() -> Uptime { Uptime(uptime: self.timeIntervalSince1970) }
+    public func uptime() -> Uptime { Uptime() }
 
     public func now() -> Date { Date(timeIntervalSince1970: self.timeIntervalSince1970) }
 }


### PR DESCRIPTION
`mach_continuous_time()` is as efficient as is possible on Apple systems.
