### PR TITLE
[iOS] [Fatal Issue] Report disabled state even for non-real devices

### DIFF
--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -232,12 +232,12 @@ public final class Logger {
 
         self.deviceCodeController = DeviceCodeController(client: client)
 
-        #if targetEnvironment(simulator)
-        Logger.issueReporterInitResult = (.initialized(.unsupportedHardware), 0)
-        #else
         if !configuration.enableFatalIssueReporting {
             Logger.issueReporterInitResult = (.initialized(.clientNotEnabled), 0)
         } else {
+            #if targetEnvironment(simulator)
+            Logger.issueReporterInitResult = (.initialized(.unsupportedHardware), 0)
+            #else
             Logger.issueReporterInitResult = measureTime {
                 guard let contents = Logger.cachedReportConfigData(base: directoryURL) else {
                     return .initialized(.runtimeNotSet)
@@ -270,8 +270,8 @@ public final class Logger {
                 MXMetricManager.shared.add(reporter)
                 return .initialized(.monitoring)
             }
+            #endif
         }
-        #endif
     }
 
     // swiftlint:enable function_body_length


### PR DESCRIPTION
## What

While testing this https://github.com/bitdriftlabs/capture-es/pull/177. I've noticed we weren't reporting CLIENT_CONFIG_DISABLED when user opt-out to fatal issue reporting and is using a simulator.

## Verification

Verified on this session https://timeline.bitdrift.dev/session/644B08C9-48D8-44D3-894E-509014FA1BF2?utm_source=sdk&utilization=0&expanded=-6261768846232997110