### PR TITLE
[Android] [gradle-test-app] Generate fake native crash off main thread

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/fatalissues/FatalIssueGenerator.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/fatalissues/FatalIssueGenerator.kt
@@ -172,7 +172,10 @@ internal object FatalIssueGenerator {
     }
 
     private fun triggerOsKill(signal: Int) {
-        Os.kill(Os.getpid(), signal)
+        Thread {
+            Thread.sleep(100)
+            Os.kill(Os.getpid(), signal)
+        }.start()
     }
 
     private val FIRST_LOCK_RESOURCE: Any = "first_lock"


### PR DESCRIPTION
Related to BIT-6846

For the gradle-test-app, generating smaller sample native reports to avoid being triggered from main thread

- [Before](https://explorations.bitdrift.dev/issues/7176104271401699703/a597db7f-9328-4b65-89d5-0cd3dbbe7bd0?utm_source=sdk)
- [After](https://explorations.bitdrift.dev/issues/8274067708040692267/4ca4310e-03d5-4171-8768-a3a7470fe807?utm_source=sdk) 