### PR TITLE
[Android] Add benchmark tests for Timber CaptureTree

### DIFF
--- a/platform/jvm/microbenchmark/build.gradle.kts
+++ b/platform/jvm/microbenchmark/build.gradle.kts
@@ -45,8 +45,10 @@ android {
 dependencies {
     // the module containing code to benchmark
     androidTestImplementation(project(":capture"))
+    androidTestImplementation(project(":capture-timber"))
     androidTestImplementation(project(":common"))
 
+    androidTestImplementation(libs.timber)
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("junit:junit:4.13.2")

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -24,7 +24,9 @@ import io.bitdrift.capture.network.HttpResponseInfo
 import io.bitdrift.capture.network.HttpUrlPath
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.timber.CaptureTree
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import timber.log.Timber
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -169,6 +171,63 @@ class LogBenchmarkTest {
             )
             Capture.Logger.log(responseInfo)
         }
+    }
+
+    @Test
+    fun timberLogWithCaptureAndNoTag() {
+        startLogger()
+        plantCaptureTree()
+
+        benchmarkRule.measureRepeated {
+            Timber.i(LOG_MESSAGE)
+        }
+    }
+
+    @Test
+    fun timberLogWithCaptureAndTag() {
+        startLogger()
+        plantCaptureTree()
+
+        benchmarkRule.measureRepeated {
+            Timber.tag("MyTag").i(LOG_MESSAGE)
+        }
+    }
+
+    @Test
+    fun timberLogWithCaptureAndError() {
+        startLogger()
+        plantCaptureTree()
+        val exception = RuntimeException("test error")
+
+        benchmarkRule.measureRepeated {
+            Timber.e(exception, LOG_MESSAGE)
+        }
+    }
+
+    @Test
+    fun timberLogWithCaptureAndErrorAndTag() {
+        startLogger()
+        plantCaptureTree()
+        val exception = RuntimeException("test error")
+
+        benchmarkRule.measureRepeated {
+            Timber.tag("MyTag").e(exception, LOG_MESSAGE)
+        }
+    }
+
+    @Test
+    fun timberLogWithoutCaptureAndErrorAndTag() {
+        Timber.uprootAll()
+        val exception = RuntimeException("test error")
+
+        benchmarkRule.measureRepeated {
+            Timber.tag("MyTag").e(exception, LOG_MESSAGE)
+        }
+    }
+
+    private fun plantCaptureTree() {
+        Timber.uprootAll()
+        Timber.plant(CaptureTree())
     }
 
     private fun buildFieldsMap(size: Int, keyIdentifier: String = "key_"): Map<String, String> =


### PR DESCRIPTION
### What

Adding more microbenchmark test to keep track of allocations at Timber CaptureTree. 

NOTE: As a follow up will try to run these on ci so we can compare PR changes against main

### Test results

<img width="1654" height="495" alt="Screenshot 2025-12-19 at 14 14 54" src="https://github.com/user-attachments/assets/a0e1230d-813a-4987-a2f2-c909e84e34c6" />
