### PR TITLE
fix(swift): remove misleading error message where no error occurred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Removed a misleading error message at launch where no error occurred
 
 ## [0.20.1]
 [0.20.1]: https://github.com/bitdriftlabs/capture-sdk/releases/tag/v0.20.1

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -79,6 +79,12 @@ fn capture_cache_kscrash_report_impl(
 
   let file_contents = fs::read(&kscrash_report_path)?;
 
+  if file_contents.len() == 0 {
+    // File is created when the writer is initialized. An empty file should
+    // indicate that no error occurred to be written.
+    return Ok(CacheResult::ReportDoesNotExist);
+  }
+
   let (hashmap, was_partial) = match decoder::from_slice(&file_contents) {
     Ok((_, Value::Object(hashmap))) => (hashmap, false),
     Ok((..)) => {


### PR DESCRIPTION
This change removes a reported SDK error message at launch which did not actually indicate an existing issue.