### PR TITLE
[iOS] Ensure _is_low_memory is emitted as well from DispatchSourceMemoryMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Emit `_is_memory_low` on iOS system memory pressure events (AppMemPressure from DispatchSource) when the threshold is configured; periodic resource utilization emission remains unchanged.
 
 ## [0.22.7]
 

--- a/platform/swift/source/default/events/memory/DispatchSourceMemoryMonitor.swift
+++ b/platform/swift/source/default/events/memory/DispatchSourceMemoryMonitor.swift
@@ -20,6 +20,7 @@ final class DispatchSourceMemoryMonitor {
 
     init(logger: CoreLogging) {
         self.logger = logger
+        self.memorySnapshotProvider.logger = logger
         // Set the event handler, but don't enable until `start()` is called.
         self.dispatchSource.setEventHandler { [weak self] in
             self?.maybeSnapshot()

--- a/platform/swift/source/default/events/resource/models/MemorySnapshot.swift
+++ b/platform/swift/source/default/events/resource/models/MemorySnapshot.swift
@@ -58,7 +58,7 @@ extension MemorySnapshot: ResourceSnapshot {
     }
 
     private var hasValidMemoryLimit: Bool {
-        appTotalMemoryLimitKB > appTotalMemoryUsedKB
+        appTotalMemoryLimitKB >= appTotalMemoryUsedKB
     }
 
     private func appUsedPercent() -> Double {

--- a/test/platform/swift/unit_integration/core/bridge/ResourceUtilizationControllerTests.swift
+++ b/test/platform/swift/unit_integration/core/bridge/ResourceUtilizationControllerTests.swift
@@ -72,4 +72,20 @@ final class ResourceUtilizationControllerTests: XCTestCase {
         XCTAssertNotNil(self.logger.resourceUtilizationLogs[2]
                             .fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
     }
+
+    func testMemorySnapshotIncludesIsMemoryLowFieldWhenThresholdProvided() {
+        let snapshot = MemorySnapshot(
+            appTotalMemoryLimitKB: 100,
+            appTotalMemoryUsedKB: 100,
+            deviceTotalMemoryKB: 200,
+            lowMemoryConfigThresholdPercent: 90,
+            relativeTimestamp: nil,
+            timeSinceDeviceBoot: 1,
+            sequenceNumber: 1,
+            timeToCaptureMicroseconds: 0
+        )
+
+        let fields = snapshot.toDictionary()
+        XCTAssertNotNil(fields["_is_memory_low"])
+    }
 }


### PR DESCRIPTION
## What

Resolve BIT-7431

`_is_low_memory` wasn't emitting when the trigger was from `DispatchSourceMemoryMonitor` given it was missing passing the logger instance allowing to read the configurable threshold under `client_feature.ios.app_low_memory_percent_threshold`. We do this already at [ResourceUtilizationController](https://github.com/bitdriftlabs/capture-sdk/blob/ebd07c7032efb4fc23e9333baf77ca1ac5d79d4f/platform/swift/source/default/events/resource/ResourceUtilizationController.swift#L24)

## Verification

- With simulator trigger a "Simulate Memory Warning event". _is_low_memory should be reported now
- With real device, on helloworld app click on the Force Memory Pressure (90%) and check logs on that session
- Verified with new workflows