### PR TITLE
fix(android/plugin): use BITDRIFT_API_KEY as default env var name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 **Added**
 
-- Nothing yet!
+- Added support for using `BITDRIFT_API_KEY` as an environment variable when uploading symbols using capture-plugin
 
 **Changed**
 

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
@@ -30,10 +30,18 @@ abstract class CLIUploadMappingTask : CLITask() {
         val versionCode = manifest.getAttribute("android:versionCode")
         val versionName = manifest.getAttribute("android:versionName")
 
+        // retrieve key using preferred or legacy fallback env var if set
+        val apiKey = System.getenv("BITDRIFT_API_KEY") ?: System.getenv("API_KEY")
+        if (apiKey == null) {
+            throw IllegalStateException("Environment variable BITDRIFT_API_KEY must be set to your Bitdrift API key before running this task")
+        }
+
         runBDCLI(
             listOf(
                 "debug-files",
                 "upload-proguard",
+                "--api-key",
+                apiKey,
                 "--app-id",
                 appId,
                 "--app-version",
@@ -66,7 +74,6 @@ abstract class CLITask : DefaultTask() {
     val downloader = BDCLIDownloader(bdcliFile)
 
     fun runBDCLI(args: List<String>) {
-        checkEnvironment()
         downloader.downloadIfNeeded()
         runCommand(listOf(bdcliFile.absolutePath) + args)
     }
@@ -79,13 +86,6 @@ abstract class CLITask : DefaultTask() {
         process.inputStream.transferTo(System.out)
         if (process.waitFor() != 0) {
             throw RuntimeException("Command $command failed")
-        }
-    }
-
-    private fun checkEnvironment() {
-        val apiKeyEnvName = "API_KEY"
-        if (System.getenv(apiKeyEnvName) == null) {
-            throw IllegalStateException("Environment variable $apiKeyEnvName must be set to your Bitdrift API key before running this task")
         }
     }
 }


### PR DESCRIPTION
keeps fallback support for `API_KEY` for now

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.