### PR TITLE
andr: Make sure to exclude  dependency from the generated pom

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -90,6 +90,7 @@ android_artifacts(
     archive_name = "capture",
     excluded_artifacts = [
         "com.google.code.findbugs:jsr305",
+        "com.squareup.retrofit2:retrofit",
     ],
     manifest = "//platform/jvm:AndroidManifest.xml",
     native_deps = select({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 **Fixed**
 
 - Fixed a jni LocalReference leak that could crash the app when very large field maps or feature flags were sent to the logger.
+- Exclude `com.squareup.retrofit2:retrofit` dependency from the generated pom.
 
 ### iOS
 


### PR DESCRIPTION
Just noticed that https://central.sonatype.com/artifact/io.bitdrift/capture/0.20.0 accidentally included retrofit dep in the pom.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.