### PR TITLE
implement dynamic ios build 

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -60,6 +60,31 @@ jobs:
         id: check_changes
         if: env.run_tests == 'true'
         run: ./ci/run_tests.sh
+  dynamic_swift_hello_world:
+    name: swift_hello_world
+    timeout-minutes: 40
+    needs: "pre_check"
+    if: needs.pre_check.outputs.should_run == 'true'
+    runs-on: macos-15
+    steps:
+      # Checkout repo to Github Actions runner
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ github.job }}
+          repository-cache: true
+
+      - name: "Install dependencies"
+        run: ./ci/mac_ci_setup.sh
+      - run: ./bazelw build --config ci --config release-ios //examples/swift/hello_world:ios_app_dynamic
+        name: "Build app"
+      # TODO(snowp): Add some kind of assertion that the app does that it's supposed to
+      - run: ./bazelw run --config ci --config release-ios //examples/swift/hello_world:ios_app_dynamic &> /tmp/envoy.log &
+        name: "Run app"
   swift_hello_world:
     name: swift_hello_world
     timeout-minutes: 40
@@ -123,7 +148,7 @@ jobs:
         run: env -u ANDROID_NDK_HOME ./bazelw test $(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)') --test_tag_filters=macos_only --test_output=errors --config ci --config ios
   verify_ios:
     runs-on: ubuntu-latest
-    needs: ["tests", "swift_hello_world", "unit_tests"]
+    needs: ["tests", "dynamic_swift_hello_world", "swift_hello_world", "unit_tests"]
     if: always()
     steps:
       # Checkout repo to Github Actions runner
@@ -133,4 +158,6 @@ jobs:
           fetch-depth: 1
       - run: |
           ./ci/check_result.sh ${{ needs.tests.result }} \
-          && ./ci/check_result.sh ${{ needs.swift_hello_world.result }}
+          && ./ci/check_result.sh ${{ needs.unit_tests.result }} \
+          && ./ci/check_result.sh ${{ needs.swift_hello_world.result }} \
+          && ./ci/check_result.sh ${{ needs.dynamic_swift_hello_world.result }}

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,18 @@ xcframework:
 	./bazelw build //:ios_dist
 	echo "XCFramework is archived at bazel-bin/Capture.ios.zip"
 
+.PHONY: run-ios-app-direct
+run-ios-app-direct:
+	./bazelw run //examples/swift/hello_world:hello_world_app --config=ios
+
+.PHONY: run-ios-app-xcframework
+run-ios-app-xcframework:
+	./bazelw build --config ci --config release-ios //examples/swift/hello_world:ios_app
+
+.PHONY: run-ios-app-dynamic
+run-ios-app-dynamic:
+	./bazelw build --config ci --config release-ios //examples/swift/hello_world:ios_app_dynamic
+
 .PHONY: test-gradle
 test-gradle:
 	platform/jvm/gradlew :capture:testDebugUnitTest -p platform/jvm

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -1,4 +1,4 @@
-load("@rules_apple//apple:apple.bzl", "apple_static_xcframework_import")
+load("@rules_apple//apple:apple.bzl", "apple_dynamic_xcframework_import", "apple_static_xcframework_import")
 load("@rules_apple//apple:ios.bzl", "ios_application")
 load("@rules_swift//swift:swift.bzl", "swift_library")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
@@ -82,4 +82,72 @@ ios_application(
     ],
     visibility = ["//visibility:public"],
     deps = [":ios_direct"],
+)
+
+# ==============================================================================
+# Dynamic Framework Variants - for testing size comparison and symbol isolation
+# ==============================================================================
+
+# Expand the dynamic xcframework for import
+# Note: Using a different output directory structure to avoid conflicts with static xcframework
+# The xcframework contains .swiftinterface files in release builds, .swiftmodule in debug builds
+genrule(
+    name = "expanded_dynamic_xcframework",
+    srcs = ["//platform/swift/source:CaptureDynamic"],
+    outs = [
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Modules/Capture.swiftmodule/x86_64.swiftinterface",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Modules/Capture.swiftmodule/x86_64.swiftdoc",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Modules/Capture.swiftmodule/arm64.swiftinterface",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Modules/Capture.swiftmodule/arm64.swiftdoc",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Modules/module.modulemap",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Headers/Capture.h",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Info.plist",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/PrivacyInfo.xcprivacy",
+        "dynamic/Capture.xcframework/ios-arm64_x86_64-simulator/Capture.framework/Capture",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/Modules/Capture.swiftmodule/arm64.swiftinterface",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/Modules/Capture.swiftmodule/arm64.swiftdoc",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/Modules/module.modulemap",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/Headers/Capture.h",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/Info.plist",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/PrivacyInfo.xcprivacy",
+        "dynamic/Capture.xcframework/ios-arm64/Capture.framework/Capture",
+        "dynamic/Capture.xcframework/Info.plist",
+    ],
+    cmd = "unzip -o $< -d $(RULEDIR)/dynamic",
+    tags = ["manual"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "capture_dynamic_xcframework",
+    xcframework_imports = [":expanded_dynamic_xcframework"],
+)
+
+swift_library(
+    name = "ios_main_dynamic",
+    srcs = glob(["*.swift"]),
+    tags = ["manual"],
+    deps = [":capture_dynamic_xcframework"],
+)
+
+# Hello World app using dynamic framework - for size comparison
+ios_application(
+    name = "ios_app_dynamic",
+    bundle_id = "io.bitdrift.example.swiftapp.helloworld.dynamic",
+    entitlements = "Protected.entitlements",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = ["Info.plist"],
+    minimum_os_version = MINIMUM_IOS_VERSION,
+    provisioning_profile = select({
+        "//bazel:ios_device_build": "//bazel/ios:ios_provisioning_profile",
+        "//conditions:default": None,
+    }),
+    tags = [
+        "manual",
+        "no-remote",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":ios_main_dynamic"],
 )

--- a/platform/swift/source/BUILD
+++ b/platform/swift/source/BUILD
@@ -1,6 +1,6 @@
-load("@rules_apple//apple:apple.bzl", "apple_static_xcframework")
+load("@rules_apple//apple:apple.bzl", "apple_static_xcframework", "apple_xcframework")
 load("@rules_apple//apple:docc.bzl", "docc_archive")
-load("@rules_apple//apple:ios.bzl", "ios_static_framework")
+load("@rules_apple//apple:ios.bzl", "ios_dynamic_framework", "ios_static_framework")
 load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@rules_swift//swift:swift.bzl", "swift_library")
 load("//bazel:bitdrift_build_system.bzl", "bitdrift_rust_library")
@@ -181,4 +181,71 @@ docc_archive(
     ],
     transform_for_static_hosting = True,
     visibility = ["//visibility:public"],
+)
+
+# Dynamic XCFramework for distribution - isolates all Rust symbols to avoid conflicts
+# with other Rust-based libraries (e.g., Yttrium/Reown-Swift)
+apple_xcframework(
+    name = "CaptureDynamic",
+    bundle_id = "io.bitdrift.Capture",
+    bundle_name = "Capture",
+    exported_symbols_lists = [":capture_exported_symbols"],
+    infoplists = ["//platform/swift/resources:info_plist"],
+    ios = {
+        "device": ["arm64"],
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+    },
+    linkopts = [
+        "-dead_strip",
+        # Strip non-global symbols from output
+        "-x",
+    ],
+    minimum_os_versions = {
+        "ios": MINIMUM_IOS_VERSION,
+    },
+    tags = [
+        "macos_only",
+        "no-cache",
+        "no-remote",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":ios_lib"],
+)
+
+# Exported symbols list - only expose public Capture API, hide all Rust internals
+exports_files(["capture_exported_symbols.txt"])
+
+filegroup(
+    name = "capture_exported_symbols",
+    srcs = ["capture_exported_symbols.txt"],
+    visibility = ["//visibility:public"],
+)
+
+# Dynamic framework for single-platform builds (useful for testing)
+ios_dynamic_framework(
+    name = "capture_ios_dynamic_framework",
+    bundle_id = "io.bitdrift.Capture",
+    bundle_name = "Capture",
+    exported_symbols_lists = [":capture_exported_symbols"],
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = ["//platform/swift/resources:info_plist"],
+    linkopts = [
+        "-dead_strip",
+        # Strip non-global symbols from output
+        "-x",
+    ],
+    minimum_os_version = MINIMUM_IOS_VERSION,
+    tags = [
+        "macos_only",
+        "no-cache",
+        "no-remote",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":ios_lib"],
 )

--- a/platform/swift/source/capture_exported_symbols.txt
+++ b/platform/swift/source/capture_exported_symbols.txt
@@ -1,0 +1,35 @@
+# Capture SDK - Exported Symbols List
+# Only these symbols will be visible externally from the dynamic framework.
+# All other symbols (including Rust runtime) will be hidden.
+#
+# This uses Apple ld's wildcard syntax:
+# - * matches zero or more characters
+# - ? matches one character
+# - [abc] matches a, b, or c
+
+# Swift module symbols - Capture module (all public Swift API)
+_$s7Capture*
+
+# Swift module symbols - CapturePassable module
+_$s15CapturePassable*
+
+# Swift extensions on Objective-C classes (e.g., NSURLSession.instrumentedSession)
+# These have mangled names like _$sSo{ObjCClassName}C7CaptureE{methodName}...
+_$sSo*7CaptureE*
+_$sSo*15CapturePassableE*
+
+# Objective-C classes (Swift-generated with mangled names)
+_OBJC_CLASS_$__TtC7Capture*
+_OBJC_METACLASS_$__TtC7Capture*
+_OBJC_CLASS_$__TtC15CapturePassable*
+_OBJC_METACLASS_$__TtC15CapturePassable*
+
+# Pure ObjC classes exposed for ObjC compatibility
+_OBJC_CLASS_$_CAPLogger
+_OBJC_METACLASS_$_CAPLogger
+_OBJC_CLASS_$_CAPSessionStrategy
+_OBJC_METACLASS_$_CAPSessionStrategy
+_OBJC_CLASS_$_CAPProxyURLSessionDelegate
+_OBJC_METACLASS_$_CAPProxyURLSessionDelegate
+_OBJC_CLASS_$_CAPProxyURLSessionTaskDelegate
+_OBJC_METACLASS_$_CAPProxyURLSessionTaskDelegate


### PR DESCRIPTION
This adds configuration to generate a dynamic xcframework version of the Capture SDK. This will likely become the only way to bundle the framework but adding it as a separate task for now until we update the release process 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.