### PR TITLE
[iOS] Resolve missing span type for network requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Fixed `Span Success` for network request/responses.
 
 ## [0.22.0]
 

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -20,6 +20,11 @@ enum HTTPFieldKey: String {
     case graphQLOperationID = "_operation_id"
 }
 
+enum HTTPSpanType: String {
+    case start
+    case end
+}
+
 /// An object representing an HTTP request.
 public struct HTTPRequestInfo {
     let method: String
@@ -74,7 +79,7 @@ public struct HTTPRequestInfo {
     ///
     /// - returns: A fields map.
     func toFields() -> Fields {
-        var fields = self.toCommonFields()
+        var fields = self.toCommonFields(spanType: .start)
 
         if let bytesExpectedToSendCount = self.bytesExpectedToSendCount, bytesExpectedToSendCount > 0 {
             // Do not put body bytes count as a common field since response log has a more accurate
@@ -105,11 +110,13 @@ public struct HTTPRequestInfo {
 
     /// Returns fields that are supposed to be shared between request and response logs.
     ///
+    /// - parameter spanType: The span type to include (.start or .end).
     /// - returns: Fields to share with response logs.
-    func toCommonFields() -> Fields {
+    func toCommonFields(spanType: HTTPSpanType) -> Fields {
         var fields: [String: Encodable] = [
             "_method": self.method,
             "_span_id": self.spanID,
+            "_span_type": spanType.rawValue,
         ]
 
         if let host = self.host {

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -111,6 +111,7 @@ public struct HTTPRequestInfo {
     /// Returns fields that are supposed to be shared between request and response logs.
     ///
     /// - parameter spanType: The span type to include (.start or .end).
+    ///
     /// - returns: Fields to share with response logs.
     func toCommonFields(spanType: HTTPSpanType) -> Fields {
         var fields: [String: Encodable] = [

--- a/platform/swift/source/logging/HTTPResponseInfo.swift
+++ b/platform/swift/source/logging/HTTPResponseInfo.swift
@@ -63,7 +63,7 @@ public struct HTTPResponseInfo {
     /// - returns: A fields map.
     func toFields() -> Fields {
         // swiftlint:disable:previous cyclomatic_complexity
-        var fields = self.requestInfo.toCommonFields()
+        var fields = self.requestInfo.toCommonFields(spanType: .end)
         fields["_duration_ms"] = String(self.duration.toMilliseconds())
 
         // Extract url information (host, path, query) from response's URL if available. Otherwise, use

--- a/test/platform/swift/unit_integration/core/LoggerTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerTests.swift
@@ -253,6 +253,7 @@ final class LoggerTests: XCTestCase {
             "_method": "POST",
             "_path": "/ping/12345",
             "_span_id": requestInfo.spanID,
+            "_span_type": "start",
             "_query": "bar",
             "foo": "bar",
         ], logFields)
@@ -308,6 +309,7 @@ final class LoggerTests: XCTestCase {
             "_path": "/ping/12345",
             "_result": "success",
             "_span_id": requestInfo.spanID,
+            "_span_type": "end",
             "_status_code": "200",
             "_query": "bar",
             "foo": "bar",
@@ -318,6 +320,7 @@ final class LoggerTests: XCTestCase {
             "_request._method": "POST",
             "_request._path": "/ping/12345",
             "_request._span_id": requestInfo.spanID,
+            "_request._span_type": "start",
             "_request._query": "bar",
         ], try log.matchingFields?.toDictionary())
     }

--- a/test/platform/swift/unit_integration/core/logging/HTTPRequestInfoTests.swift
+++ b/test/platform/swift/unit_integration/core/logging/HTTPRequestInfoTests.swift
@@ -22,6 +22,7 @@ final class HTTPRequestInfoTests: XCTestCase {
         XCTAssertEqual(
             [
                 "_method": "method",
+                "_span_type": "start",
                 "key": "value",
             ],
             fields
@@ -50,6 +51,7 @@ final class HTTPRequestInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_type": "start",
                 "key": "value",
             ],
             try XCTUnwrap(requestInfo.toFields() as? [String: String])
@@ -76,6 +78,7 @@ final class HTTPRequestInfoTests: XCTestCase {
             "_path": "/test/12345",
             "_path_template": "/test/{explicit_id}",
             "_query": "q=foo",
+            "_span_type": "start",
         ], fields)
     }
 }

--- a/test/platform/swift/unit_integration/core/logging/HTTPResponseInfoTests.swift
+++ b/test/platform/swift/unit_integration/core/logging/HTTPResponseInfoTests.swift
@@ -30,6 +30,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_method": "GET",
                 "_duration_ms": "123",
                 "_result": "success",
+                "_span_type": "end",
             ],
             fields
         )
@@ -37,7 +38,7 @@ final class HTTPResponseInfoTests: XCTestCase {
         var matchingFields = try XCTUnwrap(responseInfo.toMatchingFields() as? [String: String])
         XCTAssertNotNil(matchingFields.removeValue(forKey: "_request._span_id"))
 
-        XCTAssertEqual(["_request._method": "GET"], matchingFields)
+        XCTAssertEqual(["_request._method": "GET", "_request._span_type": "start"], matchingFields)
     }
 
     func testHTTPResponseSuccess() throws {
@@ -61,6 +62,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_type": "end",
                 "key2": "value2",
                 "_status_code": "200",
                 "_duration_ms": "123",
@@ -77,6 +79,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_type": "start",
                 "_request.key": "value",
                 "_headers.header_1": "value_1",
                 "_request._headers.request_header": "request_value",
@@ -117,6 +120,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path_template": "/testing/<id>",
                 "_query": "query",
                 "_span_id": "foo",
+                "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "success",
             ],
@@ -143,6 +147,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "success",
                 "key": "value",
@@ -173,6 +178,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path_template": "/foo_path/{explicit_id}",
                 "_query": "foo_query",
                 "_span_id": "span_id",
+                "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "success",
                 "key": "value",
@@ -206,6 +212,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_type": "end",
                 "_duration_ms": "456",
                 "_result": "canceled",
                 "key": "value",
@@ -220,6 +227,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_type": "start",
                 "_request.key": "value",
                 "_request._headers.request_header": "request_value",
             ],
@@ -250,6 +258,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_type": "end",
                 "_status_code": "400",
                 "_duration_ms": "789",
                 "_result": "failure",
@@ -265,6 +274,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_type": "start",
                 "_request.key": "value",
                 "_request._headers.request_header": "request_value",
             ],
@@ -302,6 +312,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "failure",
                 "_error_code": "100",
@@ -318,6 +329,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_type": "start",
                 "_request.key": "value",
                 "_request._headers.request_header": "request_value",
             ],

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -222,6 +222,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_method": "GET",
                 "_path": "/fe/ping",
                 "_query": "q=test",
+                "_span_type": "start",
             ],
             requestInfoFields
         )
@@ -686,6 +687,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_method": "GET",
                 "_path": "/fe/ping",
                 "_query": "q=test",
+                "_span_type": "start",
             ],
             requestInfoFields
         )
@@ -708,6 +710,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_path": "/fe/ping",
                 "_query": "q=test",
                 "_result": "success",
+                "_span_type": "end",
                 "_status_code": "200",
             ],
             remainingResponseFields
@@ -753,6 +756,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_method": "GET",
                 "_path": "/fe/ping",
                 "_query": "q=test",
+                "_span_type": "start",
             ],
             requestInfoFields
         )
@@ -775,6 +779,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_path": "/fe/ping",
                 "_query": "q=test",
                 "_result": "canceled",
+                "_span_type": "end",
             ],
             remainingResponseFields
         )


### PR DESCRIPTION
## What

Resolves BIT-7210

Adds missing span type to network request/responses on iOS. 

## Verification

Tested on sample app

- [Session on main](https://timeline.bitdrift.dev/session/5898C065-C27E-4913-B7F9-EA45AC484B1F?utm_source=sdk&utilization=0&expanded=-3866584105343357479)

- [Session on PR](https://timeline.bitdrift.dev/session/E3CC6B60-38F2-4CAE-AD2C-2581AF52AFC4?utm_source=sdk&utilization=0&expanded=-6269917384588440052)

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.