### PR TITLE
fix(ios): use recorded bundle version as build number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Fixed recording of bundle version for issues where bundle version is the complete app version rather than a separate build number
 
 ## [0.21.2]
 [0.21.2]: https://github.com/bitdriftlabs/capture-sdk/releases/tag/v0.21.2

--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -313,7 +313,16 @@ static void serialize_device_metrics(BDProcessorHandle handle, NSDictionary *met
 }
 
 static void serialize_app_metrics(BDProcessorHandle handle, NSString *app_version, NSDictionary *metadata) {
-  NSString *bundle_version = [NSString stringWithFormat:@"%@.%@", app_version, string_for_key(metadata, @"appBuildVersion")];
+  NSString *build_version = string_for_key(metadata, @"appBuildVersion");
+  NSString *bundle_version = nil;
+  if ([build_version hasPrefix:app_version]
+      && !([build_version length] > [app_version length]
+        && [build_version characterAtIndex:[app_version length]] >= '0'
+        && [build_version characterAtIndex:[app_version length]] <= '9')) {
+    bundle_version = build_version;
+  } else {
+    bundle_version = [NSString stringWithFormat:@"%@.%@", app_version, build_version];
+  }
   BDAppMetrics app = {
     .app_id = cstring_from(string_for_key(metadata, @"bundleIdentifier")),
     .version = cstring_from(app_version),


### PR DESCRIPTION
Simplify the recording of app version and bundle version to use the versions as recorded from app metadata, which should align with log metadata