### PR TITLE
[Android][WebView] Don't override webview.settings.javaScriptEnabled settings

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/webview/WebViewCapture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/webview/WebViewCapture.kt
@@ -99,7 +99,7 @@ internal object WebViewCapture {
             effectiveLogger.logInstrumentationNotInitialized(notSupportedReason)
             return
         }
-        
+
         val bridgeHandler = WebViewBridgeMessageHandler(loggerImpl)
         webview.addJavascriptInterface(bridgeHandler, BRIDGE_NAME)
 
@@ -136,10 +136,9 @@ internal object WebViewCapture {
             "WebViewFeature.DOCUMENT_START_SCRIPT not supported"
         } else if (!WebViewFeature.isFeatureSupported(WebViewFeature.GET_WEB_VIEW_CLIENT)) {
             "WebViewFeature.GET_WEB_VIEW_CLIENT not supported"
-        } else if (!webview.settings.javaScriptEnabled){
+        } else if (!webview.settings.javaScriptEnabled) {
             "webview.settings.javaScriptEnabled is set to false"
-        }
-        else {
+        } else {
             null
         }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/webview/WebViewCapture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/webview/WebViewCapture.kt
@@ -94,14 +94,12 @@ internal object WebViewCapture {
             return
         }
 
-        val notSupportedReason = getNotSupportedReason()
+        val notSupportedReason = getNotSupportedReason(webview)
         if (notSupportedReason != null) {
             effectiveLogger.logInstrumentationNotInitialized(notSupportedReason)
             return
         }
-
-        webview.settings.javaScriptEnabled = true
-
+        
         val bridgeHandler = WebViewBridgeMessageHandler(loggerImpl)
         webview.addJavascriptInterface(bridgeHandler, BRIDGE_NAME)
 
@@ -131,14 +129,17 @@ internal object WebViewCapture {
         }
     }
 
-    private fun getNotSupportedReason(): String? =
+    private fun getNotSupportedReason(webview: WebView): String? =
         if (!isWebkitAvailable()) {
             "androidx.webkit not available"
         } else if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
             "WebViewFeature.DOCUMENT_START_SCRIPT not supported"
         } else if (!WebViewFeature.isFeatureSupported(WebViewFeature.GET_WEB_VIEW_CLIENT)) {
             "WebViewFeature.GET_WEB_VIEW_CLIENT not supported"
-        } else {
+        } else if (!webview.settings.javaScriptEnabled){
+            "webview.settings.javaScriptEnabled is set to false"
+        }
+        else {
             null
         }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/webview/WebViewCaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/webview/WebViewCaptureTest.kt
@@ -91,7 +91,7 @@ class WebViewCaptureTest {
     }
 
     @Test
-    fun instrument_withValidWebViewConfigurationAndJsDisabled_shouldLogNotInitMessage() {
+    fun instrument_withValidWebViewConfigurationAndJsDisabled_shouldLogNotInitialized() {
         startSdk(webViewConfiguration = WebViewConfiguration())
         val spyLogger = spyLogger()
         webView.settings.javaScriptEnabled = false
@@ -112,7 +112,10 @@ class WebViewCaptureTest {
         )
     }
 
-    private fun assertNotInitializedMessage(spyLogger: LoggerImpl, reason: String) {
+    private fun assertNotInitializedMessage(
+        spyLogger: LoggerImpl,
+        reason: String,
+    ) {
         verify(spyLogger).log(
             eq(LogLevel.WARNING),
             fieldsCaptor.capture(),


### PR DESCRIPTION
### What

Resolve BIT-7294

Honor customer settings for `webview.settings.javaScriptEnabled`. If not enabled will log a not init message

### Verification

On the gradle-test-app, disabled javaScriptEnabled to verify log is emitted

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.