### PR TITLE
demo-app, andr: test nested coroutines stacktraces

### DIFF
--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.apollo.graphql)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    // see: https://github.com/Anamorphosee/stacktrace-decoroutinator
+    id("dev.reformator.stacktracedecoroutinator") version "2.5.8"
 }
 
 dependencies {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/DiagnosticsState.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/DiagnosticsState.kt
@@ -9,7 +9,7 @@ package io.bitdrift.gradletestapp.data.model
 
 /** Diagnostics/testing feature state */
 data class DiagnosticsState(
-    val selectedAppExitReason: AppExitReason = AppExitReason.ANR_BLOCKING_GET,
+    val selectedAppExitReason: AppExitReason = AppExitReason.APP_CRASH_REGULAR_JVM_EXCEPTION,
 )
 
 /**
@@ -23,6 +23,7 @@ enum class AppExitReason {
     ANR_GENERIC,
     ANR_SLEEP_MAIN_THREAD,
     APP_CRASH_COROUTINE_EXCEPTION,
+    APP_CRASH_NESTED_COROUTINE_EXCEPTION,
     APP_CRASH_REGULAR_JVM_EXCEPTION,
     APP_CRASH_RX_JAVA_EXCEPTION,
     APP_CRASH_OUT_OF_MEMORY,

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/AppExitRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/AppExitRepository.kt
@@ -32,6 +32,7 @@ class AppExitRepository {
             AppExitReason.ANR_GENERIC -> FatalIssueGenerator.forceGenericAnr(applicationContext)
             AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueGenerator.forceThreadSleepAnr()
             AppExitReason.APP_CRASH_COROUTINE_EXCEPTION -> FatalIssueGenerator.forceCoroutinesCrash()
+            AppExitReason.APP_CRASH_NESTED_COROUTINE_EXCEPTION -> FatalIssueGenerator.forceNestedCoroutinesCrash()
             AppExitReason.APP_CRASH_REGULAR_JVM_EXCEPTION -> FatalIssueGenerator.forceUnhandledException()
             AppExitReason.APP_CRASH_RX_JAVA_EXCEPTION -> FatalIssueGenerator.forceRxJavaException()
             AppExitReason.APP_CRASH_OUT_OF_MEMORY -> FatalIssueGenerator.forceOutOfMemoryCrash()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/fatalissues/FatalIssueGenerator.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/fatalissues/FatalIssueGenerator.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import java.util.UUID
 
 /**
@@ -110,6 +111,25 @@ internal object FatalIssueGenerator {
         CoroutineScope(Dispatchers.IO).launch {
             throw RuntimeException("Coroutine background thread crash")
         }
+    }
+
+    suspend fun fun1() {
+        yield()
+        throw Exception("Nested coroutine exception inside thread=${Thread.currentThread().name}")
+    }
+    suspend fun fun2() {
+        fun1()
+    }
+    suspend fun fun3() {
+        fun2()
+    }
+
+    /**
+     * This call exemplifies a crash that crosses coroutine boundaries
+     * see: https://github.com/Anamorphosee/stacktrace-decoroutinator
+     */
+    fun forceNestedCoroutinesCrash() = runBlocking {
+        fun3()
     }
 
     fun forceCaptureNativeCrash() {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
@@ -152,6 +152,7 @@ class FirstFragment : Fragment() {
             AppExitReason.ANR_GENERIC -> FatalIssueGenerator.forceGenericAnr(requireContext())
             AppExitReason.ANR_SLEEP_MAIN_THREAD -> FatalIssueGenerator.forceThreadSleepAnr()
             AppExitReason.APP_CRASH_COROUTINE_EXCEPTION -> FatalIssueGenerator.forceCoroutinesCrash()
+            AppExitReason.APP_CRASH_NESTED_COROUTINE_EXCEPTION -> FatalIssueGenerator.forceNestedCoroutinesCrash()
             AppExitReason.APP_CRASH_REGULAR_JVM_EXCEPTION -> FatalIssueGenerator.forceUnhandledException()
             AppExitReason.APP_CRASH_RX_JAVA_EXCEPTION -> FatalIssueGenerator.forceRxJavaException()
             AppExitReason.APP_CRASH_OUT_OF_MEMORY -> FatalIssueGenerator.forceOutOfMemoryCrash()


### PR DESCRIPTION
Testing gradle plugin that recovers coroutines stacktraces missing frames cross-boundaries. From this article published this week: https://medium.com/@berestinsky/recover-kotlin-coroutine-traces-with-decoroutinator-2ec8272a91f9

This could help inform future work for our crash handler

[before](https://explorations.bitdrift.dev/issues/13264241765907067325/f0b60024-e5d9-48f8-99e9-d9b499a00804?utm_source=sdk)(missing fun2, fun3) / [after](https://explorations.bitdrift.dev/issues/13264241765907067325/9f1168d6-e1b9-4c6b-a115-2f9941a953b8?utm_source=sdk):
<img width="1898" height="919" alt="Screenshot 2025-11-17 at 4 39 59 PM" src="https://github.com/user-attachments/assets/895b6d03-b43c-46e5-950f-bab168668cb8" />


---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.