### PR TITLE
ci: streamline disk-space cleaning for linux_tests

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -34,44 +34,23 @@ jobs:
           repository-cache: true
       - name: Attempt to free up runner disk space
         run: |
-          echo "================================"
           echo "Disk space BEFORE cleanup:"
           echo "================================"
           df -h /
-          echo ""
+          echo "Cleaning up disk space:"
           
-          # Function to check size of directory before removing
-          check_and_remove() {
-            path="$1"
-            name="$2"
-            if [ -e "$path" ]; then
-              size=$(du -sh "$path" 2>/dev/null | cut -f1 || echo "0")
-              echo "Removing $name ($size): $path"
-              sudo rm -rf "$path"
-            else
-              echo "Not found (skipping): $name"
-            fi
-          }
+          # Remove large pre-installed packages we don't need
+          sudo rm -rf /usr/share/dotnet           # .NET runtime (~4GB)
+          sudo rm -rf /usr/local/lib/android      # Android SDK (~12GB)
+          sudo rm -rf /usr/share/swift            # Swift toolchain (~3GB)
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"     # GitHub Actions tool cache (~6GB)
           
-          check_and_remove "/usr/share/dotnet" ".NET runtime"
-          check_and_remove "/opt/ghc" "Haskell compiler"
-          check_and_remove "/usr/local/share/boost" "Boost libraries"
-          check_and_remove "$AGENT_TOOLSDIRECTORY" "GitHub Actions tool cache"
-          check_and_remove "/usr/local/lib/android" "Android SDK"
-          check_and_remove "/usr/share/swift" "Swift toolchain"
-          
-          echo "Pruning Docker images..."
-          sudo docker image prune --all --force
-          
-          echo "Running apt cleanup..."
-          sudo apt-get clean
+          # Clean up apt packages
           sudo apt-get autoremove -y
-          sudo rm -rf /var/lib/apt/lists/*
           
-          echo ""
+          echo "Disk space clean-up done."
           echo "================================"
           echo "Disk space AFTER cleanup:"
-          echo "================================"
           df -h /
       - name: Check for Bazel build file changes
         id: bazel_check


### PR DESCRIPTION
Example output for `linux_test`

```
================================
Disk space BEFORE cleanup:
================================
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   57G   16G  79% /

Removing .NET runtime (4.0G): /usr/share/dotnet
Not found (skipping): Haskell compiler
Not found (skipping): Boost libraries
Removing GitHub Actions tool cache (5.8G): /opt/hostedtoolcache
Removing Android SDK (12G): /usr/local/lib/android
Removing Swift toolchain (3.2G): /usr/share/swift
Pruning Docker images...
Total reclaimed space: 0B
Running apt cleanup...
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  liblldb-16t64 liblldb-17t64
0 upgraded, 0 newly installed, 2 to remove and 21 not upgraded.
After this operation, 32.6 MB disk space will be freed.
(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 216223 files and directories currently installed.)
Removing liblldb-16t64 (1:16.0.6-23ubuntu4) ...
Removing liblldb-17t64 (1:17.0.6-9ubuntu1) ...
Processing triggers for libc-bin (2.39-0ubuntu8.6) ...

================================
Disk space AFTER cleanup:
================================
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   32G   41G  45% /
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.