### PR TITLE
andr;example: Update external gradle app to use okhttp (but no retrofit)

### DIFF
--- a/gradle/app/build.gradle
+++ b/gradle/app/build.gradle
@@ -60,8 +60,8 @@ android {
 }
 
 dependencies {
-    implementation 'io.bitdrift:capture:0.18.9'
-    implementation 'io.bitdrift:capture-timber:0.18.9'
+    implementation 'io.bitdrift:capture:0.20.1'
+    implementation 'io.bitdrift:capture-timber:0.20.1'
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'

--- a/gradle/app/src/main/java/io/bitdrift/gradleexample/MainActivity.kt
+++ b/gradle/app/src/main/java/io/bitdrift/gradleexample/MainActivity.kt
@@ -8,7 +8,6 @@
 package io.bitdrift.gradleexample
 
 import android.os.Bundle
-import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
@@ -27,7 +26,11 @@ import timber.log.Timber
 
 class MainActivity : AppCompatActivity() {
 
-    init { System.loadLibrary("native-lib"); }
+    companion object {
+        init {
+            System.loadLibrary("native-lib");
+        }
+    }
     private external fun stringFromJNI(): String?
 
     private lateinit var appBarConfiguration: AppBarConfiguration
@@ -46,9 +49,7 @@ class MainActivity : AppCompatActivity() {
         }
         Timber.plant(CaptureTree())
 
-        Log.i("MainActivity", "Bitdrift Logger configured with url: ${Logger.sessionUrl}")
         Timber.i("Bitdrift Logger configured with url: %s", Logger.sessionUrl)
-        Log.i("MainActivity", "Calling JNI method: ${stringFromJNI()}")
         Timber.i("Calling JNI method: ${stringFromJNI()}")
 
         super.onCreate(savedInstanceState)
@@ -63,7 +64,7 @@ class MainActivity : AppCompatActivity() {
         setupActionBarWithNavController(navController, appBarConfiguration)
 
         binding.fab.setOnClickListener { view ->
-            Timber.w(Exception("gradleexample test exception"), "Hello Info log from Android gradle test app")
+            Timber.w(Exception("gradleexample warning exception"), "Hello Info log from Android gradle test app")
             Snackbar.make(view, "Calling Logger.logWarning()", Snackbar.LENGTH_SHORT).show()
         }
     }

--- a/gradle/app/src/main/res/layout/fragment_first.xml
+++ b/gradle/app/src/main/res/layout/fragment_first.xml
@@ -11,30 +11,48 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/hello_first_fragment"
-        app:layout_constraintBottom_toTopOf="@id/button_first"
+        app:layout_constraintBottom_toTopOf="@id/guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <Button
+        android:id="@+id/button_okhttp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/okhttp_request"
+        app:layout_constraintBottom_toTopOf="@+id/button_crash_jvm"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline"
+        app:layout_constraintVertical_chainStyle="spread" />
 
     <Button
         android:id="@+id/button_crash_jvm"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/crash_jvm"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/button_crash_native"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textview_first" />
+        app:layout_constraintTop_toBottomOf="@+id/button_okhttp" />
 
     <Button
         android:id="@+id/button_crash_native"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/crash_native"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/button_first"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_crash_jvm" />
+        app:layout_constraintTop_toBottomOf="@+id/button_crash_jvm" />
 
     <Button
         android:id="@+id/button_first"
@@ -44,5 +62,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_crash_native" />
+        app:layout_constraintTop_toBottomOf="@+id/button_crash_native" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/app/src/main/res/values/strings.xml
+++ b/gradle/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">My Application</string>
+    <string name="app_name">External Gradle App</string>
     <string name="action_settings">Settings</string>
     <!-- Strings used for fragments for navigation -->
     <string name="first_fragment_label">First Fragment</string>
@@ -9,6 +9,7 @@
 
     <string name="hello_first_fragment">Hello first fragment</string>
     <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
+    <string name="okhttp_request">Make OkHttp request</string>
     <string name="crash_jvm">Crash JVM</string>
     <string name="crash_native">Crash Native</string>
 </resources>

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -6,11 +6,11 @@ buildscript {
     }
     dependencies {
         // TODO: Start publishing plugin to gradlePluginPortal
-        classpath 'io.bitdrift:capture-plugin:0.18.8'
+        classpath 'io.bitdrift:capture-plugin:0.20.1'
     }
 }
 plugins {
-    id 'com.android.application' version '8.12.2' apply false
-    id 'com.android.library' version '8.12.2' apply false
+    id 'com.android.application' version '8.12.3' apply false
+    id 'com.android.library' version '8.12.3' apply false
     id 'org.jetbrains.kotlin.android' version '2.2.20' apply false
 }

--- a/gradle/settings.gradle
+++ b/gradle/settings.gradle
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "My Application"
+rootProject.name = "External Gradle App"
 include ':app'


### PR DESCRIPTION
Updated deps to latest and testing that `RetrofitUrlPathProvider` doesn't error out when no retrofit is available. Also confirmed the `com.squareup.retrofit2:retrofit` dep is not added to the runtime classpath by running

`./gradle/gradlew :app:dependencies --configuration releaseRuntimeClasspath`

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.