### PR TITLE
Update CHANGELOG.md for 0.21.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,17 @@
 # Change Log
 
 ## [Unreleased]
-[Unreleased]: https://github.com/bitdriftlabs/capture-sdk/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/bitdriftlabs/capture-sdk/compare/v0.21.2...HEAD
 
 ### Both
 
 **Added**
 
-- Added support for workflow matching on feature flag state and transitions.
-- Fixed an issue where multiple Logger instances could come up and conflict. Subsequent loggers will now noop.
+- Nothing yet!
 
 **Changed**
 
-- **BREAKING**: The `variant` parameter in `setFeatureFlagExposure` (Android) / `addFeatureFlagExposure` (iOS) is now required instead of optional.
-- Added method overloads to accept `Boolean` / `Bool` values for the `variant` parameter in `setFeatureFlagExposure` (Android) / `addFeatureFlagExposure` (iOS), in addition to the existing `String` parameter.
+- Nothing yet!
 
 **Fixed**
 
@@ -42,6 +40,31 @@
 **Changed**
 
 - Nothing yet!
+
+**Fixed**
+
+- Nothing yet!
+
+## [0.21.2]
+[0.21.2]: https://github.com/bitdriftlabs/capture-sdk/releases/tag/v0.21.2
+
+### Both
+
+**Added**
+
+- Added support for workflow matching on feature flag state and transitions.
+- Fixed an issue where multiple Logger instances could come up and conflict. Subsequent loggers will now noop.
+
+**Changed**
+
+- **BREAKING**: The `variant` parameter in `setFeatureFlagExposure` (Android) / `addFeatureFlagExposure` (iOS) is now required instead of optional.
+- Added method overloads to accept `Boolean` / `Bool` values for the `variant` parameter in `setFeatureFlagExposure` (Android) / `addFeatureFlagExposure` (iOS), in addition to the existing `String` parameter.
+
+**Fixed**
+
+- Fixed an issue where multiple Logger instances could come up and conflict. Subsequent loggers will now noop.
+
+### iOS
 
 **Fixed**
 


### PR DESCRIPTION
Full changeset https://github.com/bitdriftlabs/capture-sdk/compare/ef50f6c937c5b4ce53d17fb6f148975e3bb9c20d...6883eba0d0b5630a6e0acfd7b1b00ce4609d2b9b

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.