### PR TITLE
[Android] Ensure saveCurrentSessionId runs off caller thread

### DIFF
--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -24,6 +24,7 @@ import io.bitdrift.capture.LogType
 import io.bitdrift.capture.LoggerImpl
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
 import io.bitdrift.capture.fakes.FakeFatalIssueReporter
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.FAKE_EXCEPTION
@@ -55,6 +56,8 @@ class AppExitLoggerTest {
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = mock()
     private val memoryMetricsProvider = FakeMemoryMetricsProvider()
     private val lastExitInfo = FakeLatestAppExitInfoProvider()
+    private val backgroundThreadHandler = FakeBackgroundThreadHandler()
+
     private lateinit var appExitLogger: AppExitLogger
 
     @Before
@@ -378,6 +381,7 @@ class AppExitLoggerTest {
             runtime,
             errorHandler,
             versionChecker,
+            backgroundThreadHandler,
             memoryMetricsProvider,
             lastExitInfo,
             captureUncaughtExceptionHandler,


### PR DESCRIPTION
Make sure saveCurrentSessionId runs off caller thread (likely main) as can be expensive on some low end devices.

NOTE: Will attach graph in a sec