### PR TITLE
[Android] Update session persistence

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/ISessionPersistence.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/ISessionPersistence.kt
@@ -1,0 +1,22 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture.providers.session
+
+/**
+ * Handles persisting/retrieving the current/previous session Uuid
+ */
+internal interface ISessionPersistence {
+    /**
+     * Store the current session uuid
+     */
+    fun saveCurrentSessionId(sessionUuid: String)
+
+    /**
+     * Retrieves the previous session uuid (if any)
+     */
+    fun getPreviousSessionId(): String?
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/SessionPersistenceImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/SessionPersistenceImpl.kt
@@ -1,0 +1,26 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture.providers.session
+
+import io.bitdrift.capture.IPreferences
+
+/**
+ * Concrete implementation of [io.bitdrift.capture.providers.session.ISessionPersistence]
+ */
+internal class SessionPersistenceImpl(
+    private val preferences: IPreferences,
+) : ISessionPersistence {
+    override fun saveCurrentSessionId(sessionUuid: String) {
+        preferences.setString(SESSION_UUID, sessionUuid, true)
+    }
+
+    override fun getPreviousSessionId(): String? = preferences.getString(SESSION_UUID)
+
+    private companion object {
+        private const val SESSION_UUID = "session_uuid"
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionPersistenceImplTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionPersistenceImplTest.kt
@@ -1,0 +1,32 @@
+package io.bitdrift.capture.providers.session
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.bitdrift.capture.IPreferences
+import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.SESSION_ID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SessionPersistenceImplTest {
+    private val preferences: IPreferences = mock()
+    private val sessionPersistenceImpl = SessionPersistenceImpl(preferences)
+
+    @Test
+    fun saveCurrentSessionId_withValidUuid_shouldPersistInBlockingManner() {
+        sessionPersistenceImpl.saveCurrentSessionId(SESSION_ID)
+
+        verify(preferences).setString("session_uuid", SESSION_ID, true)
+    }
+
+    @Test
+    fun getPreviousSessionId_withNullSession_shouldMatchExpectedKey() {
+        whenever(preferences.getString(any())).thenReturn(SESSION_ID)
+
+        val sessionId = sessionPersistenceImpl.getPreviousSessionId()
+
+        assertThat(sessionId).isEqualTo(SESSION_ID)
+        verify(preferences).getString("session_uuid")
+    }
+}


### PR DESCRIPTION
## What

Resolves BIT-6726

Instead of relying on `setProcessStateSummary` from app exit, persist the current session using the existing `IPreferences` and decouple it from AppExitLogger

### WARNING: Pending Verification

Verify with fatal issue sessions crashes (both [ActivityBased](https://timeline.bitdrift.dev/session/49f6dac8-d3c7-4876-9812-012f3cbd5277?utm_source=sdk&utilization=0&expanded=-2541339556489310041)/[Fixed](https://timeline.bitdrift.dev/session/ed6de2e9-c781-4846-af87-36bedebffd40?utm_source=sdk)) and with regular app kill with Activity Based session.
