### PR TITLE
andr(demo): Add basic manual instrumentation around webview operations

### DIFF
--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":capture"))
     implementation(project(":capture-apollo"))
     implementation(project(":capture-timber"))
-    implementation(libs.androidx.material3.android)
+    implementation("androidx.compose.material3:material3-android:1.2.1")
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.compose.ui:ui:1.7.8")
     implementation("androidx.compose.material:material:1.7.8")
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.0")
     implementation("androidx.compose.foundation:foundation:1.7.8")
+    implementation("androidx.webkit:webkit:1.14.0")
 
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.4.0")
     debugImplementation("androidx.fragment:fragment-testing:1.6.2")

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
@@ -33,6 +33,7 @@ import io.bitdrift.capture.FeatureFlag
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.apollo.CaptureApolloInterceptor
 import io.bitdrift.capture.events.span.Span
+import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.capture.network.okhttp.CaptureOkHttpEventListenerFactory
 import io.bitdrift.capture.network.okhttp.OkHttpRequestFieldProvider
 import io.bitdrift.gradletestapp.R
@@ -177,6 +178,8 @@ class FirstFragment : Fragment() {
                 .okHttpClient(okHttpClient)
                 .addInterceptor(CaptureApolloInterceptor())
                 .build()
+
+        firstFragmentToCopySessionSpan?.end(SpanResult.SUCCESS)
     }
 
     override fun onDestroyView() {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/WebViewFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/WebViewFragment.kt
@@ -7,16 +7,24 @@
 
 package io.bitdrift.gradletestapp.ui.fragments
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.LogLevel
+import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.gradletestapp.R
+import kotlin.concurrent.Volatile
 
 /**
  * A basic WebView that can be used to test multi process.
@@ -28,11 +36,51 @@ class WebViewFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val span = Capture.Logger.startSpan("WebViewFragment", LogLevel.INFO)
         val view = inflater.inflate(R.layout.fragment_web_view, container, false)
         val webView = view.findViewById<WebView>(R.id.webView)
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.GET_WEB_VIEW_CLIENT)) {
+            val original = WebViewCompat.getWebViewClient(webView)
+            webView.webViewClient = WebViewClientWrapper(original)
+        }
         webView.loadUrl("https://bitdrift.io/")
-        span?.end(SpanResult.SUCCESS)
         return view
+    }
+
+    class WebViewClientWrapper(private val original : WebViewClient) : WebViewClient() {
+        @Volatile
+        var onPageSpan: Span? = null
+        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+            val fields = url?.let {
+                mapOf("_url" to it)
+            }
+            onPageSpan = Capture.Logger.startSpan("WebViewFragment.onPage", LogLevel.INFO, fields)
+            original.onPageStarted(view, url, favicon)
+        }
+        override fun onPageFinished(view: WebView?, url: String?) {
+            original.onPageFinished(view, url)
+            onPageSpan?.end(SpanResult.SUCCESS)
+            onPageSpan = null
+        }
+
+        override fun onReceivedError(
+            view: WebView?,
+            request: WebResourceRequest?,
+            error: WebResourceError?
+        ) {
+            // Only handle errors for the main page load, not for sub-resources like images.
+            if (request?.isForMainFrame == true) {
+                val fields = mapOf(
+                    "_errorCode" to error?.errorCode.toString(),
+                    "_description" to error?.description?.toString().orEmpty(),
+                    "_url" to request.url.toString(),
+                )
+                Capture.Logger.logError(fields = fields) { "WebViewFragment.onReceivedError" }
+
+                // End the span with a failure result
+                onPageSpan?.end(SpanResult.FAILURE)
+                onPageSpan = null
+            }
+            original.onReceivedError(view, request, error)
+        }
     }
 }

--- a/platform/jvm/gradle/libs.versions.toml
+++ b/platform/jvm/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ junit                   = "4.13.2"
 kotlin                  = "2.1.21"
 kotlinResultJvm         = "1.1.18"
 lifecycleCommon         = "2.8.7"
-material3Android        = "1.2.1"
 mavenPublishPlugin      = "0.28.0"
 mockitoCore             = "4.11.0"
 mockitoKotlin           = "2.2.0"
@@ -35,7 +34,6 @@ androidx-appcompat         = { module = "androidx.appcompat:appcompat", version.
 androidx-core              = { group = "androidx.core", name = "core", version.ref = "androidxCore" }
 androidx-lifecycle-common  = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycleCommon" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleCommon" }
-androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
 androidx-startup-runtime   = { module = "androidx.startup:startup-runtime", version.ref = "startupRuntime" }
 androidx-test-core         = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 androidx-ui                = { module = "androidx.compose.ui:ui", version.ref = "ui" }


### PR DESCRIPTION
Playing with the gradle test app as an example of what type of instrumentation we could provide for Webviews

example session:
https://timeline.bitdrift.dev/session/3c689c63-9add-4480-a80e-f4e63c506f2b?utilization=0&h=-8465107813118278626&h=-8454706699268341280