### PR TITLE
Revert "Remove androidx.metrics:metrics-performance (#914)"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -175,6 +175,7 @@ maven.install(
         "org.jetbrains.kotlin:kotlin-stdlib:{}".format(KOTLIN_STD_VERSION),
         "androidx.emoji2:emoji2:1.5.0",
         "androidx.collection:collection:1.4.5",
+        "androidx.metrics:metrics-performance:1.0.0",
         "com.google.flatbuffers:flatbuffers-java:25.2.10",
         "com.google.protobuf:protobuf-kotlin-lite:4.31.1",
 

--- a/examples/android/BUILD
+++ b/examples/android/BUILD
@@ -26,6 +26,7 @@ _maven_deps = [
     artifact("com.squareup.okio:okio-jvm"),
     artifact("org.jetbrains.kotlin:kotlin-stdlib"),
     artifact("org.jetbrains:annotations"),
+    artifact("androidx.metrics:metrics-performance"),
     artifact("com.squareup.retrofit2:retrofit"),
     artifact("androidx.webkit:webkit"),
 ]

--- a/platform/jvm/capture/BUILD.bazel
+++ b/platform/jvm/capture/BUILD.bazel
@@ -76,6 +76,7 @@ bitdrift_kt_android_library(
         artifact("com.google.code.gson:gson"),
         artifact("com.google.flatbuffers:flatbuffers-java"),
         artifact("com.google.protobuf:protobuf-kotlin-lite"),
+        artifact("androidx.metrics:metrics-performance"),
         # Compile-only dependency (neverlink wrapper). Not packaged nor appearing in POM.
         ":retrofit_compile_only",
         ":webkit_compile_only",

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.androidx.startup.runtime)
     implementation(libs.jsr305)
     implementation(libs.gson)
+    implementation(libs.performance)
     implementation(libs.protobuf.kotlinlite)
 
     compileOnly(libs.retrofit)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -8,6 +8,7 @@
 package io.bitdrift.capture
 
 import android.app.ActivityManager
+import android.app.Application
 import android.content.Context
 import android.util.Log
 import androidx.annotation.VisibleForTesting
@@ -28,6 +29,7 @@ import io.bitdrift.capture.events.lifecycle.AppLifecycleListenerLogger
 import io.bitdrift.capture.events.lifecycle.EventsListenerTarget
 import io.bitdrift.capture.events.performance.BatteryMonitor
 import io.bitdrift.capture.events.performance.DiskUsageMonitor
+import io.bitdrift.capture.events.performance.JankStatsMonitor
 import io.bitdrift.capture.events.performance.MemoryMetricsProvider
 import io.bitdrift.capture.events.performance.ResourceUtilizationTarget
 import io.bitdrift.capture.events.span.Span
@@ -98,6 +100,7 @@ internal class LoggerImpl(
     private val memoryMetricsProvider: MemoryMetricsProvider
     private val appExitLogger: AppExitLogger
     private val runtime: JniRuntime
+    private var jankStatsMonitor: JankStatsMonitor? = null
 
     // we can assume a properly formatted api url is being used, so we can follow the same pattern
     // making sure we only replace the first occurrence
@@ -251,6 +254,8 @@ internal class LoggerImpl(
             ),
         )
 
+        addJankStatsMonitorTarget(windowManager, context)
+
         appExitLogger =
             AppExitLogger(
                 logger = this,
@@ -326,6 +331,7 @@ internal class LoggerImpl(
     }
 
     override fun logScreenView(screenName: String) {
+        jankStatsMonitor?.trackScreenNameChanged(screenName)
         CaptureJniLibrary.writeScreenViewLog(this.loggerId, screenName)
     }
 
@@ -671,6 +677,27 @@ internal class LoggerImpl(
             if (result is CaptureResult.Success) {
                 Log.i("capture", "Temporary device code: ${result.value}")
             }
+        }
+    }
+
+    private fun addJankStatsMonitorTarget(
+        windowManager: IWindowManager,
+        context: Context,
+    ) {
+        if (context is Application) {
+            jankStatsMonitor =
+                JankStatsMonitor(
+                    context,
+                    this,
+                    ProcessLifecycleOwner.get(),
+                    runtime,
+                    windowManager,
+                )
+            jankStatsMonitor?.let {
+                eventsListenerTarget.add(it)
+            }
+        } else {
+            errorHandler.handleError("Couldn't start JankStatsMonitor. Invalid application provided")
         }
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitor.kt
@@ -1,0 +1,309 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.performance
+
+import android.app.Activity
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import android.view.Window
+import androidx.annotation.OpenForTesting
+import androidx.annotation.UiThread
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.metrics.performance.FrameData
+import androidx.metrics.performance.FrameDataApi24
+import androidx.metrics.performance.FrameDataApi31
+import androidx.metrics.performance.JankStats
+import androidx.metrics.performance.PerformanceMetricsState
+import androidx.metrics.performance.StateInfo
+import io.bitdrift.capture.IInternalLogger
+import io.bitdrift.capture.LogLevel
+import io.bitdrift.capture.LogType
+import io.bitdrift.capture.common.IBackgroundThreadHandler
+import io.bitdrift.capture.common.IWindowManager
+import io.bitdrift.capture.common.MainThreadHandler
+import io.bitdrift.capture.common.Runtime
+import io.bitdrift.capture.common.RuntimeConfig
+import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.events.IEventListenerLogger
+import io.bitdrift.capture.events.span.SpanField
+import io.bitdrift.capture.providers.ArrayFields
+import io.bitdrift.capture.providers.combineFields
+import io.bitdrift.capture.providers.fieldsOf
+import io.bitdrift.capture.threading.CaptureDispatchers
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reports Jank Frames and its duration in ms
+ *
+ * This will be a no-op when `client_feature.android.jank_stats_reporting` kill switch is disabled.
+ *
+ */
+internal class JankStatsMonitor(
+    private val application: Application,
+    private val logger: IInternalLogger,
+    private val processLifecycleOwner: LifecycleOwner,
+    private val runtime: Runtime,
+    private val windowManager: IWindowManager,
+    private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
+    private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
+) : IEventListenerLogger,
+    Application.ActivityLifecycleCallbacks,
+    LifecycleEventObserver,
+    JankStats.OnFrameListener {
+    @VisibleForTesting
+    internal var jankStats: JankStats? = null
+    private var currentWindow: Window? = null
+    private var performanceMetricsStateHolder: PerformanceMetricsState.Holder? = null
+
+    override fun start() {
+        mainThreadHandler.run {
+            // TODO(FranAguilera): BIT-4785. To improve detection of Application/Activity lifecycles
+            processLifecycleOwner.lifecycle.addObserver(this)
+            application.registerActivityLifecycleCallbacks(this)
+        }
+    }
+
+    override fun stop() {
+        stopCollection()
+        mainThreadHandler.run {
+            processLifecycleOwner.lifecycle.removeObserver(this)
+            application.unregisterActivityLifecycleCallbacks(this)
+        }
+    }
+
+    override fun onFrame(volatileFrameData: FrameData) {
+        if (!volatileFrameData.isJank) {
+            return
+        }
+        if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+            stopCollection()
+            return
+        }
+
+        // From the docs: note that the FrameData object sent in the callback is reused on every frame
+        // to prevent having to allocate new objects for data reporting.
+        // This means that you must copy and cache that data elsewhere since that object should be considered stale
+        // and obsolete as soon as the callback returns.
+        val frameData = volatileFrameData.copy()
+
+        val durationNano = frameData.toDurationNano()
+        val durationMillis = frameData.toDurationMillis()
+        if (durationNano < 0 || durationMillis > ERROR_DURATION_THRESHOLD_MILLIS) {
+            val errorMessage =
+                "Unexpected frame duration. durationInNano: $durationNano." +
+                    " durationMillis: $durationMillis"
+            logInternalError(errorMessage)
+            return
+        }
+
+        if (durationMillis < runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)) {
+            // The Frame is considered as Jank but it didn't reached the min
+            // threshold defined by MIN_JANK_FRAME_THRESHOLD_MS config
+            return
+        }
+
+        // Below API 24 [onFrame(volatileFrameData)] call happens on the main thread
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            backgroundThreadHandler.runAsync { frameData.sendJankFrameData() }
+        } else {
+            // For >= 24 this happens on `FrameMetricsAggregator` thread
+            frameData.sendJankFrameData()
+        }
+    }
+
+    /**
+     * [LifecycleEventObserver] callback to determine when the Application process is first resumed
+     */
+    override fun onStateChanged(
+        source: LifecycleOwner,
+        event: Lifecycle.Event,
+    ) {
+        if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+            return
+        }
+        if (event == Lifecycle.Event.ON_RESUME) {
+            windowManager.findFirstValidActivity()?.let {
+                setJankStatsForCurrentWindow(it.window)
+            }
+            // We are done detecting initial Application ON_RESUME, we don't need to listen anymore
+            processLifecycleOwner.lifecycle.removeObserver(this)
+        }
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+            return
+        }
+        setJankStatsForCurrentWindow(activity.window)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        stopCollectionIfNeeded(activity)
+    }
+
+    override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?,
+    ) {
+        // no-op
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        // no-op
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // no-op
+    }
+
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle,
+    ) {
+        // no-op
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        stopCollectionIfNeeded(activity)
+    }
+
+    fun trackScreenNameChanged(screenName: String) {
+        if (runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+            performanceMetricsStateHolder?.state?.putState(SCREEN_NAME_KEY, screenName)
+        }
+    }
+
+    @UiThread
+    private fun setJankStatsForCurrentWindow(window: Window) {
+        try {
+            if (!runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)) {
+                stopCollection()
+                return
+            }
+            jankStats = JankStats.createAndTrack(window, this)
+            currentWindow = window
+            performanceMetricsStateHolder = PerformanceMetricsState.getHolderForHierarchy(window.decorView.rootView)
+            jankStats?.jankHeuristicMultiplier = runtime.getConfigValue(RuntimeConfig.JANK_FRAME_HEURISTICS_MULTIPLIER).toFloat()
+        } catch (illegalStateException: IllegalStateException) {
+            logInternalError(errorMessage = "Couldn't create JankStats instance", throwable = illegalStateException)
+        }
+    }
+
+    private fun stopCollectionIfNeeded(activity: Activity) {
+        if (activity.window == currentWindow) {
+            stopCollection()
+        }
+    }
+
+    private fun stopCollection() {
+        jankStats?.isTrackingEnabled = false
+        performanceMetricsStateHolder?.state?.removeState(SCREEN_NAME_KEY)
+        jankStats = null
+        currentWindow = null
+        performanceMetricsStateHolder = null
+    }
+
+    @WorkerThread
+    private fun FrameData.sendJankFrameData() {
+        val jankFrameType = toJankType()
+
+        val coreJankFields =
+            fieldsOf(
+                SpanField.Key.DURATION to toDurationMillis().toString(),
+                DROPPED_FRAME_TYPE_KEY to jankFrameType.value,
+            )
+        val jankFrameStateFields = this@sendJankFrameData.states.toInternalFields()
+
+        logger.logInternal(
+            LogType.UX,
+            jankFrameType.logLevel,
+            combineFields(coreJankFields, jankFrameStateFields),
+        ) { DROPPED_FRAME_MESSAGE_ID }
+    }
+
+    @WorkerThread
+    private fun List<StateInfo>.toInternalFields(): ArrayFields {
+        // Convert the list of StateInfo to a map of fields using StateInfo's key and value properties
+        if (isEmpty()) return ArrayFields.EMPTY
+        val keys = Array(size) { i -> this[i].key }
+        val values = Array(size) { i -> this[i].value }
+        return ArrayFields(keys, values)
+    }
+
+    private fun FrameData.toJankType(): JankFrameType {
+        val durationMillis = this.toDurationMillis()
+        return if (durationMillis < runtime.getConfigValue(RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS)) {
+            JankFrameType.SLOW
+        } else if (durationMillis < runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_MS)) {
+            JankFrameType.FROZEN
+        } else {
+            JankFrameType.ANR
+        }
+    }
+
+    private fun FrameData.toDurationMillis(): Long = TimeUnit.NANOSECONDS.toMillis(this.toDurationNano())
+
+    private fun FrameData.toDurationNano(): Long =
+        when (this) {
+            is FrameDataApi31 -> frameDurationTotalNanos
+            is FrameDataApi24 -> frameDurationCpuNanos
+            else -> {
+                frameDurationUiNanos
+            }
+        }
+
+    private fun logInternalError(
+        errorMessage: String,
+        throwable: Throwable? = null,
+    ) {
+        logger.logInternal(
+            type = LogType.INTERNALSDK,
+            level = LogLevel.ERROR,
+            arrayFields = ArrayFields.EMPTY,
+            throwable = throwable,
+        ) {
+            errorMessage
+        }
+    }
+
+    /**
+     * The different type of Janks according to Play Vitals
+     */
+    @OpenForTesting
+    internal enum class JankFrameType(
+        val logLevel: LogLevel,
+        val value: String,
+    ) {
+        /**
+         * Has a duration >= 16 ms and below [RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS]
+         */
+        SLOW(LogLevel.WARNING, "Slow"),
+
+        /**
+         * With a duration between [RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS] and below [RuntimeConfig.ANR_FRAME_THRESHOLD_MS]
+         */
+        FROZEN(LogLevel.ERROR, "Frozen"),
+
+        /**
+         * With a duration above [RuntimeConfig.ANR_FRAME_THRESHOLD_MS]
+         */
+        ANR(LogLevel.ERROR, "ANR"),
+    }
+
+    private companion object {
+        private const val ERROR_DURATION_THRESHOLD_MILLIS = 100_000_000L
+        private const val DROPPED_FRAME_MESSAGE_ID = "DroppedFrame"
+        private const val SCREEN_NAME_KEY = "_screen_name"
+        private const val DROPPED_FRAME_TYPE_KEY = "_frame_issue_type"
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/JankStatsMonitorTest.kt
@@ -1,0 +1,388 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.performance
+
+import android.app.Activity
+import android.app.Application
+import android.view.Window
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.metrics.performance.FrameData
+import androidx.metrics.performance.StateInfo
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.bitdrift.capture.IInternalLogger
+import io.bitdrift.capture.LogLevel
+import io.bitdrift.capture.LogType
+import io.bitdrift.capture.Mocks
+import io.bitdrift.capture.common.IWindowManager
+import io.bitdrift.capture.common.Runtime
+import io.bitdrift.capture.common.RuntimeConfig
+import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.events.performance.JankStatsMonitor.JankFrameType
+import io.bitdrift.capture.providers.ArrayFields
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verifyNoInteractions
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class JankStatsMonitorTest {
+    private val logger: IInternalLogger = mock()
+    private val runtime: Runtime = mock()
+    private val lifecycle: Lifecycle = mock()
+    private val processLifecycleOwner: LifecycleOwner = mock()
+    private val windowManager: IWindowManager = mock()
+    private val mainThreadHandler = Mocks.sameThreadHandler
+
+    private val illegalStateExceptionCaptor = argumentCaptor<IllegalStateException>()
+    private val logMessageCaptor = argumentCaptor<() -> String>()
+
+    private lateinit var application: Application
+    private lateinit var activity: Activity
+    private lateinit var window: Window
+    private lateinit var jankStatsMonitor: JankStatsMonitor
+
+    @Before
+    fun setUp() {
+        application = RuntimeEnvironment.getApplication()
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        window = activity.window
+
+        whenever(processLifecycleOwner.lifecycle).thenReturn(lifecycle)
+        whenever(windowManager.findFirstValidActivity()).thenReturn(activity)
+
+        whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(true)
+        whenever(runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)).thenReturn(16)
+        whenever(runtime.getConfigValue(RuntimeConfig.FROZEN_FRAME_THRESHOLD_MS)).thenReturn(700)
+        whenever(runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_MS)).thenReturn(5000)
+
+        jankStatsMonitor =
+            JankStatsMonitor(
+                application,
+                logger,
+                processLifecycleOwner,
+                runtime,
+                windowManager,
+                mainThreadHandler,
+            )
+    }
+
+    @Test
+    fun onApplicationCreate_withSlowFrame_shouldLogWithWarningAndDroppedFrameMessage() {
+        val jankDurationInMilli = 200L
+        jankStatsMonitor.onStateChanged(processLifecycleOwner, Lifecycle.Event.ON_CREATE)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        assertLogDetails(jankDurationInMilli, JankFrameType.SLOW)
+    }
+
+    @Test
+    fun onApplicationCreate_withFlagDisabled_shouldNotInteractWithWindowManager() {
+        whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(false)
+
+        jankStatsMonitor.onStateChanged(processLifecycleOwner, Lifecycle.Event.ON_CREATE)
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = 5000L,
+        )
+
+        verifyNoInteractions(windowManager)
+        verifyNoInteractions(logger)
+    }
+
+    @Test
+    fun onActivityResumed_withFlagDisabled_shouldNotSetJankStats() {
+        whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(false)
+
+        jankStatsMonitor.onActivityResumed(activity)
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = 5000L,
+        )
+
+        verify(runtime, never()).getConfigValue(RuntimeConfig.JANK_FRAME_HEURISTICS_MULTIPLIER)
+        verifyNoInteractions(logger)
+    }
+
+    @Test
+    fun onActivityResumed_withSlowFrame_shouldLogWithWarningAndDroppedFrameMessage() {
+        val jankDurationInMilli = 690L
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        assertLogDetails(jankDurationInMilli, JankFrameType.SLOW)
+    }
+
+    @Test
+    fun onActivityResumed_withFrozenFrame_shouldLogWithErrorAndDroppedFrameMessage() {
+        val jankDurationInMilli = 700L
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        assertLogDetails(jankDurationInMilli, JankFrameType.FROZEN)
+    }
+
+    @Test
+    fun onActivityResumed_withAnrFrame_shouldLogWithErrorAndAnrMessage() {
+        val jankDurationInMilli = 5000L
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        assertLogDetails(jankDurationInMilli, JankFrameType.ANR)
+    }
+
+    @Test
+    fun onActivityResumed_withUpdatedConfigAndAnrFrame_shouldLogWithErrorAndAnrMessage() {
+        whenever(runtime.getConfigValue(RuntimeConfig.ANR_FRAME_THRESHOLD_MS)).thenReturn(2000)
+        val jankDurationInMilli = 2000L
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        assertLogDetails(jankDurationInMilli, JankFrameType.ANR)
+    }
+
+    @Test
+    fun onActivityResumed_withNegativeFrameDurations_shouldOnlyReportError() {
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = -1L,
+        )
+
+        assertWrongDuration(
+            expectedMessage = "Unexpected frame duration. durationInNano: -1000000. durationMillis: -1",
+        )
+    }
+
+    @Test
+    fun onActivityResumed_withOverflownFrameDurations_shouldOnlyReportError() {
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = 9223369584987L,
+        )
+
+        assertWrongDuration(
+            expectedMessage = "Unexpected frame duration. durationInNano: 9223369584987000000. durationMillis: 9223369584987",
+        )
+    }
+
+    @Test
+    fun onActivityResumed_withJankyFrameBelowMinThreshold_shouldNotLogAnyMessage() {
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = 4L,
+        )
+
+        verifyNoInteractions(logger)
+    }
+
+    @Test
+    fun onActivityResumed_withAnrFrameAndBelowRuntimeConfig_shouldNotLogAnyMessage() {
+        val jankDurationInMilli = 5000L
+        whenever(runtime.getConfigValue(RuntimeConfig.MIN_JANK_FRAME_THRESHOLD_MS)).thenReturn(6000)
+
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+        )
+
+        verifyNoInteractions(logger)
+    }
+
+    @Test
+    fun onActivityResumed_withoutJankyFrame_shouldNotLogJankFrameData() {
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = false,
+            durationInMilli = 1L,
+        )
+
+        verifyNoInteractions(logger)
+    }
+
+    @Test
+    fun onActivityResumed_withJankyFrameAndKillSwitchEnabled_shouldNotLogJankFrameData() {
+        whenever(runtime.isEnabled(RuntimeFeature.DROPPED_EVENTS_MONITORING)).thenReturn(false)
+        jankStatsMonitor.onActivityResumed(activity)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = 5000,
+        )
+
+        verifyNoInteractions(logger)
+    }
+
+    @Test
+    fun onActivityResumed_withNullDecorView_shouldReportError() {
+        val nullDecorView: Window = mock()
+        val mockedActivity: Activity = mock()
+        whenever(mockedActivity.window).thenReturn(nullDecorView)
+
+        jankStatsMonitor.onActivityResumed(mockedActivity)
+
+        verify(logger).logInternal(
+            type = eq(LogType.INTERNALSDK),
+            level = eq(LogLevel.ERROR),
+            arrayFields = eq(ArrayFields.EMPTY),
+            throwable = illegalStateExceptionCaptor.capture(),
+            blocking = eq(false),
+            message = logMessageCaptor.capture(),
+        )
+        assertThat(logMessageCaptor.firstValue()).isEqualTo("Couldn't create JankStats instance")
+        assertThat(illegalStateExceptionCaptor.lastValue).isInstanceOf(IllegalStateException::class.java)
+        assertThat(
+            illegalStateExceptionCaptor.lastValue.message,
+        ).isEqualTo("window.peekDecorView() is null: JankStats can only be created with a Window that has a non-null DecorView")
+    }
+
+    @Test
+    fun onActivityPaused_withPreviousOnActivityResumed_shouldStopCollection() {
+        jankStatsMonitor.onActivityResumed(activity)
+
+        jankStatsMonitor.onActivityPaused(activity)
+
+        assertThat(jankStatsMonitor.jankStats).isNull()
+    }
+
+    @Test
+    fun onActivityResumed_withJankyFrameAndScreenNameState_shouldLogScreeNameField() {
+        val jankDurationInMilli = 16L
+        val screenName = "test"
+        jankStatsMonitor.onActivityResumed(activity)
+        jankStatsMonitor.trackScreenNameChanged(screenName)
+
+        triggerOnFrame(
+            isJankyFrame = true,
+            durationInMilli = jankDurationInMilli,
+            states = listOf(StateInfo("_screen_name", screenName)),
+        )
+
+        verify(logger).logInternal(
+            any(),
+            any(),
+            argThat<ArrayFields> { fields ->
+                fields["_duration_ms"] == jankDurationInMilli.toString() &&
+                    fields["_frame_issue_type"] == JankFrameType.SLOW.value.toString() &&
+                    fields["_screen_name"] == screenName
+            },
+            anyOrNull(),
+            anyOrNull(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test
+    fun onActivityDestroyed_afterOnStateChangedAttachesJankStats_shouldClearJankStatsWithoutLeak() {
+        // 1. SDK starts, onStateChanged ON_CREATE and ON_RESUME triggers findFirstValidActivity
+        //    which returns our activity and attaches JankStats to its window
+        jankStatsMonitor.onStateChanged(processLifecycleOwner, Lifecycle.Event.ON_CREATE)
+        jankStatsMonitor.onStateChanged(processLifecycleOwner, Lifecycle.Event.ON_RESUME)
+
+        assertThat(jankStatsMonitor.jankStats).isNotNull()
+
+        // 2. Activity is destroyed WITHOUT going through onActivityPaused
+        //    (simulates finish() from onCreate, or activity was already paused when SDK started)
+        jankStatsMonitor.onActivityDestroyed(activity)
+
+        // 3. Prior Leak: jankStats wasn't null before
+        assertThat(jankStatsMonitor.jankStats).isNull()
+
+        jankStatsMonitor.onActivityResumed(activity)
+
+        assertThat(jankStatsMonitor.jankStats).isNotNull
+    }
+
+    private fun triggerOnFrame(
+        isJankyFrame: Boolean,
+        durationInMilli: Long,
+        states: List<StateInfo> = emptyList(),
+    ) {
+        val frameData =
+            FrameData(
+                frameStartNanos = 0L,
+                frameDurationUiNanos = durationInMilli * 1000000,
+                isJank = isJankyFrame,
+                states = states,
+            )
+        jankStatsMonitor.onFrame(frameData)
+    }
+
+    private fun assertLogDetails(
+        jankDurationInMilli: Long,
+        expectedFrameType: JankStatsMonitor.JankFrameType,
+    ) {
+        verify(logger).logInternal(
+            eq(LogType.UX),
+            eq(expectedFrameType.logLevel),
+            argThat<ArrayFields> { fields ->
+                fields["_duration_ms"] == jankDurationInMilli.toString() &&
+                    fields["_frame_issue_type"] == expectedFrameType.value.toString()
+            },
+            eq(ArrayFields.EMPTY),
+            eq(null),
+            eq(false),
+            argThat { message: () -> String -> message.invoke() == "DroppedFrame" },
+        )
+    }
+
+    private fun assertWrongDuration(expectedMessage: String) {
+        verify(logger).logInternal(
+            type = eq(LogType.INTERNALSDK),
+            level = eq(LogLevel.ERROR),
+            arrayFields = eq(ArrayFields.EMPTY),
+            throwable = anyOrNull(),
+            blocking = eq(false),
+            message = logMessageCaptor.capture(),
+        )
+        assertThat(logMessageCaptor.firstValue()).isEqualTo(expectedMessage)
+    }
+}

--- a/platform/jvm/gradle/libs.versions.toml
+++ b/platform/jvm/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ mockitoCore             = "5.12.0"
 mockitoKotlin           = "2.2.0"
 mockitoKotlinVersion    = "4.1.0"
 okhttp                  = "4.12.0"
+performance             = "1.0.0"
 protobufKotlinLite      = "4.31.1"
 retrofit                = "3.0.0"
 robolectric             = "4.13"
@@ -51,6 +52,7 @@ mockito-core               = { module = "org.mockito:mockito-core", version.ref 
 mockito-kotlin             = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version.ref = "mockitoKotlin" }
 mockwebserver              = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okhttp                     = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+performance                = { module = "androidx.metrics:metrics-performance", version.ref = "performance" }
 protobuf-kotlinlite        = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobufKotlinLite" }
 retrofit                   = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 robolectric                = { module = "org.robolectric:robolectric", version.ref = "robolectric" }

--- a/test/platform/pom_checker/src/lib.rs
+++ b/test/platform/pom_checker/src/lib.rs
@@ -24,6 +24,7 @@ mod test {
       "androidx.core:core",
       "androidx.lifecycle:lifecycle-common",
       "androidx.lifecycle:lifecycle-process",
+      "androidx.metrics:metrics-performance",
       "androidx.startup:startup-runtime",
       "com.google.code.gson:gson",
       "com.google.flatbuffers:flatbuffers-java",


### PR DESCRIPTION
This reverts commit eb84dd9f9bbd77e8c6265145983ee856a6d0569e.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.