### PR TITLE
[iOS] Fix inaccurate timestamp on crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,12 @@
 
 **Changed**
 
-- Changed previous-run fatal issue reporting to use the cached KSCrash report as the canonical iOS crash source, with MetricKit used only as optional enrichment for non-crash diagnostics.
+- Nothing yet!
 
 **Fixed**
 
-- Fixed inaccurate iOS previous-run crash timestamps and duplicate previous-run crash materialization caused by relying on MetricKit crash diagnostics as the primary report source.
+- Fixed inaccurate iOS previous-run crash timestamps by overriding MetricKit crash times with the cached KSCrash crash time when available.
+- Fixed duplicate iOS previous-run crash materialization caused by creating separate crash artifacts from both KSCrash and MetricKit.
 
 ## [0.22.13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,11 @@
 
 **Changed**
 
-- Nothing yet!
+- Changed previous-run fatal issue reporting to use the cached KSCrash report as the canonical iOS crash source, with MetricKit used only as optional enrichment for non-crash diagnostics.
 
 **Fixed**
 
-- Nothing yet!
+- Fixed inaccurate iOS previous-run crash timestamps and duplicate previous-run crash materialization caused by relying on MetricKit crash diagnostics as the primary report source.
 
 ## [0.22.13]
 

--- a/bazel/framework_imports_extractor.bzl
+++ b/bazel/framework_imports_extractor.bzl
@@ -29,8 +29,7 @@ def _framework_imports_extractor(ctx):
             arch = arch[4:]
 
         outputs.extend([
-            ctx.actions.declare_file("Capture.framework/Modules/Capture.swiftmodule/{}.swiftdoc".format(arch)),
-            ctx.actions.declare_file("Capture.framework/Modules/Capture.swiftmodule/{}.swiftinterface".format(arch)),
+            ctx.actions.declare_file("Capture.framework/Modules/Capture.swiftmodule/{}.swiftmodule".format(arch)),
         ])
 
     if len(ctx.attr.framework[0].files.to_list()) != 1:

--- a/examples/objective-c/CAPViewController.m
+++ b/examples/objective-c/CAPViewController.m
@@ -3,9 +3,26 @@
 
 #import "CAPViewController.h"
 
-NSString * const kCaptureAPIKey= @"<YOUR API KEY GOES HERE>";
-NSString * const kCaptureURLString = @"https://api.bitdrift.io";
-NSString * const kDeviceId = @"ios-objc-helloworld";
+static NSString * const kDefaultCaptureAPIKey = @"<YOUR API KEY GOES HERE>";
+static NSString * const kDefaultCaptureURLString = @"https://api.bitdrift.io";
+static NSString * const kSavedCaptureAPIKeyKey = @"capture_api_key";
+static NSString * const kSavedCaptureURLKey = @"capture_api_url";
+
+@interface CAPIssueLogger : NSObject <IssueReportCallback>
+@end
+
+@implementation CAPIssueLogger
+
+- (void)onBeforeReportSendWithReport:(CAPIssueReport *)report {
+    NSMutableDictionary<NSString *, NSString *> *fields = [NSMutableDictionary dictionaryWithDictionary:report.fields ?: @{}];
+    fields[@"reportType"] = report.reportType ?: @"";
+    fields[@"reason"] = report.reason ?: @"";
+    fields[@"details"] = report.details ?: @"";
+    fields[@"sessionID"] = report.sessionID ?: @"";
+    [CAPLogger logInfo:@"Bitdrift IssueCallback" fields:fields];
+}
+
+@end
 
 NSString *logLevelToString(LogLevel level) {
     switch (level) {
@@ -24,15 +41,28 @@ NSString *logLevelToString(LogLevel level) {
     return @"Unknown";
 }
 
-@interface CAPViewController ()
+@interface CAPViewController () <UITextFieldDelegate>
 
 @property (nonatomic, strong) NSArray<NSNumber *> *logLevels;
 @property (nonatomic, assign) LogLevel selectedLogLevel;
 @property (nonatomic, weak) UIButton *pickLogLevelButton;
+@property (nonatomic, weak) UITextField *apiKeyTextField;
+@property (nonatomic, weak) UITextField *apiURLTextField;
+@property (nonatomic, strong) CAPIssueLogger *issueLogger;
 
 @end
 
 @implementation CAPViewController
+
+- (NSString *)savedAPIKey {
+    NSString *apiKey = [[NSUserDefaults standardUserDefaults] stringForKey:kSavedCaptureAPIKeyKey];
+    return apiKey.length > 0 ? apiKey : kDefaultCaptureAPIKey;
+}
+
+- (NSString *)savedAPIURLString {
+    NSString *apiURLString = [[NSUserDefaults standardUserDefaults] stringForKey:kSavedCaptureURLKey];
+    return apiURLString.length > 0 ? apiURLString : kDefaultCaptureURLString;
+}
 
 - (instancetype)init {
     self = [super init];
@@ -53,16 +83,48 @@ NSString *logLevelToString(LogLevel level) {
 }
 
 - (void)loadView {
+    UIView *rootView = [UIView new];
+    rootView.backgroundColor = [UIColor whiteColor];
+
+    UIView *configurationView = [self createConfigurationView];
     UIView *sendLogView = [self createSendLogView];
+    UIView *copySessionURLView = [self createCopySessionURLView];
+    UIView *crashView = [self createCrashView];
     UIView *copySessionIDView = [self createCopySessionIDView];
 
-    UIStackView *view = [[UIStackView alloc]
-                         initWithArrangedSubviews:@[[UIView new], sendLogView, copySessionIDView]];
-    view.axis = UILayoutConstraintAxisVertical;
-    view.distribution = UIStackViewDistributionEqualCentering;
-    view.backgroundColor = [UIColor whiteColor];
+    UIStackView *contentStack = [[UIStackView alloc]
+                                 initWithArrangedSubviews:@[configurationView, sendLogView, crashView, copySessionURLView, copySessionIDView]];
+    contentStack.axis = UILayoutConstraintAxisVertical;
+    contentStack.spacing = 16;
+    contentStack.translatesAutoresizingMaskIntoConstraints = NO;
 
-    self.view = view;
+    UIScrollView *scrollView = [UIScrollView new];
+    scrollView.alwaysBounceVertical = YES;
+    scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+    scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [scrollView addSubview:contentStack];
+    [rootView addSubview:scrollView];
+
+    UILayoutGuide *safeArea = rootView.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [scrollView.topAnchor constraintEqualToAnchor:safeArea.topAnchor],
+        [scrollView.leadingAnchor constraintEqualToAnchor:safeArea.leadingAnchor],
+        [scrollView.trailingAnchor constraintEqualToAnchor:safeArea.trailingAnchor],
+        [scrollView.bottomAnchor constraintEqualToAnchor:safeArea.bottomAnchor],
+
+        [contentStack.topAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.topAnchor constant:16],
+        [contentStack.leadingAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.leadingAnchor constant:16],
+        [contentStack.trailingAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.trailingAnchor constant:-16],
+        [contentStack.bottomAnchor constraintEqualToAnchor:scrollView.contentLayoutGuide.bottomAnchor constant:-16],
+        [contentStack.widthAnchor constraintEqualToAnchor:scrollView.frameLayoutGuide.widthAnchor constant:-32],
+    ]];
+
+    UITapGestureRecognizer *dismissKeyboardGesture = [[UITapGestureRecognizer alloc] initWithTarget:rootView action:@selector(endEditing:)];
+    dismissKeyboardGesture.cancelsTouchesInView = NO;
+    [rootView addGestureRecognizer:dismissKeyboardGesture];
+
+    self.view = rootView;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -79,18 +141,32 @@ NSString *logLevelToString(LogLevel level) {
 // MARK: - Setup
 
 - (void)setUpLogger {
+    NSURL *apiURL = [NSURL URLWithString:[self savedAPIURLString]];
+    self.issueLogger = [CAPIssueLogger new];
+    CAPIssueCallbackConfiguration *issueCallbackConfiguration = [[CAPIssueCallbackConfiguration alloc]
+                                                                initWithCallbackQueue:dispatch_get_main_queue()
+                                                                issueReportCallback:self.issueLogger];
     CAPConfiguration *config = [[CAPConfiguration alloc] initWithEnableFatalIssueReporting:true
                                                                enableURLSessionIntegration:true
                                                                                  sleepMode:false
-                                                                                    apiURL:[NSURL URLWithString:kCaptureURLString]
-                                                                               rootFileURL:nil];
+                                                                                    apiURL:apiURL
+                                                                                rootFileURL:nil
+                                                                 issueCallbackConfiguration:issueCallbackConfiguration];
     [CAPLogger
-     startWithAPIKey:kCaptureAPIKey
+     startWithAPIKey:[self savedAPIKey]
      sessionStrategy:[CAPSessionStrategy fixed]
-     configuration: config
+      configuration: config
     ];
 
     [CAPLogger logInfo:@"An objective-c example app is launching" fields:nil];
+
+    NSDictionary *previousRunInfo = [CAPLogger previousRunInfo];
+    if (previousRunInfo != nil) {
+        NSMutableDictionary<NSString *, NSString *> *fields = [NSMutableDictionary new];
+        NSNumber *hasFatallyTerminated = previousRunInfo[@"hasFatallyTerminated"];
+        fields[@"hasFatallyTerminated"] = hasFatallyTerminated.boolValue ? @"true" : @"false";
+        [CAPLogger logInfo:@"Bitdrift PreviousRunInfo" fields:fields];
+    }
 }
 
 - (void)refresh {
@@ -98,9 +174,55 @@ NSString *logLevelToString(LogLevel level) {
      setTitle:logLevelToString(self.selectedLogLevel)
      forState:UIControlStateNormal
     ];
+
+    self.apiKeyTextField.text = [self savedAPIKey];
+    self.apiURLTextField.text = [self savedAPIURLString];
 }
 
 // MARK: - Views
+
+- (UIView *)createConfigurationView {
+    UILabel *apiKeyLabel = [UILabel new];
+    apiKeyLabel.text = @"API Key";
+
+    UITextField *apiKeyTextField = [UITextField new];
+    apiKeyTextField.borderStyle = UITextBorderStyleRoundedRect;
+    apiKeyTextField.placeholder = kDefaultCaptureAPIKey;
+    apiKeyTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+    apiKeyTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    apiKeyTextField.returnKeyType = UIReturnKeyDone;
+    apiKeyTextField.delegate = self;
+    apiKeyTextField.text = [self savedAPIKey];
+
+    UILabel *apiURLLabel = [UILabel new];
+    apiURLLabel.text = @"API URL";
+
+    UITextField *apiURLTextField = [UITextField new];
+    apiURLTextField.borderStyle = UITextBorderStyleRoundedRect;
+    apiURLTextField.placeholder = kDefaultCaptureURLString;
+    apiURLTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+    apiURLTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    apiURLTextField.keyboardType = UIKeyboardTypeURL;
+    apiURLTextField.returnKeyType = UIReturnKeyDone;
+    apiURLTextField.delegate = self;
+    apiURLTextField.text = [self savedAPIURLString];
+
+    UIButton *saveButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    saveButton.backgroundColor = UIColor.systemBlueColor;
+    saveButton.tintColor = UIColor.whiteColor;
+    [saveButton setTitle:@"Save Config" forState:UIControlStateNormal];
+    [saveButton addTarget:self action:@selector(saveConfiguration) forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *configurationView = [[UIStackView alloc]
+                                      initWithArrangedSubviews:@[apiKeyLabel, apiKeyTextField, apiURLLabel, apiURLTextField, saveButton]];
+    configurationView.axis = UILayoutConstraintAxisVertical;
+    configurationView.spacing = 8;
+
+    self.apiKeyTextField = apiKeyTextField;
+    self.apiURLTextField = apiURLTextField;
+
+    return configurationView;
+}
 
 - (UIView *)createSendLogView {
     UIButton *sendLogButton = [UIButton buttonWithType:UIButtonTypeSystem];
@@ -131,6 +253,32 @@ NSString *logLevelToString(LogLevel level) {
     self.pickLogLevelButton = pickLogLevelButton;
 
     return sendLogRow;
+}
+
+- (UIView *)createCrashView {
+    UIButton *crashButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    crashButton.backgroundColor = UIColor.systemRedColor;
+    crashButton.tintColor = UIColor.whiteColor;
+    [crashButton setTitle:@"Trigger Controlled Crash"
+                 forState:UIControlStateNormal];
+    [crashButton addTarget:self
+                    action:@selector(triggerControlledCrash)
+          forControlEvents:UIControlEventTouchUpInside];
+
+    return crashButton;
+}
+
+- (UIView *)createCopySessionURLView {
+    UIButton *copySessionURLButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    copySessionURLButton.backgroundColor = UIColor.systemGreenColor;
+    copySessionURLButton.tintColor = UIColor.whiteColor;
+    [copySessionURLButton setTitle:@"Copy Session URL"
+                          forState:UIControlStateNormal];
+    [copySessionURLButton addTarget:self
+                             action:@selector(copySessionURL)
+                   forControlEvents:UIControlEventTouchUpInside];
+
+    return copySessionURLButton;
 }
 
 - (UIView *)createCopySessionIDView {
@@ -199,8 +347,43 @@ NSString *logLevelToString(LogLevel level) {
     [self presentViewController:alert animated:YES completion:nil];
 }
 
+- (void)saveConfiguration {
+    [self.view endEditing:YES];
+
+    NSString *apiKey = self.apiKeyTextField.text.length > 0 ? self.apiKeyTextField.text : kDefaultCaptureAPIKey;
+    NSString *apiURLString = self.apiURLTextField.text.length > 0 ? self.apiURLTextField.text : kDefaultCaptureURLString;
+
+    [[NSUserDefaults standardUserDefaults] setObject:apiKey forKey:kSavedCaptureAPIKeyKey];
+    [[NSUserDefaults standardUserDefaults] setObject:apiURLString forKey:kSavedCaptureURLKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+
+     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Saved"
+                                                                    message:@"Restart the app to apply the new settings."
+                                                             preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)triggerControlledCrash {
+    [CAPLogger logInfo:@"About to trigger controlled crash" fields:nil];
+    NSArray<NSNumber *> *items = @[@1, @2, @3];
+    NSLog(@"About to access out-of-bounds item: %@", items[3]);
+}
+
+- (void)copySessionURL {
+    NSString *sessionURL = [[CAPLogger class] sessionURL];
+    if (sessionURL.length > 0) {
+        UIPasteboard.generalPasteboard.string = sessionURL;
+    }
+}
+
 - (void)copySessionIDRow {
     UIPasteboard.generalPasteboard.string = [[CAPLogger class] sessionID];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    [textField resignFirstResponder];
+    return YES;
 }
 
 @end

--- a/examples/objective-c/CAPViewController.m
+++ b/examples/objective-c/CAPViewController.m
@@ -154,7 +154,7 @@ NSString *logLevelToString(LogLevel level) {
                                                                  issueCallbackConfiguration:issueCallbackConfiguration];
     [CAPLogger
      startWithAPIKey:[self savedAPIKey]
-     sessionStrategy:[CAPSessionStrategy fixed]
+     sessionStrategy:[CAPSessionStrategy activityBased]
       configuration: config
     ];
 

--- a/examples/objective-c/CAPViewController.m
+++ b/examples/objective-c/CAPViewController.m
@@ -355,7 +355,6 @@ NSString *logLevelToString(LogLevel level) {
 
     [[NSUserDefaults standardUserDefaults] setObject:apiKey forKey:kSavedCaptureAPIKeyKey];
     [[NSUserDefaults standardUserDefaults] setObject:apiURLString forKey:kSavedCaptureURLKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 
      UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Saved"
                                                                     message:@"Restart the app to apply the new settings."

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -264,19 +264,11 @@ public final class Logger {
                     // hasFatallyTerminatedOnPreviousRun may already be set if configure() succeeded
                 }
 
-                if Logger.hasFatallyTerminatedOnPreviousRun == true {
-                    _ = try? BitdriftKSCrashWrapper.createPreviousRunIssueReport(
-                        withOutputDir: Logger.reportCollectionDirectory(base: directoryURL),
-                        sdkVersion: capture_get_sdk_version()
-                    )
-                    self.underlyingLogger.processIssueReports(reportProcessingSession: .previousRun)
-                }
-
                 let hangDuration = self.underlyingLogger.runtimeValue(.applicationANRReporterThresholdMs)
                 let reporter = DiagnosticEventReporter(
                     outputDir: Logger.reportCollectionDirectory(base: directoryURL),
                     sdkVersion: capture_get_sdk_version(),
-                    eventTypes: .hang,
+                    eventTypes: [.crash, .hang],
                     minimumHangSeconds: Double(hangDuration) / Double(MSEC_PER_SEC)) { [weak self] in
                     self?.underlyingLogger.processIssueReports(reportProcessingSession: .previousRun)
                 }

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -264,11 +264,19 @@ public final class Logger {
                     // hasFatallyTerminatedOnPreviousRun may already be set if configure() succeeded
                 }
 
+                if Logger.hasFatallyTerminatedOnPreviousRun == true {
+                    _ = try? BitdriftKSCrashWrapper.createPreviousRunIssueReport(
+                        withOutputDir: Logger.reportCollectionDirectory(base: directoryURL),
+                        sdkVersion: capture_get_sdk_version()
+                    )
+                    self.underlyingLogger.processIssueReports(reportProcessingSession: .previousRun)
+                }
+
                 let hangDuration = self.underlyingLogger.runtimeValue(.applicationANRReporterThresholdMs)
                 let reporter = DiagnosticEventReporter(
                     outputDir: Logger.reportCollectionDirectory(base: directoryURL),
                     sdkVersion: capture_get_sdk_version(),
-                    eventTypes: .crash,
+                    eventTypes: .hang,
                     minimumHangSeconds: Double(hangDuration) / Double(MSEC_PER_SEC)) { [weak self] in
                     self?.underlyingLogger.processIssueReports(reportProcessingSession: .previousRun)
                 }

--- a/platform/swift/source/LoggerObjc.swift
+++ b/platform/swift/source/LoggerObjc.swift
@@ -13,6 +13,7 @@ import Foundation
 public final class CAPConfiguration: NSObject {
     let underlyingConfig: Configuration
     public let enableURLSessionIntegration: Bool
+    public let issueCallbackConfiguration: IssueCallbackConfiguration?
 
     /// Initializes a new instance of the Capture configuration.
     ///
@@ -22,6 +23,7 @@ public final class CAPConfiguration: NSObject {
     public init(enableFatalIssueReporting: Bool, enableURLSessionIntegration: Bool) {
         self.underlyingConfig = Configuration(enableFatalIssueReporting: enableFatalIssueReporting)
         self.enableURLSessionIntegration = enableURLSessionIntegration
+        self.issueCallbackConfiguration = nil
     }
 
     /// Initializes a new instance of the Capture configuration.
@@ -41,6 +43,7 @@ public final class CAPConfiguration: NSObject {
         self.underlyingConfig = Configuration(sleepMode: sleepMode, enableFatalIssueReporting: enableFatalIssueReporting,
                                               apiURL: apiURL ?? URL(string: "https://api.bitdrift.io")!, rootFileURL: rootFileURL)
         self.enableURLSessionIntegration = enableURLSessionIntegration
+        self.issueCallbackConfiguration = nil
     }
 
     /// Initializes a new instance of the Capture configuration.
@@ -52,6 +55,21 @@ public final class CAPConfiguration: NSObject {
     public init(enableFatalIssueReporting: Bool, enableURLSessionIntegration: Bool, sleepMode: SleepMode) {
         self.underlyingConfig = Configuration(sleepMode: sleepMode, enableFatalIssueReporting: enableFatalIssueReporting)
         self.enableURLSessionIntegration = enableURLSessionIntegration
+        self.issueCallbackConfiguration = nil
+    }
+
+    @objc
+    public init(enableFatalIssueReporting: Bool, enableURLSessionIntegration: Bool,
+                sleepMode: SleepMode, apiURL: URL?, rootFileURL: URL?,
+                issueCallbackConfiguration: IssueCallbackConfiguration?)
+    {
+        self.underlyingConfig = Configuration(sleepMode: sleepMode,
+                                              enableFatalIssueReporting: enableFatalIssueReporting,
+                                              apiURL: apiURL ?? URL(string: "https://api.bitdrift.io")!,
+                                              rootFileURL: rootFileURL,
+                                              issueCallbackConfiguration: issueCallbackConfiguration)
+        self.enableURLSessionIntegration = enableURLSessionIntegration
+        self.issueCallbackConfiguration = issueCallbackConfiguration
     }
 }
 

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSDate *_Nullable)cachedCrashDate;
 
++ (NSString *_Nullable)cachedCrashEventID;
+
 + (void)stopCrashReporter;
 
 @end

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
@@ -52,9 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSNumber *_Nullable)didCrashLastLaunch;
 
-+ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir
-                                       sdkVersion:(NSString *)sdkVersion
-                                           error:(NSError **)error;
++ (NSDate *_Nullable)cachedCrashDate;
 
 + (void)stopCrashReporter;
 

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
@@ -52,6 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSNumber *_Nullable)didCrashLastLaunch;
 
++ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir
+                                       sdkVersion:(NSString *)sdkVersion
+                                           error:(NSError **)error;
+
 + (void)stopCrashReporter;
 
 @end

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
@@ -40,11 +40,11 @@ typedef enum {
     CacheResultSuccess = 3
 } CacheResult;
 
-typedef enum {
-    ReportCreationResultFailure = 0,
-    ReportCreationResultReportDoesNotExist = 1,
-    ReportCreationResultSuccess = 2,
-} ReportCreationResult;
+typedef struct {
+    uint64_t seconds;
+    uint32_t nanoseconds;
+    bool found;
+} CachedCrashTimestamp;
 
 /** Cache a KSCrash report, which will be used later for report enhancement. */
 CacheResult capture_cache_kscrash_report(NSString *reportPath);
@@ -52,8 +52,8 @@ CacheResult capture_cache_kscrash_report(NSString *reportPath);
 /** Enhance a MetricKit report using the cached KSCrash report. */
 NSDictionary *_Nullable capture_enhance_metrickit_diagnostic_report(const NSDictionary *_Nullable report);
 
-/** Create a capture report directly from the cached KSCrash report. */
-ReportCreationResult capture_create_report_from_cached_kscrash_report(NSString *reportPath, NSString *sdkVersion);
+/** Get the cached KSCrash crash timestamp for the most recent previous-run crash. */
+CachedCrashTimestamp capture_cached_kscrash_timestamp(void);
 
 #pragma mark Crash Handling
 
@@ -230,33 +230,13 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
     return capture_enhance_metrickit_diagnostic_report(metricKitReport);
 }
 
-+ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir sdkVersion:(NSString *)sdkVersion error:(NSError **)error {
-    return [self.sharedInstance createPreviousRunIssueReportWithOutputDir:outputDir sdkVersion:sdkVersion error:error];
-}
-
-- (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir sdkVersion:(NSString *)sdkVersion error:(NSError **)error {
-    if (self.kscrashReportFilePath == nil || self.didCrashLastLaunch.boolValue != YES) {
-        return NO;
++ (NSDate *_Nullable)cachedCrashDate {
+    CachedCrashTimestamp timestamp = capture_cached_kscrash_timestamp();
+    if (!timestamp.found) {
+        return nil;
     }
-
-    NSString *identifier = [[NSUUID UUID] UUIDString];
-    NSString *filename = [NSString stringWithFormat:@"kscrash_previous_run_crash_%@.cap", identifier];
-    NSString *path = [[outputDir URLByAppendingPathComponent:filename] path];
-
-    switch (capture_create_report_from_cached_kscrash_report(path, sdkVersion)) {
-        case ReportCreationResultSuccess:
-            return YES;
-        case ReportCreationResultReportDoesNotExist:
-            return NO;
-        case ReportCreationResultFailure:
-            if (error != nil) {
-                *error = [NSError errorWithDomain:@"BitdriftKSCrashHandler" code:0 userInfo:@{
-                    NSLocalizedDescriptionKey: @"Failed to create previous run issue report",
-                    NSLocalizedFailureReasonErrorKey: @"Unable to serialize cached KSCrash report",
-                }];
-            }
-            return NO;
-    }
+    NSTimeInterval interval = (NSTimeInterval)timestamp.seconds + ((NSTimeInterval)timestamp.nanoseconds / NSEC_PER_SEC);
+    return [NSDate dateWithTimeIntervalSince1970:interval];
 }
 
 @end

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
@@ -18,6 +18,7 @@
 #import "ReportContext.h"
 
 #import <stdatomic.h>
+#import <time.h>
 #import <string.h>
 #import <sys/sysctl.h>
 #import <sys/utsname.h>
@@ -39,11 +40,20 @@ typedef enum {
     CacheResultSuccess = 3
 } CacheResult;
 
+typedef enum {
+    ReportCreationResultFailure = 0,
+    ReportCreationResultReportDoesNotExist = 1,
+    ReportCreationResultSuccess = 2,
+} ReportCreationResult;
+
 /** Cache a KSCrash report, which will be used later for report enhancement. */
 CacheResult capture_cache_kscrash_report(NSString *reportPath);
 
 /** Enhance a MetricKit report using the cached KSCrash report. */
 NSDictionary *_Nullable capture_enhance_metrickit_diagnostic_report(const NSDictionary *_Nullable report);
+
+/** Create a capture report directly from the cached KSCrash report. */
+ReportCreationResult capture_create_report_from_cached_kscrash_report(NSString *reportPath, NSString *sdkVersion);
 
 #pragma mark Crash Handling
 
@@ -57,7 +67,10 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
         return;
     }
 
-    g_crashHandlerReportContext.metadata.time = time(NULL);
+    struct timespec crashTime;
+    clock_gettime(CLOCK_REALTIME, &crashTime);
+    g_crashHandlerReportContext.metadata.time = crashTime.tv_sec;
+    g_crashHandlerReportContext.metadata.timeNanos = (uint32_t)crashTime.tv_nsec;
     g_crashHandlerReportContext.monitorContext = monitorContext;
     bitdrift_writeKSCrashReport(&g_crashHandlerReportContext);
 }
@@ -66,6 +79,7 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
 
 @interface BitdriftKSCrashHandler ()
 @property(nonatomic, strong) NSString *kscrashReportFilePath;
+@property(nonatomic, strong) NSString *reportCollectionDirectoryPath;
 @property(nullable, nonatomic, strong) NSNumber *didCrashLastLaunch;
 @property(class, nonatomic, readonly, strong) BitdriftKSCrashHandler *sharedInstance;
 @end
@@ -108,6 +122,7 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
     }
 
     self.kscrashReportFilePath = crashReportFile;
+    self.reportCollectionDirectoryPath = [crashReportDir.absoluteURL.path stringByDeletingLastPathComponent];
 
     BOOL result = YES;
 
@@ -213,6 +228,35 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
     }
 
     return capture_enhance_metrickit_diagnostic_report(metricKitReport);
+}
+
++ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir sdkVersion:(NSString *)sdkVersion error:(NSError **)error {
+    return [self.sharedInstance createPreviousRunIssueReportWithOutputDir:outputDir sdkVersion:sdkVersion error:error];
+}
+
+- (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir sdkVersion:(NSString *)sdkVersion error:(NSError **)error {
+    if (self.kscrashReportFilePath == nil || self.didCrashLastLaunch.boolValue != YES) {
+        return NO;
+    }
+
+    NSString *identifier = [[NSUUID UUID] UUIDString];
+    NSString *filename = [NSString stringWithFormat:@"kscrash_previous_run_crash_%@.cap", identifier];
+    NSString *path = [[outputDir URLByAppendingPathComponent:filename] path];
+
+    switch (capture_create_report_from_cached_kscrash_report(path, sdkVersion)) {
+        case ReportCreationResultSuccess:
+            return YES;
+        case ReportCreationResultReportDoesNotExist:
+            return NO;
+        case ReportCreationResultFailure:
+            if (error != nil) {
+                *error = [NSError errorWithDomain:@"BitdriftKSCrashHandler" code:0 userInfo:@{
+                    NSLocalizedDescriptionKey: @"Failed to create previous run issue report",
+                    NSLocalizedFailureReasonErrorKey: @"Unable to serialize cached KSCrash report",
+                }];
+            }
+            return NO;
+    }
 }
 
 @end

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
@@ -46,6 +46,12 @@ typedef struct {
     bool found;
 } CachedCrashTimestamp;
 
+typedef enum {
+    CachedCrashEventIdResultFailure = 0,
+    CachedCrashEventIdResultEventDoesNotExist = 1,
+    CachedCrashEventIdResultSuccess = 2,
+} CachedCrashEventIdResult;
+
 /** Cache a KSCrash report, which will be used later for report enhancement. */
 CacheResult capture_cache_kscrash_report(NSString *reportPath);
 
@@ -54,6 +60,9 @@ NSDictionary *_Nullable capture_enhance_metrickit_diagnostic_report(const NSDict
 
 /** Get the cached KSCrash crash timestamp for the most recent previous-run crash. */
 CachedCrashTimestamp capture_cached_kscrash_timestamp(void);
+
+/** Get the cached KSCrash event identifier for the most recent previous-run crash. */
+CachedCrashEventIdResult capture_cached_kscrash_event_id(NSString * _Nullable * _Nonnull eventID);
 
 #pragma mark Crash Handling
 
@@ -237,6 +246,14 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
     }
     NSTimeInterval interval = (NSTimeInterval)timestamp.seconds + ((NSTimeInterval)timestamp.nanoseconds / NSEC_PER_SEC);
     return [NSDate dateWithTimeIntervalSince1970:interval];
+}
+
++ (NSString *_Nullable)cachedCrashEventID {
+    NSString *eventID = nil;
+    if (capture_cached_kscrash_event_id(&eventID) != CachedCrashEventIdResultSuccess) {
+        return nil;
+    }
+    return eventID;
 }
 
 @end

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
@@ -131,7 +131,6 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
     }
 
     self.kscrashReportFilePath = crashReportFile;
-    self.reportCollectionDirectoryPath = [crashReportDir.absoluteURL.path stringByDeletingLastPathComponent];
 
     BOOL result = YES;
 

--- a/platform/swift/source/crash_handler/ReportContext.h
+++ b/platform/swift/source/crash_handler/ReportContext.h
@@ -21,6 +21,7 @@ extern "C" {
 typedef struct {
     pid_t pid;
     time_t time;
+    uint32_t timeNanos;
 } ReportMetadata;
 
 typedef struct {

--- a/platform/swift/source/crash_handler/ReportWriter.c
+++ b/platform/swift/source/crash_handler/ReportWriter.c
@@ -159,10 +159,67 @@ static bool writeAllThreads(BDCrashWriterHandle writer, const ReportContext* ctx
 
 static bool writeMetadata(BDCrashWriterHandle writer, const ReportContext* ctx) {
     RETURN_ON_FAIL(writeKVUnsigned(writer, "crashedAt", ctx->metadata.time));
+    RETURN_ON_FAIL(writeKVUnsigned(writer, "crashedAtNanos", ctx->metadata.timeNanos));
     RETURN_ON_FAIL(writeKVUnsigned(writer, "pid", ctx->metadata.pid));
     RETURN_ON_FAIL(writeKVUnsigned(writer, "exceptionType", ctx->monitorContext->mach.type));
     RETURN_ON_FAIL(writeKVUnsigned(writer, "exceptionCode", ctx->monitorContext->mach.code));
     RETURN_ON_FAIL(writeKVUnsigned(writer, "signal", ctx->monitorContext->signal.signum));
+    if (ctx->monitorContext->eventID != NULL) {
+        RETURN_ON_FAIL(writeKVString(writer, "eventID", ctx->monitorContext->eventID));
+    }
+    return true;
+}
+
+static bool writeErrorInfo(BDCrashWriterHandle writer, const ReportContext* ctx) {
+    RETURN_ON_FAIL(writeKVObjectBegin(writer, "error"));
+    {
+        if (ctx->monitorContext->exceptionName != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "exceptionName", ctx->monitorContext->exceptionName));
+        }
+        if (ctx->monitorContext->crashReason != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "crashReason", ctx->monitorContext->crashReason));
+        }
+        if (ctx->monitorContext->monitorId != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "monitorId", ctx->monitorContext->monitorId));
+        }
+        RETURN_ON_FAIL(writeKVBoolean(writer, "stackOverflow", ctx->monitorContext->isStackOverflow));
+    }
+    RETURN_ON_FAIL(bdcrw_write_container_end(writer));
+    return true;
+}
+
+static bool writeSystemInfo(BDCrashWriterHandle writer, const ReportContext* ctx) {
+    RETURN_ON_FAIL(writeKVObjectBegin(writer, "system"));
+    {
+        if (ctx->monitorContext->System.bundleID != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "bundleID", ctx->monitorContext->System.bundleID));
+        }
+        if (ctx->monitorContext->System.bundleShortVersion != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "bundleShortVersion", ctx->monitorContext->System.bundleShortVersion));
+        }
+        if (ctx->monitorContext->System.bundleVersion != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "bundleVersion", ctx->monitorContext->System.bundleVersion));
+        }
+        if (ctx->monitorContext->System.osVersion != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "osVersion", ctx->monitorContext->System.osVersion));
+        }
+        if (ctx->monitorContext->System.systemName != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "systemName", ctx->monitorContext->System.systemName));
+        }
+        if (ctx->monitorContext->System.kernelVersion != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "kernelVersion", ctx->monitorContext->System.kernelVersion));
+        }
+        if (ctx->monitorContext->System.model != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "model", ctx->monitorContext->System.model));
+        }
+        if (ctx->monitorContext->System.binaryArchitecture != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "binaryArchitecture", ctx->monitorContext->System.binaryArchitecture));
+        }
+        if (ctx->monitorContext->System.timezone != NULL) {
+            RETURN_ON_FAIL(writeKVString(writer, "timezone", ctx->monitorContext->System.timezone));
+        }
+    }
+    RETURN_ON_FAIL(bdcrw_write_container_end(writer));
     return true;
 }
 
@@ -174,6 +231,10 @@ static bool writeReport(BDCrashWriterHandle writer, ReportContext* ctx) {
             RETURN_ON_FAIL(writeMetadata(writer, ctx));
         }
         RETURN_ON_FAIL(bdcrw_write_container_end(writer));
+
+        RETURN_ON_FAIL(writeErrorInfo(writer, ctx));
+
+        RETURN_ON_FAIL(writeSystemInfo(writer, ctx));
 
         RETURN_ON_FAIL(writeKVArrayBegin(writer, "threads"));
         {

--- a/platform/swift/source/crash_handler/ReportWriter.c
+++ b/platform/swift/source/crash_handler/ReportWriter.c
@@ -8,6 +8,7 @@
 #include "ReportWriter.h"
 
 #include "KSCrashMonitorContext.h"
+#include "KSBinaryImageCache.h"
 #include "KSMachineContext.h"
 #include "KSLogger.h"
 #include "KSStackCursor.h"
@@ -72,6 +73,45 @@ static bool writeKVUUID(BDCrashWriterHandle writer, const char *key, const uint8
     *p = '\0';
     
     return writeKVString(writer, key, uuid);
+}
+
+static bool writeBinaryImage(BDCrashWriterHandle writer, const ks_dyld_image_info *info) {
+    if (info == NULL || info->imageFilePath == NULL || info->imageLoadAddress == NULL) {
+        return true;
+    }
+
+    KSBinaryImage image = {0};
+    if (!ksdl_binaryImageForHeader(info->imageLoadAddress, info->imageFilePath, &image)) {
+        return true;
+    }
+
+    RETURN_ON_FAIL(bdcrw_write_map_begin(writer));
+    {
+        RETURN_ON_FAIL(writeKVString(writer, "name", info->imageFilePath));
+        RETURN_ON_FAIL(writeKVUnsigned(writer, "loadAddress", (uintptr_t)info->imageLoadAddress));
+        if (image.uuid != NULL) {
+            RETURN_ON_FAIL(writeKVUUID(writer, "uuid", image.uuid));
+        }
+    }
+    RETURN_ON_FAIL(bdcrw_write_container_end(writer));
+    return true;
+}
+
+static bool writeBinaryImages(BDCrashWriterHandle writer) {
+    uint32_t imageCount = 0;
+    const ks_dyld_image_info *images = ksbic_getImages(&imageCount);
+    if (images == NULL || imageCount == 0) {
+        return true;
+    }
+
+    RETURN_ON_FAIL(writeKVArrayBegin(writer, "binaryImages"));
+    {
+        for (uint32_t i = 0; i < imageCount; i++) {
+            RETURN_ON_FAIL(writeBinaryImage(writer, &images[i]));
+        }
+    }
+    RETURN_ON_FAIL(bdcrw_write_container_end(writer));
+    return true;
 }
 
 static bool writeBacktrace(BDCrashWriterHandle writer, const char *const key, KSStackCursor *stackCursor) {
@@ -164,7 +204,7 @@ static bool writeMetadata(BDCrashWriterHandle writer, const ReportContext* ctx) 
     RETURN_ON_FAIL(writeKVUnsigned(writer, "exceptionType", ctx->monitorContext->mach.type));
     RETURN_ON_FAIL(writeKVUnsigned(writer, "exceptionCode", ctx->monitorContext->mach.code));
     RETURN_ON_FAIL(writeKVUnsigned(writer, "signal", ctx->monitorContext->signal.signum));
-    if (ctx->monitorContext->eventID != NULL) {
+    if (ctx->monitorContext->eventID[0] != '\0') {
         RETURN_ON_FAIL(writeKVString(writer, "eventID", ctx->monitorContext->eventID));
     }
     return true;
@@ -235,6 +275,8 @@ static bool writeReport(BDCrashWriterHandle writer, ReportContext* ctx) {
         RETURN_ON_FAIL(writeErrorInfo(writer, ctx));
 
         RETURN_ON_FAIL(writeSystemInfo(writer, ctx));
+
+        RETURN_ON_FAIL(writeBinaryImages(writer));
 
         RETURN_ON_FAIL(writeKVArrayBegin(writer, "threads"));
         {

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.h
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSDate *_Nullable)cachedCrashDate;
 
++ (NSString *_Nullable)cachedCrashEventID;
+
 + (void)stopCrashReporter;
 
 @end

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.h
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.h
@@ -52,9 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSNumber *_Nullable)didCrashLastLaunch;
 
-+ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir
-                                       sdkVersion:(NSString *)sdkVersion
-                                           error:(NSError **)error;
++ (NSDate *_Nullable)cachedCrashDate;
 
 + (void)stopCrashReporter;
 

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.h
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.h
@@ -52,6 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSNumber *_Nullable)didCrashLastLaunch;
 
++ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir
+                                       sdkVersion:(NSString *)sdkVersion
+                                           error:(NSError **)error;
+
 + (void)stopCrashReporter;
 
 @end

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.m
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.m
@@ -47,6 +47,16 @@
 #endif
 }
 
++ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir
+                                       sdkVersion:(NSString *)sdkVersion
+                                           error:(NSError **)error {
+#ifndef BITDRIFT_OMIT_KSCRASH
+    return [BitdriftKSCrashHandler createPreviousRunIssueReportWithOutputDir:outputDir sdkVersion:sdkVersion error:error];
+#else
+    return false;
+#endif
+}
+
 + (void)stopCrashReporter {
 #ifndef BITDRIFT_OMIT_KSCRASH
     [BitdriftKSCrashHandler stopCrashReporter];

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.m
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.m
@@ -47,13 +47,11 @@
 #endif
 }
 
-+ (BOOL)createPreviousRunIssueReportWithOutputDir:(NSURL *)outputDir
-                                       sdkVersion:(NSString *)sdkVersion
-                                           error:(NSError **)error {
++ (NSDate *_Nullable)cachedCrashDate {
 #ifndef BITDRIFT_OMIT_KSCRASH
-    return [BitdriftKSCrashHandler createPreviousRunIssueReportWithOutputDir:outputDir sdkVersion:sdkVersion error:error];
+    return [BitdriftKSCrashHandler cachedCrashDate];
 #else
-    return false;
+    return nil;
 #endif
 }
 

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.m
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.m
@@ -55,6 +55,14 @@
 #endif
 }
 
++ (NSString *_Nullable)cachedCrashEventID {
+#ifndef BITDRIFT_OMIT_KSCRASH
+    return [BitdriftKSCrashHandler cachedCrashEventID];
+#else
+    return nil;
+#endif
+}
+
 + (void)stopCrashReporter {
 #ifndef BITDRIFT_OMIT_KSCRASH
     [BitdriftKSCrashHandler stopCrashReporter];

--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -84,9 +84,12 @@ static const char *name_for_diagnostic_type(ReportType type);
   }
 
   for (MXDiagnosticPayload *payload in payloads) {
-    NSTimeInterval timestamp = [payload.timeStampEnd timeIntervalSince1970];
     if ((self.diagnosticTypes & CAPDiagnosticTypeCrash) > 0) {
       for (MXCrashDiagnostic *event in payload.crashDiagnostics) {
+        NSDate *cachedCrashDate = [BitdriftKSCrashWrapper cachedCrashDate];
+        NSTimeInterval timestamp = cachedCrashDate != nil
+          ? cachedCrashDate.timeIntervalSince1970
+          : [payload.timeStampEnd timeIntervalSince1970];
         [self processDiagnostic:event atTimestamp:timestamp];
       }
     }
@@ -97,6 +100,7 @@ static const char *name_for_diagnostic_type(ReportType type);
         if ([duration measurementBySubtractingMeasurement:self.minimumHangDuration].doubleValue < 0) {
           continue;
         }
+        NSTimeInterval timestamp = [payload.timeStampEnd timeIntervalSince1970];
         [self processDiagnostic:event atTimestamp:timestamp];
       }
     }

--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -88,8 +88,8 @@ static const char *name_for_diagnostic_type(ReportType type);
 
   for (MXDiagnosticPayload *payload in payloads) {
     if ((self.diagnosticTypes & CAPDiagnosticTypeCrash) > 0) {
+      NSDate *cachedCrashDate = payload.crashDiagnostics.count == 1 ? [BitdriftKSCrashWrapper cachedCrashDate] : nil;
       for (MXCrashDiagnostic *event in payload.crashDiagnostics) {
-        NSDate *cachedCrashDate = [BitdriftKSCrashWrapper cachedCrashDate];
         NSTimeInterval timestamp = cachedCrashDate != nil
           ? cachedCrashDate.timeIntervalSince1970
           : [payload.timeStampEnd timeIntervalSince1970];

--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -29,6 +29,7 @@ static NSString *const OS_VERSION_MATCHER = @"^(?<osName>.*)\\s+(?<osVersion>\\d
 static NSString *const DEFAULT_HANG_NAME = @"App Hang";
 // SDK identifier used in generated files
 static const char *const SDK_ID = "io.bitdrift.capture-apple";
+static NSString *const PREVIOUS_RUN_CRASH_MARKER_PREFIX = @"previous_run_crash_";
 
 /**
  * Create a buffer containing a serialized diagnostic
@@ -45,6 +46,8 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle,
                                        MXDiagnostic *_Nonnull event,
                                        NSTimeInterval timestamp)
                                        API_AVAILABLE(ios(14.0), macos(12.0));
+
+static NSString *dedupe_marker_filename(NSString *eventID);
 
 static const char *name_for_diagnostic_type(ReportType type);
 
@@ -111,6 +114,16 @@ static const char *name_for_diagnostic_type(ReportType type);
 }
 
 - (void)processDiagnostic:(MXDiagnostic *)event atTimestamp:(NSTimeInterval)timestamp {
+  if ([event isKindOfClass:[MXCrashDiagnostic class]]) {
+    NSString *eventID = [BitdriftKSCrashWrapper cachedCrashEventID];
+    if (eventID.length > 0) {
+      NSString *markerPath = [[self.dir URLByAppendingPathComponent:dedupe_marker_filename(eventID)] path];
+      if ([[NSFileManager defaultManager] fileExistsAtPath:markerPath]) {
+        return;
+      }
+    }
+  }
+
   const void *handle = 0;
   ReportType report_type = serialize_diagnostic(&handle, self.sdkVersion, event, timestamp);
   if (report_type != ReportTypeNone && handle != 0) {
@@ -121,10 +134,23 @@ static const char *name_for_diagnostic_type(ReportType type);
     NSString *filename = [NSString stringWithFormat:@"%Lf_%s_%@.cap", truncl(timestamp), name_for_diagnostic_type(report_type), identifier];
     NSString *path = [[self.dir URLByAppendingPathComponent:filename] path];
     [[NSFileManager defaultManager] createFileAtPath:path contents:data attributes:0];
+
+    if ([event isKindOfClass:[MXCrashDiagnostic class]]) {
+      NSString *eventID = [BitdriftKSCrashWrapper cachedCrashEventID];
+      if (eventID.length > 0) {
+        NSString *markerPath = [[self.dir URLByAppendingPathComponent:dedupe_marker_filename(eventID)] path];
+        [[NSFileManager defaultManager] createFileAtPath:markerPath contents:[NSData data] attributes:0];
+      }
+    }
+
     bdrw_dispose_buffer_handle(&handle);
   }
 }
 @end
+
+static NSString *dedupe_marker_filename(NSString *eventID) {
+  return [NSString stringWithFormat:@"%@%@", PREVIOUS_RUN_CRASH_MARKER_PREFIX, eventID];
+}
 
 static NSString *name_for_signal(NSNumber *signal);
 static NSString *name_for_crash(MXCrashDiagnostic *event) API_AVAILABLE(ios(14.0), macos(12.0));

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -524,6 +524,10 @@ fn call_stacks_match(call_stack_a: &[u64], call_stack_b: &[u64]) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::ffi::nsstring_into_string;
+  use ahash::AHashMap;
+  use bd_bonjson::Value;
+  use objc::runtime::Object;
   use std::io::Write;
 
   #[test]
@@ -556,5 +560,95 @@ mod tests {
     report.write("\0\0\0".as_bytes()).unwrap();
     let report_path = report.path().to_str().unwrap().to_string();
     assert!(parse_cached_report(report_path).is_err());
+  }
+
+  #[test]
+  fn cached_crash_timestamp_with_nanos_test() {
+    let mut diagnostic_meta = AHashMap::new();
+    diagnostic_meta.insert("crashedAt".to_string(), Value::Unsigned(1_234_567_890));
+    diagnostic_meta.insert("crashedAtNanos".to_string(), Value::Unsigned(500_000_000));
+
+    let mut report = AHashMap::new();
+    report.insert(
+      "diagnosticMetaData".to_string(),
+      Value::Object(diagnostic_meta),
+    );
+
+    *CACHED_KSCRASH_REPORT.lock() = Some(report);
+
+    assert_eq!(
+      cached_kscrash_timestamp_impl().unwrap(),
+      CachedCrashTimestamp {
+        seconds: 1_234_567_890,
+        nanoseconds: 500_000_000,
+        found: true,
+      }
+    );
+  }
+
+  #[test]
+  fn cached_crash_timestamp_without_nanos_test() {
+    let mut diagnostic_meta = AHashMap::new();
+    diagnostic_meta.insert("crashedAt".to_string(), Value::Unsigned(1_234_567_890));
+
+    let mut report = AHashMap::new();
+    report.insert(
+      "diagnosticMetaData".to_string(),
+      Value::Object(diagnostic_meta),
+    );
+
+    *CACHED_KSCRASH_REPORT.lock() = Some(report);
+
+    assert_eq!(
+      cached_kscrash_timestamp_impl().unwrap(),
+      CachedCrashTimestamp {
+        seconds: 1_234_567_890,
+        nanoseconds: 0,
+        found: true,
+      }
+    );
+  }
+
+  #[test]
+  fn cached_event_id_missing_test() {
+    let mut diagnostic_meta = AHashMap::new();
+    diagnostic_meta.insert("crashedAt".to_string(), Value::Unsigned(1_234_567_890));
+
+    let mut report = AHashMap::new();
+    report.insert(
+      "diagnosticMetaData".to_string(),
+      Value::Object(diagnostic_meta),
+    );
+
+    *CACHED_KSCRASH_REPORT.lock() = Some(report);
+
+    let mut event_id_ptr: *const Object = std::ptr::null();
+    let result = cached_kscrash_event_id_impl(&mut event_id_ptr).unwrap();
+    assert_eq!(result, CachedCrashEventIdResult::EventDoesNotExist);
+    assert!(event_id_ptr.is_null());
+  }
+
+  #[test]
+  fn cached_event_id_present_test() {
+    let mut diagnostic_meta = AHashMap::new();
+    diagnostic_meta.insert(
+      "eventID".to_string(),
+      Value::String("test-event-id-123".to_string()),
+    );
+
+    let mut report = AHashMap::new();
+    report.insert(
+      "diagnosticMetaData".to_string(),
+      Value::Object(diagnostic_meta),
+    );
+
+    *CACHED_KSCRASH_REPORT.lock() = Some(report);
+
+    let mut event_id_ptr: *const Object = std::ptr::null();
+    let result = cached_kscrash_event_id_impl(&mut event_id_ptr).unwrap();
+    assert_eq!(result, CachedCrashEventIdResult::Success);
+    assert!(!event_id_ptr.is_null());
+    let event_id_str = unsafe { nsstring_into_string(event_id_ptr) }.unwrap();
+    assert_eq!(event_id_str, "test-event-id-123");
   }
 }

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -15,8 +15,12 @@ use bd_error_reporter::reporter::with_handle_unexpected_or;
 use objc::runtime::Object;
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::ffi::c_void;
+use std::ffi::CString;
 use std::fs;
 use std::path::Path;
+use std::ptr::null;
+use std::slice;
 
 struct NamedThread {
   name: String,
@@ -28,13 +32,136 @@ struct NamedThread {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheResult {
   /// The report was not cached due to an error
-  Failure            = 0,
+  Failure = 0,
   /// The report file does not exist
   ReportDoesNotExist = 1,
   /// Successfully cached a partial document
-  PartialSuccess     = 2,
+  PartialSuccess = 2,
   /// Successfully cached the complete document
-  Success            = 3,
+  Success = 3,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportCreationResult {
+  Failure = 0,
+  ReportDoesNotExist = 1,
+  Success = 2,
+}
+
+#[repr(i8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReportType {
+  NativeCrash = 5,
+}
+
+const SDK_ID: &str = "io.bitdrift.capture-apple";
+
+type BDProcessorHandle = *mut *const c_void;
+
+#[repr(C)]
+struct BDBinaryImage {
+  id: *const i8,
+  path: *const i8,
+  load_address: u64,
+}
+
+#[repr(C)]
+struct BDCPURegister {
+  name: *const i8,
+  value: u64,
+}
+
+#[repr(C)]
+struct BDStackFrame {
+  type_: i8,
+  frame_address: u64,
+  symbol_address: u64,
+  symbol_name: *const i8,
+  class_name: *const i8,
+  file_name: *const i8,
+  line: i64,
+  column: i64,
+  image_id: *const i8,
+  state_count: usize,
+  state: *const *const i8,
+  reg_count: usize,
+  regs: *const BDCPURegister,
+}
+
+#[repr(C)]
+struct BDThread {
+  name: *const i8,
+  state: *const i8,
+  active: bool,
+  index: u32,
+  priority: f32,
+  quality_of_service: i8,
+}
+
+#[repr(C)]
+struct BDDeviceMetrics {
+  time_seconds: u64,
+  time_nanos: u32,
+  timezone: *const i8,
+  manufacturer: *const i8,
+  model: *const i8,
+  os_version: *const i8,
+  os_brand: *const i8,
+  os_fingerprint: *const i8,
+  os_kernversion: *const i8,
+  power_state: i8,
+  power_charge_percent: u8,
+  network_state: i8,
+  architecture: i8,
+  display_height: u32,
+  display_width: u32,
+  display_density_dpi: u32,
+  platform: i8,
+  rotation: i8,
+  cpu_abi_count: u8,
+  cpu_abis: *const *const i8,
+}
+
+#[repr(C)]
+struct BDAppMetrics {
+  app_id: *const i8,
+  version: *const i8,
+  version_code: i64,
+  cf_bundle_version: *const i8,
+  running_state: *const i8,
+  memory_used: u64,
+  memory_free: u64,
+  memory_total: u64,
+}
+
+unsafe extern "C-unwind" {
+  fn bdrw_create_buffer_handle(
+    handle: BDProcessorHandle,
+    report_type: i8,
+    sdk_id: *const i8,
+    sdk_version: *const i8,
+  );
+  fn bdrw_get_completed_buffer(handle: BDProcessorHandle, buffer_length: *mut u64) -> *const u8;
+  fn bdrw_dispose_buffer_handle(handle: BDProcessorHandle);
+  fn bdrw_add_binary_image(handle: BDProcessorHandle, image: *const BDBinaryImage) -> bool;
+  fn bdrw_add_thread(
+    handle: BDProcessorHandle,
+    system_thread_count: u16,
+    thread_ptr: *const BDThread,
+    stack_count: u32,
+    stack: *const BDStackFrame,
+  ) -> bool;
+  fn bdrw_add_error(
+    handle: BDProcessorHandle,
+    name: *const i8,
+    reason: *const i8,
+    relation_to_next: i8,
+    stack_count: u32,
+    stack: *const BDStackFrame,
+  ) -> bool;
+  fn bdrw_add_device(handle: BDProcessorHandle, device_ptr: *const BDDeviceMetrics) -> bool;
+  fn bdrw_add_app(handle: BDProcessorHandle, app_ptr: *const BDAppMetrics) -> bool;
 }
 
 // Global cache for the most recently loaded KSCrash report.
@@ -65,6 +192,20 @@ extern "C" fn capture_enhance_metrickit_diagnostic_report(
     .unwrap_or(metrickit_report_ptr)
 }
 
+#[no_mangle]
+extern "C" fn capture_create_report_from_cached_kscrash_report(
+  report_path_ptr: *const Object,
+  sdk_version_ptr: *const Object,
+) -> ReportCreationResult {
+  with_handle_unexpected_or(
+    || -> anyhow::Result<ReportCreationResult> {
+      create_report_from_cached_kscrash_report_impl(report_path_ptr, sdk_version_ptr)
+    },
+    ReportCreationResult::Failure,
+    "create crash report from cached kscrash report",
+  )
+}
+
 // Implementation
 
 fn capture_cache_kscrash_report_impl(
@@ -73,6 +214,24 @@ fn capture_cache_kscrash_report_impl(
   let report_path = unsafe { nsstring_into_string(kscrash_report_path_ptr) }
     .map_err(|e| anyhow::anyhow!("Failed to convert KSCrash report path to string: {e}"))?;
   parse_cached_report(report_path)
+}
+
+fn create_report_from_cached_kscrash_report_impl(
+  report_path_ptr: *const Object,
+  sdk_version_ptr: *const Object,
+) -> anyhow::Result<ReportCreationResult> {
+  let report_path = unsafe { nsstring_into_string(report_path_ptr) }
+    .map_err(|e| anyhow::anyhow!("Failed to convert report path to string: {e}"))?;
+  let sdk_version = unsafe { nsstring_into_string(sdk_version_ptr) }
+    .map_err(|e| anyhow::anyhow!("Failed to convert sdk version to string: {e}"))?;
+
+  let Some(kscrash_report) = CACHED_KSCRASH_REPORT.lock().as_ref().cloned() else {
+    return Ok(ReportCreationResult::ReportDoesNotExist);
+  };
+
+  let bytes = build_report_bytes_from_kscrash_report(&kscrash_report, &sdk_version)?;
+  fs::write(report_path, bytes)?;
+  Ok(ReportCreationResult::Success)
 }
 
 fn parse_cached_report(report_path: String) -> anyhow::Result<CacheResult> {
@@ -111,13 +270,460 @@ fn parse_cached_report(report_path: String) -> anyhow::Result<CacheResult> {
 
   CACHED_KSCRASH_REPORT.lock().replace(hashmap);
 
-  Ok(
-    if was_partial {
-      CacheResult::PartialSuccess
-    } else {
-      CacheResult::Success
-    },
-  )
+  Ok(if was_partial {
+    CacheResult::PartialSuccess
+  } else {
+    CacheResult::Success
+  })
+}
+
+fn build_report_bytes_from_kscrash_report(
+  kscrash_report: &AHashMap<String, Value>,
+  sdk_version: &str,
+) -> anyhow::Result<Vec<u8>> {
+  let mut handle_ptr: *const std::ffi::c_void = null();
+  let handle: BDProcessorHandle = &mut handle_ptr;
+  let sdk_id = CString::new(SDK_ID)?;
+  let sdk_version = CString::new(sdk_version)?;
+
+  unsafe {
+    bdrw_create_buffer_handle(
+      handle,
+      ReportType::NativeCrash as i8,
+      sdk_id.as_ptr(),
+      sdk_version.as_ptr(),
+    );
+  }
+
+  let result = build_report_contents(handle, kscrash_report);
+
+  if result.is_err() {
+    unsafe {
+      bdrw_dispose_buffer_handle(handle);
+    }
+  }
+
+  result
+}
+
+fn build_report_contents(
+  handle: BDProcessorHandle,
+  kscrash_report: &AHashMap<String, Value>,
+) -> anyhow::Result<Vec<u8>> {
+  add_binary_images(handle, kscrash_report)?;
+  let crashed_thread_stack = add_threads(handle, kscrash_report)?;
+  add_error(handle, kscrash_report, crashed_thread_stack.as_deref())?;
+  add_app_metrics(handle, kscrash_report)?;
+  add_device_metrics(handle, kscrash_report)?;
+
+  let mut length = 0_u64;
+  let buffer = unsafe { bdrw_get_completed_buffer(handle, &mut length) };
+  if buffer.is_null() {
+    unsafe {
+      bdrw_dispose_buffer_handle(handle);
+    }
+    return Err(anyhow::anyhow!("Failed to serialize crash report buffer"));
+  }
+
+  let bytes = unsafe { slice::from_raw_parts(buffer, length as usize) }.to_vec();
+  unsafe {
+    bdrw_dispose_buffer_handle(handle);
+  }
+  Ok(bytes)
+}
+
+fn add_binary_images(
+  handle: BDProcessorHandle,
+  kscrash_report: &AHashMap<String, Value>,
+) -> anyhow::Result<()> {
+  let Some(Value::Array(images)) = kscrash_report.get("binaryImages") else {
+    return Ok(());
+  };
+
+  for image in images {
+    let Value::Object(image) = image else {
+      continue;
+    };
+
+    let Some(Value::String(id)) = image.get("uuid") else {
+      continue;
+    };
+    let Some(Value::String(path)) = image.get("name") else {
+      continue;
+    };
+    let Some(load_address) = image.get("loadAddress").and_then(value_as_u64) else {
+      continue;
+    };
+
+    let id = CString::new(id.as_str())?;
+    let path = CString::new(path.as_str())?;
+    let image = BDBinaryImage {
+      id: id.as_ptr(),
+      path: path.as_ptr(),
+      load_address,
+    };
+
+    unsafe {
+      let _ = bdrw_add_binary_image(handle, &image);
+    }
+  }
+
+  Ok(())
+}
+
+fn add_threads(
+  handle: BDProcessorHandle,
+  kscrash_report: &AHashMap<String, Value>,
+) -> anyhow::Result<Option<Vec<BDStackFrame>>> {
+  let Some(Value::Array(threads)) = kscrash_report.get("threads") else {
+    return Ok(None);
+  };
+
+  let system_thread_count = u16::try_from(threads.len()).unwrap_or(u16::MAX);
+  let mut crashed_thread_stack = None;
+
+  for thread in threads {
+    let Value::Object(thread) = thread else {
+      continue;
+    };
+
+    let index = thread
+      .get("index")
+      .and_then(value_as_u64)
+      .and_then(|index| u32::try_from(index).ok())
+      .unwrap_or(0);
+    let active = thread
+      .get("crashed")
+      .and_then(value_as_bool)
+      .unwrap_or(false);
+
+    let thread_name = thread
+      .get("name")
+      .and_then(value_as_string)
+      .or_else(|| thread.get("dispatchQueue").and_then(value_as_string));
+    let thread_name_c = thread_name.as_deref().map(CString::new).transpose()?;
+
+    let stack = build_stack_frames(thread)?;
+    let thread_info = BDThread {
+      name: thread_name_c
+        .as_ref()
+        .map_or(null(), |value| value.as_ptr()),
+      state: null(),
+      active,
+      index,
+      priority: 0.0,
+      quality_of_service: -1,
+    };
+
+    unsafe {
+      let _ = bdrw_add_thread(
+        handle,
+        system_thread_count,
+        &thread_info,
+        u32::try_from(stack.len()).unwrap_or(u32::MAX),
+        if stack.is_empty() {
+          null()
+        } else {
+          stack.as_ptr()
+        },
+      );
+    }
+
+    if active && crashed_thread_stack.is_none() {
+      crashed_thread_stack = Some(stack);
+    }
+  }
+
+  Ok(crashed_thread_stack)
+}
+
+fn add_error(
+  handle: BDProcessorHandle,
+  kscrash_report: &AHashMap<String, Value>,
+  crashed_thread_stack: Option<&[BDStackFrame]>,
+) -> anyhow::Result<()> {
+  let error = kscrash_report
+    .get("error")
+    .and_then(|value| value.as_object().ok());
+  let diagnostic = kscrash_report
+    .get("diagnosticMetaData")
+    .and_then(|value| value.as_object().ok());
+
+  let name = error
+    .and_then(|error| error.get("exceptionName").and_then(value_as_string))
+    .or_else(|| diagnostic.and_then(|meta| diagnostic_name(meta)))
+    .unwrap_or_else(|| "Native Crash".to_string());
+
+  let reason = error
+    .and_then(|error| error.get("crashReason").and_then(value_as_string))
+    .or_else(|| diagnostic.and_then(|meta| diagnostic_reason(meta)));
+
+  let name = CString::new(name)?;
+  let reason_c = reason.as_deref().map(CString::new).transpose()?;
+  let stack = crashed_thread_stack.unwrap_or(&[]);
+
+  unsafe {
+    let _ = bdrw_add_error(
+      handle,
+      name.as_ptr(),
+      reason_c.as_ref().map_or(null(), |value| value.as_ptr()),
+      0,
+      u32::try_from(stack.len()).unwrap_or(u32::MAX),
+      if stack.is_empty() {
+        null()
+      } else {
+        stack.as_ptr()
+      },
+    );
+  }
+
+  Ok(())
+}
+
+fn add_app_metrics(
+  handle: BDProcessorHandle,
+  kscrash_report: &AHashMap<String, Value>,
+) -> anyhow::Result<()> {
+  let system = kscrash_report
+    .get("system")
+    .and_then(|value| value.as_object().ok())
+    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing system info"))?;
+
+  let app_id = CString::new(
+    system
+      .get("bundleID")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+  let version = CString::new(
+    system
+      .get("bundleShortVersion")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+  let bundle_version = CString::new(
+    system
+      .get("bundleVersion")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+
+  let app = BDAppMetrics {
+    app_id: app_id.as_ptr(),
+    version: version.as_ptr(),
+    version_code: 0,
+    cf_bundle_version: bundle_version.as_ptr(),
+    running_state: null(),
+    memory_used: 0,
+    memory_free: 0,
+    memory_total: 0,
+  };
+
+  unsafe {
+    let _ = bdrw_add_app(handle, &app);
+  }
+  Ok(())
+}
+
+fn add_device_metrics(
+  handle: BDProcessorHandle,
+  kscrash_report: &AHashMap<String, Value>,
+) -> anyhow::Result<()> {
+  let system = kscrash_report
+    .get("system")
+    .and_then(|value| value.as_object().ok())
+    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing system info"))?;
+  let diagnostic = kscrash_report
+    .get("diagnosticMetaData")
+    .and_then(|value| value.as_object().ok())
+    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing diagnostic metadata"))?;
+
+  let crashed_at = diagnostic
+    .get("crashedAt")
+    .and_then(value_as_u64)
+    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing crash timestamp"))?;
+  let crashed_at_nanos = diagnostic
+    .get("crashedAtNanos")
+    .and_then(value_as_u64)
+    .and_then(|value| u32::try_from(value).ok())
+    .unwrap_or(0);
+  let model = CString::new(
+    system
+      .get("model")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+  let os_version = CString::new(
+    system
+      .get("osVersion")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+  let os_brand = CString::new(
+    system
+      .get("systemName")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+  let kernel_version = CString::new(
+    system
+      .get("kernelVersion")
+      .and_then(value_as_string)
+      .unwrap_or_default(),
+  )?;
+  let timezone = system
+    .get("timezone")
+    .and_then(value_as_string)
+    .map(CString::new)
+    .transpose()?;
+
+  let device = BDDeviceMetrics {
+    time_seconds: crashed_at,
+    time_nanos: crashed_at_nanos,
+    timezone: timezone.as_ref().map_or(null(), |value| value.as_ptr()),
+    manufacturer: null(),
+    model: model.as_ptr(),
+    os_version: os_version.as_ptr(),
+    os_brand: os_brand.as_ptr(),
+    os_fingerprint: null(),
+    os_kernversion: kernel_version.as_ptr(),
+    power_state: 0,
+    power_charge_percent: 0,
+    network_state: 0,
+    architecture: architecture_constant(
+      system
+        .get("binaryArchitecture")
+        .and_then(value_as_string)
+        .as_deref(),
+    ),
+    display_height: 0,
+    display_width: 0,
+    display_density_dpi: 0,
+    platform: 2,
+    rotation: 0,
+    cpu_abi_count: 0,
+    cpu_abis: null(),
+  };
+
+  unsafe {
+    let _ = bdrw_add_device(handle, &device);
+  }
+  Ok(())
+}
+
+fn build_stack_frames(thread: &AHashMap<String, Value>) -> anyhow::Result<Vec<BDStackFrame>> {
+  let Some(Value::Object(backtrace)) = thread.get("backtrace") else {
+    return Ok(Vec::new());
+  };
+  let Some(Value::Array(contents)) = backtrace.get("contents") else {
+    return Ok(Vec::new());
+  };
+
+  let mut frames = Vec::with_capacity(contents.len());
+  for frame in contents {
+    let Value::Object(frame) = frame else {
+      continue;
+    };
+    let Some(frame_address) = frame.get("address").and_then(value_as_u64) else {
+      continue;
+    };
+    let image_id = frame
+      .get("binaryUUID")
+      .and_then(value_as_string)
+      .map(CString::new)
+      .transpose()?;
+
+    frames.push(BDStackFrame {
+      type_: 2,
+      frame_address,
+      symbol_address: 0,
+      symbol_name: null(),
+      class_name: null(),
+      file_name: null(),
+      line: -1,
+      column: -1,
+      image_id: image_id.as_ref().map_or(null(), |value| value.as_ptr()),
+      state_count: 0,
+      state: null(),
+      reg_count: 0,
+      regs: null(),
+    });
+  }
+
+  Ok(frames)
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+  match value {
+    Value::Unsigned(value) => Some(*value),
+    Value::Signed(value) => (*value >= 0).then_some(*value as u64),
+    _ => None,
+  }
+}
+
+fn value_as_bool(value: &Value) -> Option<bool> {
+  match value {
+    Value::Bool(value) => Some(*value),
+    _ => None,
+  }
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+  match value {
+    Value::String(value) => Some(value.clone()),
+    _ => None,
+  }
+}
+
+fn architecture_constant(arch: Option<&str>) -> i8 {
+  match arch {
+    Some(arch) if arch.contains("arm64") => 2,
+    Some(arch) if arch.contains("x86_64") => 4,
+    _ => 0,
+  }
+}
+
+fn diagnostic_name(meta: &AHashMap<String, Value>) -> Option<String> {
+  let exception_type = meta.get("exceptionType").and_then(value_as_u64)?;
+  match exception_type {
+    1 => Some("EXC_BAD_ACCESS".to_string()),
+    2 => Some("EXC_BAD_INSTRUCTION".to_string()),
+    3 => Some("EXC_ARITHMETIC".to_string()),
+    4 => Some("EXC_EMULATION".to_string()),
+    5 => Some("EXC_SOFTWARE".to_string()),
+    6 => Some("EXC_BREAKPOINT".to_string()),
+    10 => Some("EXC_CRASH".to_string()),
+    _ => None,
+  }
+}
+
+fn diagnostic_reason(meta: &AHashMap<String, Value>) -> Option<String> {
+  let exception_code = meta.get("exceptionCode").and_then(value_as_u64)?;
+  let signal = meta.get("signal").and_then(value_as_u64)?;
+  Some(format!(
+    "code: {exception_code}, signal: {}",
+    signal_name(signal)
+  ))
+}
+
+fn signal_name(signal: u64) -> &'static str {
+  match signal {
+    1 => "SIGHUP",
+    2 => "SIGINT",
+    3 => "SIGQUIT",
+    4 => "SIGILL",
+    5 => "SIGTRAP",
+    6 => "SIGABRT",
+    8 => "SIGFPE",
+    9 => "SIGKILL",
+    10 => "SIGBUS",
+    11 => "SIGSEGV",
+    12 => "SIGSYS",
+    13 => "SIGPIPE",
+    14 => "SIGALRM",
+    15 => "SIGTERM",
+    _ => "UNKNOWN",
+  }
 }
 
 fn enhance_metrickit_diagnostic_report_impl(

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -45,6 +45,14 @@ pub struct CachedCrashTimestamp {
   pub found: bool,
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CachedCrashEventIdResult {
+  Failure           = 0,
+  EventDoesNotExist = 1,
+  Success           = 2,
+}
+
 // Global cache for the most recently loaded KSCrash report.
 // This allows us to safely delete the report file so that it's not picked up next launch by
 // mistake.
@@ -83,6 +91,17 @@ extern "C" fn capture_cached_kscrash_timestamp() -> CachedCrashTimestamp {
       found: false,
     },
     "read cached kscrash timestamp",
+  )
+}
+
+#[no_mangle]
+extern "C" fn capture_cached_kscrash_event_id(
+  event_id_ptr: *mut *const Object,
+) -> CachedCrashEventIdResult {
+  with_handle_unexpected_or(
+    || -> anyhow::Result<CachedCrashEventIdResult> { cached_kscrash_event_id_impl(event_id_ptr) },
+    CachedCrashEventIdResult::Failure,
+    "read cached kscrash event id",
   )
 }
 
@@ -170,6 +189,30 @@ fn cached_kscrash_timestamp_impl() -> anyhow::Result<CachedCrashTimestamp> {
     nanoseconds,
     found: true,
   })
+}
+
+fn cached_kscrash_event_id_impl(
+  event_id_ptr: *mut *const Object,
+) -> anyhow::Result<CachedCrashEventIdResult> {
+  let Some(kscrash_report) = CACHED_KSCRASH_REPORT.lock().as_ref().cloned() else {
+    return Ok(CachedCrashEventIdResult::EventDoesNotExist);
+  };
+
+  let diagnostic = kscrash_report
+    .get("diagnosticMetaData")
+    .and_then(|value| value.as_object().ok())
+    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing diagnostic metadata"))?;
+
+  let Some(Value::String(event_id)) = diagnostic.get("eventID") else {
+    return Ok(CachedCrashEventIdResult::EventDoesNotExist);
+  };
+
+  let nsstring = crate::ffi::make_nsstring(event_id)?;
+  unsafe {
+    *event_id_ptr = *nsstring;
+  }
+
+  Ok(CachedCrashEventIdResult::Success)
 }
 
 fn value_as_u64(value: &Value) -> Option<u64> {

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -209,7 +209,7 @@ fn cached_kscrash_event_id_impl(
 
   let nsstring = crate::ffi::make_nsstring(event_id)?;
   unsafe {
-    *event_id_ptr = *nsstring;
+    *event_id_ptr = nsstring.autorelease() as *const Object;
   }
 
   Ok(CachedCrashEventIdResult::Success)

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -28,6 +28,11 @@ struct NamedThread {
   count: usize,
 }
 
+struct OwnedStackTrace {
+  _image_ids: Vec<CString>,
+  frames: Vec<BDStackFrame>,
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheResult {
@@ -344,19 +349,18 @@ fn add_binary_images(
     let Value::Object(image) = image else {
       continue;
     };
-
-    let Some(Value::String(id)) = image.get("uuid") else {
+    let Some(binary_uuid) = image.get("uuid").and_then(value_as_string) else {
       continue;
     };
-    let Some(Value::String(path)) = image.get("name") else {
+    let Some(binary_name) = image.get("name").and_then(value_as_string) else {
       continue;
     };
     let Some(load_address) = image.get("loadAddress").and_then(value_as_u64) else {
       continue;
     };
 
-    let id = CString::new(id.as_str())?;
-    let path = CString::new(path.as_str())?;
+    let id = CString::new(binary_uuid)?;
+    let path = CString::new(binary_name)?;
     let image = BDBinaryImage {
       id: id.as_ptr(),
       path: path.as_ptr(),
@@ -375,12 +379,12 @@ fn add_threads(
   handle: BDProcessorHandle,
   kscrash_report: &AHashMap<String, Value>,
 ) -> anyhow::Result<Option<Vec<BDStackFrame>>> {
+  let mut crashed_thread_stack = None;
   let Some(Value::Array(threads)) = kscrash_report.get("threads") else {
     return Ok(None);
   };
 
   let system_thread_count = u16::try_from(threads.len()).unwrap_or(u16::MAX);
-  let mut crashed_thread_stack = None;
 
   for thread in threads {
     let Value::Object(thread) = thread else {
@@ -420,17 +424,17 @@ fn add_threads(
         handle,
         system_thread_count,
         &thread_info,
-        u32::try_from(stack.len()).unwrap_or(u32::MAX),
-        if stack.is_empty() {
+        u32::try_from(stack.frames.len()).unwrap_or(u32::MAX),
+        if stack.frames.is_empty() {
           null()
         } else {
-          stack.as_ptr()
+          stack.frames.as_ptr()
         },
       );
     }
 
     if active && crashed_thread_stack.is_none() {
-      crashed_thread_stack = Some(stack);
+      crashed_thread_stack = Some(stack.frames);
     }
   }
 
@@ -611,14 +615,21 @@ fn add_device_metrics(
   Ok(())
 }
 
-fn build_stack_frames(thread: &AHashMap<String, Value>) -> anyhow::Result<Vec<BDStackFrame>> {
+fn build_stack_frames(thread: &AHashMap<String, Value>) -> anyhow::Result<OwnedStackTrace> {
   let Some(Value::Object(backtrace)) = thread.get("backtrace") else {
-    return Ok(Vec::new());
+    return Ok(OwnedStackTrace {
+      _image_ids: Vec::new(),
+      frames: Vec::new(),
+    });
   };
   let Some(Value::Array(contents)) = backtrace.get("contents") else {
-    return Ok(Vec::new());
+    return Ok(OwnedStackTrace {
+      _image_ids: Vec::new(),
+      frames: Vec::new(),
+    });
   };
 
+  let mut image_ids = Vec::with_capacity(contents.len());
   let mut frames = Vec::with_capacity(contents.len());
   for frame in contents {
     let Value::Object(frame) = frame else {
@@ -627,22 +638,30 @@ fn build_stack_frames(thread: &AHashMap<String, Value>) -> anyhow::Result<Vec<BD
     let Some(frame_address) = frame.get("address").and_then(value_as_u64) else {
       continue;
     };
+    let symbol_address = frame
+      .get("offsetIntoBinaryTextSegment")
+      .and_then(value_as_u64)
+      .unwrap_or(0);
     let image_id = frame
       .get("binaryUUID")
       .and_then(value_as_string)
       .map(CString::new)
       .transpose()?;
+    if let Some(image_id) = image_id {
+      image_ids.push(image_id);
+    }
+    let image_id_ptr = image_ids.last().map_or(null(), |value| value.as_ptr());
 
     frames.push(BDStackFrame {
       type_: 2,
       frame_address,
-      symbol_address: 0,
+      symbol_address,
       symbol_name: null(),
       class_name: null(),
       file_name: null(),
       line: -1,
       column: -1,
-      image_id: image_id.as_ref().map_or(null(), |value| value.as_ptr()),
+      image_id: image_id_ptr,
       state_count: 0,
       state: null(),
       reg_count: 0,
@@ -650,7 +669,10 @@ fn build_stack_frames(thread: &AHashMap<String, Value>) -> anyhow::Result<Vec<BD
     });
   }
 
-  Ok(frames)
+  Ok(OwnedStackTrace {
+    _image_ids: image_ids,
+    frames,
+  })
 }
 
 fn value_as_u64(value: &Value) -> Option<u64> {

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -576,8 +576,10 @@ mod tests {
 
     *CACHED_KSCRASH_REPORT.lock() = Some(report);
 
+    let result = cached_kscrash_timestamp_impl().unwrap();
+    *CACHED_KSCRASH_REPORT.lock() = None;
     assert_eq!(
-      cached_kscrash_timestamp_impl().unwrap(),
+      result,
       CachedCrashTimestamp {
         seconds: 1_234_567_890,
         nanoseconds: 500_000_000,
@@ -599,8 +601,10 @@ mod tests {
 
     *CACHED_KSCRASH_REPORT.lock() = Some(report);
 
+    let result = cached_kscrash_timestamp_impl().unwrap();
+    *CACHED_KSCRASH_REPORT.lock() = None;
     assert_eq!(
-      cached_kscrash_timestamp_impl().unwrap(),
+      result,
       CachedCrashTimestamp {
         seconds: 1_234_567_890,
         nanoseconds: 0,
@@ -624,6 +628,7 @@ mod tests {
 
     let mut event_id_ptr: *const Object = std::ptr::null();
     let result = cached_kscrash_event_id_impl(&mut event_id_ptr).unwrap();
+    *CACHED_KSCRASH_REPORT.lock() = None;
     assert_eq!(result, CachedCrashEventIdResult::EventDoesNotExist);
     assert!(event_id_ptr.is_null());
   }
@@ -646,6 +651,7 @@ mod tests {
 
     let mut event_id_ptr: *const Object = std::ptr::null();
     let result = cached_kscrash_event_id_impl(&mut event_id_ptr).unwrap();
+    *CACHED_KSCRASH_REPORT.lock() = None;
     assert_eq!(result, CachedCrashEventIdResult::Success);
     assert!(!event_id_ptr.is_null());
     let event_id_str = unsafe { nsstring_into_string(event_id_ptr) }.unwrap();

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -28,13 +28,13 @@ struct NamedThread {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheResult {
   /// The report was not cached due to an error
-  Failure = 0,
+  Failure            = 0,
   /// The report file does not exist
   ReportDoesNotExist = 1,
   /// Successfully cached a partial document
-  PartialSuccess = 2,
+  PartialSuccess     = 2,
   /// Successfully cached the complete document
-  Success = 3,
+  Success            = 3,
 }
 
 #[repr(C)]
@@ -132,11 +132,13 @@ fn parse_cached_report(report_path: String) -> anyhow::Result<CacheResult> {
 
   CACHED_KSCRASH_REPORT.lock().replace(hashmap);
 
-  Ok(if was_partial {
-    CacheResult::PartialSuccess
-  } else {
-    CacheResult::Success
-  })
+  Ok(
+    if was_partial {
+      CacheResult::PartialSuccess
+    } else {
+      CacheResult::Success
+    },
+  )
 }
 
 fn cached_kscrash_timestamp_impl() -> anyhow::Result<CachedCrashTimestamp> {

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -15,22 +15,13 @@ use bd_error_reporter::reporter::with_handle_unexpected_or;
 use objc::runtime::Object;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::ffi::c_void;
-use std::ffi::CString;
 use std::fs;
 use std::path::Path;
-use std::ptr::null;
-use std::slice;
 
 struct NamedThread {
   name: String,
   call_stack: Vec<u64>,
   count: usize,
-}
-
-struct OwnedStackTrace {
-  _image_ids: Vec<CString>,
-  frames: Vec<BDStackFrame>,
 }
 
 #[repr(C)]
@@ -47,126 +38,11 @@ pub enum CacheResult {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReportCreationResult {
-  Failure = 0,
-  ReportDoesNotExist = 1,
-  Success = 2,
-}
-
-#[repr(i8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReportType {
-  NativeCrash = 5,
-}
-
-const SDK_ID: &str = "io.bitdrift.capture-apple";
-
-type BDProcessorHandle = *mut *const c_void;
-
-#[repr(C)]
-struct BDBinaryImage {
-  id: *const i8,
-  path: *const i8,
-  load_address: u64,
-}
-
-#[repr(C)]
-struct BDCPURegister {
-  name: *const i8,
-  value: u64,
-}
-
-#[repr(C)]
-struct BDStackFrame {
-  type_: i8,
-  frame_address: u64,
-  symbol_address: u64,
-  symbol_name: *const i8,
-  class_name: *const i8,
-  file_name: *const i8,
-  line: i64,
-  column: i64,
-  image_id: *const i8,
-  state_count: usize,
-  state: *const *const i8,
-  reg_count: usize,
-  regs: *const BDCPURegister,
-}
-
-#[repr(C)]
-struct BDThread {
-  name: *const i8,
-  state: *const i8,
-  active: bool,
-  index: u32,
-  priority: f32,
-  quality_of_service: i8,
-}
-
-#[repr(C)]
-struct BDDeviceMetrics {
-  time_seconds: u64,
-  time_nanos: u32,
-  timezone: *const i8,
-  manufacturer: *const i8,
-  model: *const i8,
-  os_version: *const i8,
-  os_brand: *const i8,
-  os_fingerprint: *const i8,
-  os_kernversion: *const i8,
-  power_state: i8,
-  power_charge_percent: u8,
-  network_state: i8,
-  architecture: i8,
-  display_height: u32,
-  display_width: u32,
-  display_density_dpi: u32,
-  platform: i8,
-  rotation: i8,
-  cpu_abi_count: u8,
-  cpu_abis: *const *const i8,
-}
-
-#[repr(C)]
-struct BDAppMetrics {
-  app_id: *const i8,
-  version: *const i8,
-  version_code: i64,
-  cf_bundle_version: *const i8,
-  running_state: *const i8,
-  memory_used: u64,
-  memory_free: u64,
-  memory_total: u64,
-}
-
-unsafe extern "C-unwind" {
-  fn bdrw_create_buffer_handle(
-    handle: BDProcessorHandle,
-    report_type: i8,
-    sdk_id: *const i8,
-    sdk_version: *const i8,
-  );
-  fn bdrw_get_completed_buffer(handle: BDProcessorHandle, buffer_length: *mut u64) -> *const u8;
-  fn bdrw_dispose_buffer_handle(handle: BDProcessorHandle);
-  fn bdrw_add_binary_image(handle: BDProcessorHandle, image: *const BDBinaryImage) -> bool;
-  fn bdrw_add_thread(
-    handle: BDProcessorHandle,
-    system_thread_count: u16,
-    thread_ptr: *const BDThread,
-    stack_count: u32,
-    stack: *const BDStackFrame,
-  ) -> bool;
-  fn bdrw_add_error(
-    handle: BDProcessorHandle,
-    name: *const i8,
-    reason: *const i8,
-    relation_to_next: i8,
-    stack_count: u32,
-    stack: *const BDStackFrame,
-  ) -> bool;
-  fn bdrw_add_device(handle: BDProcessorHandle, device_ptr: *const BDDeviceMetrics) -> bool;
-  fn bdrw_add_app(handle: BDProcessorHandle, app_ptr: *const BDAppMetrics) -> bool;
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CachedCrashTimestamp {
+  pub seconds: u64,
+  pub nanoseconds: u32,
+  pub found: bool,
 }
 
 // Global cache for the most recently loaded KSCrash report.
@@ -198,16 +74,15 @@ extern "C" fn capture_enhance_metrickit_diagnostic_report(
 }
 
 #[no_mangle]
-extern "C" fn capture_create_report_from_cached_kscrash_report(
-  report_path_ptr: *const Object,
-  sdk_version_ptr: *const Object,
-) -> ReportCreationResult {
+extern "C" fn capture_cached_kscrash_timestamp() -> CachedCrashTimestamp {
   with_handle_unexpected_or(
-    || -> anyhow::Result<ReportCreationResult> {
-      create_report_from_cached_kscrash_report_impl(report_path_ptr, sdk_version_ptr)
+    || -> anyhow::Result<CachedCrashTimestamp> { cached_kscrash_timestamp_impl() },
+    CachedCrashTimestamp {
+      seconds: 0,
+      nanoseconds: 0,
+      found: false,
     },
-    ReportCreationResult::Failure,
-    "create crash report from cached kscrash report",
+    "read cached kscrash timestamp",
   )
 }
 
@@ -219,24 +94,6 @@ fn capture_cache_kscrash_report_impl(
   let report_path = unsafe { nsstring_into_string(kscrash_report_path_ptr) }
     .map_err(|e| anyhow::anyhow!("Failed to convert KSCrash report path to string: {e}"))?;
   parse_cached_report(report_path)
-}
-
-fn create_report_from_cached_kscrash_report_impl(
-  report_path_ptr: *const Object,
-  sdk_version_ptr: *const Object,
-) -> anyhow::Result<ReportCreationResult> {
-  let report_path = unsafe { nsstring_into_string(report_path_ptr) }
-    .map_err(|e| anyhow::anyhow!("Failed to convert report path to string: {e}"))?;
-  let sdk_version = unsafe { nsstring_into_string(sdk_version_ptr) }
-    .map_err(|e| anyhow::anyhow!("Failed to convert sdk version to string: {e}"))?;
-
-  let Some(kscrash_report) = CACHED_KSCRASH_REPORT.lock().as_ref().cloned() else {
-    return Ok(ReportCreationResult::ReportDoesNotExist);
-  };
-
-  let bytes = build_report_bytes_from_kscrash_report(&kscrash_report, &sdk_version)?;
-  fs::write(report_path, bytes)?;
-  Ok(ReportCreationResult::Success)
 }
 
 fn parse_cached_report(report_path: String) -> anyhow::Result<CacheResult> {
@@ -282,396 +139,34 @@ fn parse_cached_report(report_path: String) -> anyhow::Result<CacheResult> {
   })
 }
 
-fn build_report_bytes_from_kscrash_report(
-  kscrash_report: &AHashMap<String, Value>,
-  sdk_version: &str,
-) -> anyhow::Result<Vec<u8>> {
-  let mut handle_ptr: *const std::ffi::c_void = null();
-  let handle: BDProcessorHandle = &mut handle_ptr;
-  let sdk_id = CString::new(SDK_ID)?;
-  let sdk_version = CString::new(sdk_version)?;
-
-  unsafe {
-    bdrw_create_buffer_handle(
-      handle,
-      ReportType::NativeCrash as i8,
-      sdk_id.as_ptr(),
-      sdk_version.as_ptr(),
-    );
-  }
-
-  let result = build_report_contents(handle, kscrash_report);
-
-  if result.is_err() {
-    unsafe {
-      bdrw_dispose_buffer_handle(handle);
-    }
-  }
-
-  result
-}
-
-fn build_report_contents(
-  handle: BDProcessorHandle,
-  kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<Vec<u8>> {
-  add_binary_images(handle, kscrash_report)?;
-  let crashed_thread_stack = add_threads(handle, kscrash_report)?;
-  add_error(handle, kscrash_report, crashed_thread_stack.as_deref())?;
-  add_app_metrics(handle, kscrash_report)?;
-  add_device_metrics(handle, kscrash_report)?;
-
-  let mut length = 0_u64;
-  let buffer = unsafe { bdrw_get_completed_buffer(handle, &mut length) };
-  if buffer.is_null() {
-    unsafe {
-      bdrw_dispose_buffer_handle(handle);
-    }
-    return Err(anyhow::anyhow!("Failed to serialize crash report buffer"));
-  }
-
-  let bytes = unsafe { slice::from_raw_parts(buffer, length as usize) }.to_vec();
-  unsafe {
-    bdrw_dispose_buffer_handle(handle);
-  }
-  Ok(bytes)
-}
-
-fn add_binary_images(
-  handle: BDProcessorHandle,
-  kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<()> {
-  let Some(Value::Array(images)) = kscrash_report.get("binaryImages") else {
-    return Ok(());
+fn cached_kscrash_timestamp_impl() -> anyhow::Result<CachedCrashTimestamp> {
+  let Some(kscrash_report) = CACHED_KSCRASH_REPORT.lock().as_ref().cloned() else {
+    return Ok(CachedCrashTimestamp {
+      seconds: 0,
+      nanoseconds: 0,
+      found: false,
+    });
   };
 
-  for image in images {
-    let Value::Object(image) = image else {
-      continue;
-    };
-    let Some(binary_uuid) = image.get("uuid").and_then(value_as_string) else {
-      continue;
-    };
-    let Some(binary_name) = image.get("name").and_then(value_as_string) else {
-      continue;
-    };
-    let Some(load_address) = image.get("loadAddress").and_then(value_as_u64) else {
-      continue;
-    };
-
-    let id = CString::new(binary_uuid)?;
-    let path = CString::new(binary_name)?;
-    let image = BDBinaryImage {
-      id: id.as_ptr(),
-      path: path.as_ptr(),
-      load_address,
-    };
-
-    unsafe {
-      let _ = bdrw_add_binary_image(handle, &image);
-    }
-  }
-
-  Ok(())
-}
-
-fn add_threads(
-  handle: BDProcessorHandle,
-  kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<Option<Vec<BDStackFrame>>> {
-  let mut crashed_thread_stack = None;
-  let Some(Value::Array(threads)) = kscrash_report.get("threads") else {
-    return Ok(None);
-  };
-
-  let system_thread_count = u16::try_from(threads.len()).unwrap_or(u16::MAX);
-
-  for thread in threads {
-    let Value::Object(thread) = thread else {
-      continue;
-    };
-
-    let index = thread
-      .get("index")
-      .and_then(value_as_u64)
-      .and_then(|index| u32::try_from(index).ok())
-      .unwrap_or(0);
-    let active = thread
-      .get("crashed")
-      .and_then(value_as_bool)
-      .unwrap_or(false);
-
-    let thread_name = thread
-      .get("name")
-      .and_then(value_as_string)
-      .or_else(|| thread.get("dispatchQueue").and_then(value_as_string));
-    let thread_name_c = thread_name.as_deref().map(CString::new).transpose()?;
-
-    let stack = build_stack_frames(thread)?;
-    let thread_info = BDThread {
-      name: thread_name_c
-        .as_ref()
-        .map_or(null(), |value| value.as_ptr()),
-      state: null(),
-      active,
-      index,
-      priority: 0.0,
-      quality_of_service: -1,
-    };
-
-    unsafe {
-      let _ = bdrw_add_thread(
-        handle,
-        system_thread_count,
-        &thread_info,
-        u32::try_from(stack.frames.len()).unwrap_or(u32::MAX),
-        if stack.frames.is_empty() {
-          null()
-        } else {
-          stack.frames.as_ptr()
-        },
-      );
-    }
-
-    if active && crashed_thread_stack.is_none() {
-      crashed_thread_stack = Some(stack.frames);
-    }
-  }
-
-  Ok(crashed_thread_stack)
-}
-
-fn add_error(
-  handle: BDProcessorHandle,
-  kscrash_report: &AHashMap<String, Value>,
-  crashed_thread_stack: Option<&[BDStackFrame]>,
-) -> anyhow::Result<()> {
-  let error = kscrash_report
-    .get("error")
-    .and_then(|value| value.as_object().ok());
-  let diagnostic = kscrash_report
-    .get("diagnosticMetaData")
-    .and_then(|value| value.as_object().ok());
-
-  let name = error
-    .and_then(|error| error.get("exceptionName").and_then(value_as_string))
-    .or_else(|| diagnostic.and_then(|meta| diagnostic_name(meta)))
-    .unwrap_or_else(|| "Native Crash".to_string());
-
-  let reason = error
-    .and_then(|error| error.get("crashReason").and_then(value_as_string))
-    .or_else(|| diagnostic.and_then(|meta| diagnostic_reason(meta)));
-
-  let name = CString::new(name)?;
-  let reason_c = reason.as_deref().map(CString::new).transpose()?;
-  let stack = crashed_thread_stack.unwrap_or(&[]);
-
-  unsafe {
-    let _ = bdrw_add_error(
-      handle,
-      name.as_ptr(),
-      reason_c.as_ref().map_or(null(), |value| value.as_ptr()),
-      0,
-      u32::try_from(stack.len()).unwrap_or(u32::MAX),
-      if stack.is_empty() {
-        null()
-      } else {
-        stack.as_ptr()
-      },
-    );
-  }
-
-  Ok(())
-}
-
-fn add_app_metrics(
-  handle: BDProcessorHandle,
-  kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<()> {
-  let system = kscrash_report
-    .get("system")
-    .and_then(|value| value.as_object().ok())
-    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing system info"))?;
-
-  let app_id = CString::new(
-    system
-      .get("bundleID")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-  let version = CString::new(
-    system
-      .get("bundleShortVersion")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-  let bundle_version = CString::new(
-    system
-      .get("bundleVersion")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-
-  let app = BDAppMetrics {
-    app_id: app_id.as_ptr(),
-    version: version.as_ptr(),
-    version_code: 0,
-    cf_bundle_version: bundle_version.as_ptr(),
-    running_state: null(),
-    memory_used: 0,
-    memory_free: 0,
-    memory_total: 0,
-  };
-
-  unsafe {
-    let _ = bdrw_add_app(handle, &app);
-  }
-  Ok(())
-}
-
-fn add_device_metrics(
-  handle: BDProcessorHandle,
-  kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<()> {
-  let system = kscrash_report
-    .get("system")
-    .and_then(|value| value.as_object().ok())
-    .ok_or_else(|| anyhow::anyhow!("KSCrash report missing system info"))?;
   let diagnostic = kscrash_report
     .get("diagnosticMetaData")
     .and_then(|value| value.as_object().ok())
     .ok_or_else(|| anyhow::anyhow!("KSCrash report missing diagnostic metadata"))?;
 
-  let crashed_at = diagnostic
+  let seconds = diagnostic
     .get("crashedAt")
     .and_then(value_as_u64)
     .ok_or_else(|| anyhow::anyhow!("KSCrash report missing crash timestamp"))?;
-  let crashed_at_nanos = diagnostic
+  let nanoseconds = diagnostic
     .get("crashedAtNanos")
     .and_then(value_as_u64)
     .and_then(|value| u32::try_from(value).ok())
     .unwrap_or(0);
-  let model = CString::new(
-    system
-      .get("model")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-  let os_version = CString::new(
-    system
-      .get("osVersion")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-  let os_brand = CString::new(
-    system
-      .get("systemName")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-  let kernel_version = CString::new(
-    system
-      .get("kernelVersion")
-      .and_then(value_as_string)
-      .unwrap_or_default(),
-  )?;
-  let timezone = system
-    .get("timezone")
-    .and_then(value_as_string)
-    .map(CString::new)
-    .transpose()?;
 
-  let device = BDDeviceMetrics {
-    time_seconds: crashed_at,
-    time_nanos: crashed_at_nanos,
-    timezone: timezone.as_ref().map_or(null(), |value| value.as_ptr()),
-    manufacturer: null(),
-    model: model.as_ptr(),
-    os_version: os_version.as_ptr(),
-    os_brand: os_brand.as_ptr(),
-    os_fingerprint: null(),
-    os_kernversion: kernel_version.as_ptr(),
-    power_state: 0,
-    power_charge_percent: 0,
-    network_state: 0,
-    architecture: architecture_constant(
-      system
-        .get("binaryArchitecture")
-        .and_then(value_as_string)
-        .as_deref(),
-    ),
-    display_height: 0,
-    display_width: 0,
-    display_density_dpi: 0,
-    platform: 2,
-    rotation: 0,
-    cpu_abi_count: 0,
-    cpu_abis: null(),
-  };
-
-  unsafe {
-    let _ = bdrw_add_device(handle, &device);
-  }
-  Ok(())
-}
-
-fn build_stack_frames(thread: &AHashMap<String, Value>) -> anyhow::Result<OwnedStackTrace> {
-  let Some(Value::Object(backtrace)) = thread.get("backtrace") else {
-    return Ok(OwnedStackTrace {
-      _image_ids: Vec::new(),
-      frames: Vec::new(),
-    });
-  };
-  let Some(Value::Array(contents)) = backtrace.get("contents") else {
-    return Ok(OwnedStackTrace {
-      _image_ids: Vec::new(),
-      frames: Vec::new(),
-    });
-  };
-
-  let mut image_ids = Vec::with_capacity(contents.len());
-  let mut frames = Vec::with_capacity(contents.len());
-  for frame in contents {
-    let Value::Object(frame) = frame else {
-      continue;
-    };
-    let Some(frame_address) = frame.get("address").and_then(value_as_u64) else {
-      continue;
-    };
-    let symbol_address = frame
-      .get("offsetIntoBinaryTextSegment")
-      .and_then(value_as_u64)
-      .unwrap_or(0);
-    let image_id = frame
-      .get("binaryUUID")
-      .and_then(value_as_string)
-      .map(CString::new)
-      .transpose()?;
-    if let Some(image_id) = image_id {
-      image_ids.push(image_id);
-    }
-    let image_id_ptr = image_ids.last().map_or(null(), |value| value.as_ptr());
-
-    frames.push(BDStackFrame {
-      type_: 2,
-      frame_address,
-      symbol_address,
-      symbol_name: null(),
-      class_name: null(),
-      file_name: null(),
-      line: -1,
-      column: -1,
-      image_id: image_id_ptr,
-      state_count: 0,
-      state: null(),
-      reg_count: 0,
-      regs: null(),
-    });
-  }
-
-  Ok(OwnedStackTrace {
-    _image_ids: image_ids,
-    frames,
+  Ok(CachedCrashTimestamp {
+    seconds,
+    nanoseconds,
+    found: true,
   })
 }
 
@@ -680,71 +175,6 @@ fn value_as_u64(value: &Value) -> Option<u64> {
     Value::Unsigned(value) => Some(*value),
     Value::Signed(value) => (*value >= 0).then_some(*value as u64),
     _ => None,
-  }
-}
-
-fn value_as_bool(value: &Value) -> Option<bool> {
-  match value {
-    Value::Bool(value) => Some(*value),
-    _ => None,
-  }
-}
-
-fn value_as_string(value: &Value) -> Option<String> {
-  match value {
-    Value::String(value) => Some(value.clone()),
-    _ => None,
-  }
-}
-
-fn architecture_constant(arch: Option<&str>) -> i8 {
-  match arch {
-    Some(arch) if arch.contains("arm64") => 2,
-    Some(arch) if arch.contains("x86_64") => 4,
-    _ => 0,
-  }
-}
-
-fn diagnostic_name(meta: &AHashMap<String, Value>) -> Option<String> {
-  let exception_type = meta.get("exceptionType").and_then(value_as_u64)?;
-  match exception_type {
-    1 => Some("EXC_BAD_ACCESS".to_string()),
-    2 => Some("EXC_BAD_INSTRUCTION".to_string()),
-    3 => Some("EXC_ARITHMETIC".to_string()),
-    4 => Some("EXC_EMULATION".to_string()),
-    5 => Some("EXC_SOFTWARE".to_string()),
-    6 => Some("EXC_BREAKPOINT".to_string()),
-    10 => Some("EXC_CRASH".to_string()),
-    _ => None,
-  }
-}
-
-fn diagnostic_reason(meta: &AHashMap<String, Value>) -> Option<String> {
-  let exception_code = meta.get("exceptionCode").and_then(value_as_u64)?;
-  let signal = meta.get("signal").and_then(value_as_u64)?;
-  Some(format!(
-    "code: {exception_code}, signal: {}",
-    signal_name(signal)
-  ))
-}
-
-fn signal_name(signal: u64) -> &'static str {
-  match signal {
-    1 => "SIGHUP",
-    2 => "SIGINT",
-    3 => "SIGQUIT",
-    4 => "SIGILL",
-    5 => "SIGTRAP",
-    6 => "SIGABRT",
-    8 => "SIGFPE",
-    9 => "SIGKILL",
-    10 => "SIGBUS",
-    11 => "SIGSEGV",
-    12 => "SIGSYS",
-    13 => "SIGPIPE",
-    14 => "SIGALRM",
-    15 => "SIGTERM",
-    _ => "UNKNOWN",
   }
 }
 


### PR DESCRIPTION
Fixes inaccurate timestamps on iOS crash reports by persisting higher-precision crash time (`crashedAt`/`crashedAtNanos`) in the KSCrash report and using it when materializing MetricKit crash diagnostics.

## Changes

- **Rust bridge**: New FFI APIs to read cached KSCrash crash timestamp (secs + nanos) and event ID from the in-memory report cache
- **KSCrash handler**: Writes `crashedAtNanos`, `eventID`, and additional crash metadata (system/error info, binary images) into the KSCrash report; uses cached crash time for MetricKit crash timestamps with file-based dedupe
- **MetricKit reporter**: Uses cached KSCrash timestamp when enhancing `MXCrashDiagnostic` entries
- **Tests**: Unit tests for `cached_kscrash_timestamp_impl` (with/without nanos) and `cached_kscrash_event_id_impl` (present/missing `eventID`)
- **ObjC sample app**: Configuration UX improvements and `IssueCallback` support
- **Bazel**: Updates framework extraction outputs from `.swiftdoc`/`.swiftinterface` to `.swiftmodule`

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.