### PR TITLE
[Android] Support PreviousRunInfo below OS 11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -267,8 +267,6 @@ object Capture {
          *
          * Must be called after [start]. Returns `null` if the logger is not initialized.
          *
-         * Available on Android API 30+ (OS 11+). On API < 30, this returns `null` at the moment.
-         *
          * Note: on API 30, native crashes are reported as a fatal termination reason but do not
          * trigger an `onBeforeSend` callback with the crash report. The `onBeforeSend` callback
          * for native crashes is only available on API >= 31.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -56,6 +56,8 @@ import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfoResolver
+import io.bitdrift.capture.reports.jvmcrash.CaptureUncaughtExceptionHandler
+import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.processor.ICompletedReportsProcessor
 import io.bitdrift.capture.reports.processor.IIssueReporterProcessor
 import io.bitdrift.capture.reports.processor.ReportProcessingSession
@@ -119,9 +121,11 @@ internal class LoggerImpl(
     private val eventsListenerTarget = EventsListenerTarget()
 
     private val sessionReplayTarget: ISessionReplayTarget
+    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = CaptureUncaughtExceptionHandler()
 
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider = LatestAppExitInfoProvider(activityManager)
-    private val previousRunInfoResolver = PreviousRunInfoResolver(latestAppExitInfoProvider)
+    private val previousRunInfoResolver =
+        PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler)
 
     private val issueReporter: IssueReporter? =
         if (configuration.enableFatalIssueReporting) {
@@ -129,6 +133,7 @@ internal class LoggerImpl(
                 internalLogger = this,
                 dateProvider = dateProvider,
                 latestAppExitInfoProvider = latestAppExitInfoProvider,
+                captureUncaughtExceptionHandler = captureUncaughtExceptionHandler,
             )
         } else {
             null
@@ -279,6 +284,7 @@ internal class LoggerImpl(
                 runtime,
                 memoryMetricsProvider = memoryMetricsProvider,
                 latestAppExitInfoProvider = latestAppExitInfoProvider,
+                captureUncaughtExceptionHandler = captureUncaughtExceptionHandler,
                 issueReporter = issueReporter,
             )
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -27,7 +27,6 @@ import io.bitdrift.capture.reports.IIssueReporter
 import io.bitdrift.capture.reports.IssueReporterState
 import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitReasonResult
-import io.bitdrift.capture.reports.jvmcrash.CaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.IJvmCrashListener
 import io.bitdrift.capture.utils.BuildVersionChecker
@@ -38,7 +37,7 @@ internal class AppExitLogger(
     private val versionChecker: BuildVersionChecker = BuildVersionChecker(),
     private val memoryMetricsProvider: IMemoryMetricsProvider,
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider,
-    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = CaptureUncaughtExceptionHandler,
+    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler,
     private val issueReporter: IIssueReporter?,
 ) : IJvmCrashListener {
     companion object {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IssueReporter.kt
@@ -20,7 +20,6 @@ import io.bitdrift.capture.reports.IssueReporterState.NotInitialized
 import io.bitdrift.capture.reports.IssueReporterState.RuntimeState
 import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitReasonResult
-import io.bitdrift.capture.reports.jvmcrash.CaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.IJvmCrashListener
 import io.bitdrift.capture.reports.persistence.IssueReporterStore
@@ -49,7 +48,7 @@ internal class IssueReporter(
     private val internalLogger: IInternalLogger,
     private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider,
-    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = CaptureUncaughtExceptionHandler,
+    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler,
     private val dateProvider: DateProvider,
 ) : IIssueReporter,
     IJvmCrashListener {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
@@ -9,23 +9,68 @@ package io.bitdrift.capture.reports.exitinfo
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import io.bitdrift.capture.IPreferences
+import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
+import io.bitdrift.capture.reports.jvmcrash.IJvmCrashListener
 
 /**
  * Provides [PreviousRunInfo] for the previous app session.
  *
  * On API >= 30, uses [ApplicationExitInfo] directly.
- * On API < 30, returns `null` (no previous run info available yet). Will be implemented in BIT-7703.
+ * On API < 30, relies on manually persisted previous-run state, including when a JVM crash was recorded.
  */
 internal class PreviousRunInfoResolver(
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider,
-) : IPreviousRunInfoResolver {
+    preferences: IPreferences,
+    captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler,
+) : IPreviousRunInfoResolver,
+    IJvmCrashListener {
+    private val previousRunInfoLegacyStore by lazy { LegacyPreviousRunStateStore(preferences) }
+
+    private val legacyPreviousRunState: LegacyPreviousRunState?
+
+    init {
+        if (isBelowApi30()) {
+            legacyPreviousRunState = previousRunInfoLegacyStore.getPreviousState()
+            previousRunInfoLegacyStore.writeState(LegacyPreviousRunState.Started)
+            captureUncaughtExceptionHandler.install(this)
+        } else {
+            legacyPreviousRunState = null
+        }
+    }
+
     override fun get(): PreviousRunInfo? =
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            // TODO (BIT-7703): Enable support below OS 11
-            null
+        if (isBelowApi30()) {
+            getFromLegacyState()
         } else {
             getFromAppExitInfo()
         }
+
+    /**
+     * Will only trigger below OS 11
+     */
+    override fun onJvmCrash(
+        thread: Thread,
+        throwable: Throwable,
+    ) {
+        previousRunInfoLegacyStore.writeState(LegacyPreviousRunState.JvmCrash)
+    }
+
+    private fun isBelowApi30() = Build.VERSION.SDK_INT < Build.VERSION_CODES.R
+
+    private fun getFromLegacyState(): PreviousRunInfo? {
+        val previousState = legacyPreviousRunState ?: return null
+
+        return when (previousState) {
+            LegacyPreviousRunState.JvmCrash ->
+                PreviousRunInfo(
+                    hasFatallyTerminated = true,
+                    terminationReason = ExitReason.JvmCrash,
+                )
+
+            LegacyPreviousRunState.Started -> PreviousRunInfo(hasFatallyTerminated = false)
+        }
+    }
 
     @RequiresApi(Build.VERSION_CODES.R)
     private fun getFromAppExitInfo(): PreviousRunInfo? =
@@ -61,6 +106,34 @@ data class PreviousRunInfo(
     val hasFatallyTerminated: Boolean,
     val terminationReason: ExitReason? = null,
 )
+
+internal class LegacyPreviousRunStateStore(
+    private val preferences: IPreferences,
+) {
+    fun getPreviousState(): LegacyPreviousRunState? = preferences.getString(STATE_KEY)?.let(LegacyPreviousRunState::fromStorageValue)
+
+    fun writeState(state: LegacyPreviousRunState) {
+        val blocking = state == LegacyPreviousRunState.JvmCrash
+        preferences.setString(STATE_KEY, state.value, blocking = blocking)
+    }
+
+    private companion object {
+        private const val STATE_KEY = "io.bitdrift.capture.previous_run_info.state"
+    }
+}
+
+internal enum class LegacyPreviousRunState(
+    /** Stable text representation*/
+    val value: String,
+) {
+    Started("started"),
+    JvmCrash("jvm_crash"),
+    ;
+
+    companion object {
+        fun fromStorageValue(value: String): LegacyPreviousRunState? = entries.firstOrNull { it.value == value }
+    }
+}
 
 /**
  * Contract for producing [PreviousRunInfo] from app exit signals.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/jvmcrash/CaptureUncaughtExceptionHandler.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/jvmcrash/CaptureUncaughtExceptionHandler.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Concrete implementation of [io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler]
  * that will notify the specified listener when a JVM crash has occurred.
  */
-internal object CaptureUncaughtExceptionHandler : ICaptureUncaughtExceptionHandler {
+internal class CaptureUncaughtExceptionHandler : ICaptureUncaughtExceptionHandler {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     val crashing = AtomicBoolean(false)
     private val installed = AtomicBoolean(false)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -20,12 +20,14 @@ import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.exitinfo.ExitReason
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfoResolver
+import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
+import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -34,6 +36,8 @@ import org.robolectric.annotation.Config
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class CaptureTest {
     private val latestAppExitInfoProvider = FakeLatestAppExitInfoProvider()
+    private val preferences = MockPreferences()
+    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = mock()
 
     @Before
     fun tearDown() {
@@ -118,7 +122,7 @@ class CaptureTest {
     fun getPreviousRunInfo_returnsCrashForCrashReasons() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_CRASH)
 
-        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(previousRunInfo).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
@@ -130,7 +134,7 @@ class CaptureTest {
     fun getPreviousRunInfo_returnsNoCrashForExitSelfReason() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_EXIT_SELF)
 
-        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(previousRunInfo).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = false, terminationReason = ExitReason.ExitSelf),
@@ -142,7 +146,7 @@ class CaptureTest {
     fun getPreviousRunInfo_returnsNoCrashWhenNoExitInfo() {
         latestAppExitInfoProvider.setAsEmptyReason()
 
-        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(previousRunInfo).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false, terminationReason = null))
     }
@@ -152,7 +156,7 @@ class CaptureTest {
     fun getPreviousRunInfo_returnsNullWhenProviderFails() {
         latestAppExitInfoProvider.setAsErrorResult()
 
-        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(previousRunInfo).isNull()
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -36,6 +36,8 @@ import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.reports.IssueReporterState
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider.Companion.EXIT_REASON_EXCEPTION_MESSAGE
+import io.bitdrift.capture.reports.exitinfo.LegacyPreviousRunState
+import io.bitdrift.capture.reports.exitinfo.LegacyPreviousRunStateStore
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.utils.BuildVersionChecker
 import io.bitdrift.capture.utils.toStringMap

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -15,12 +15,14 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.IInternalLogger
 import io.bitdrift.capture.LogAttributesOverrides
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.LogType
+import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.fakes.FakeIssueReporter
@@ -37,6 +39,7 @@ import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider.Companion.
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.utils.BuildVersionChecker
 import io.bitdrift.capture.utils.toStringMap
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
@@ -49,6 +52,7 @@ class AppExitLoggerTest {
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = mock()
     private val memoryMetricsProvider = FakeMemoryMetricsProvider()
     private val lastExitInfo = FakeLatestAppExitInfoProvider()
+    private val preferences = MockPreferences()
 
     private lateinit var appExitLogger: AppExitLogger
 
@@ -61,13 +65,23 @@ class AppExitLoggerTest {
     }
 
     @Test
-    fun testLoggerIsNotInstalledWhenRuntimeDisabled() {
+    fun testPreviousExitReasonIsNotLoggedWhenRuntimeDisabled() {
         // ARRANGE
         whenever(runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)).thenReturn(false)
         // ACT
         appExitLogger.installAppExitLogger()
         // ASSERT
         verify(captureUncaughtExceptionHandler, never()).install(any())
+        verify(logger, never()).handleInternalError(any(), any())
+        verify(logger, never()).logInternal(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
     }
 
     @Test
@@ -196,6 +210,25 @@ class AppExitLoggerTest {
             argThat { i: () -> String -> i.invoke() == "AppExit" },
         )
         verify(logger).flush(true)
+    }
+
+    @Test
+    fun previousRunInfoStateStore_persistsLegacyJvmCrashMarker() {
+        val previousRunInfoStateStore = LegacyPreviousRunStateStore(preferences)
+
+        previousRunInfoStateStore.writeState(LegacyPreviousRunState.Started)
+        previousRunInfoStateStore.writeState(LegacyPreviousRunState.JvmCrash)
+
+        assertThat(preferences.getString("io.bitdrift.capture.previous_run_info.state")).isEqualTo("jvm_crash")
+    }
+
+    @Test
+    fun installAppExitLogger_whenAppExitEventsDisabled_doesNotInstallCrashHandler() {
+        whenever(runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)).thenReturn(false)
+
+        appExitLogger.installAppExitLogger()
+
+        verify(captureUncaughtExceptionHandler, never()).install(appExitLogger)
     }
 
     @Test

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
@@ -8,6 +8,8 @@
 package io.bitdrift.capture.reports.exitinfo
 
 import android.app.ApplicationExitInfo
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
@@ -133,5 +135,21 @@ class PreviousRunInfoResolverTest {
         val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isNull()
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun init_belowApi30_shouldInstallCrashHandler() {
+        val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler)
+
+        verify(captureUncaughtExceptionHandler).install(resolver)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun init_Api30_shouldNotInstallCrashHandler() {
+        val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler)
+
+        verify(captureUncaughtExceptionHandler, never()).install(resolver)
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
@@ -8,11 +8,14 @@
 package io.bitdrift.capture.reports.exitinfo
 
 import android.app.ApplicationExitInfo
+import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
+import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -20,6 +23,9 @@ import org.robolectric.annotation.Config
 @Config(sdk = [30])
 class PreviousRunInfoResolverTest {
     private val latestAppExitInfoProvider = FakeLatestAppExitInfoProvider()
+    private val preferences = MockPreferences()
+    private val previousRunInfoStateStore = LegacyPreviousRunStateStore(preferences)
+    private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = mock()
 
     @Before
     fun tearDown() {
@@ -30,7 +36,7 @@ class PreviousRunInfoResolverTest {
     fun get_returnsFatalForCrashReason() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_CRASH)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
@@ -41,7 +47,7 @@ class PreviousRunInfoResolverTest {
     fun get_returnsFatalForNativeCrash() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_CRASH_NATIVE)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.NativeCrash),
@@ -52,7 +58,7 @@ class PreviousRunInfoResolverTest {
     fun get_returnsFatalForAnr() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_ANR)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.AppNotResponding),
@@ -63,7 +69,7 @@ class PreviousRunInfoResolverTest {
     fun get_returnsNonFatalForUserRequested() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_USER_REQUESTED)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = false, terminationReason = ExitReason.UserRequested),
@@ -74,7 +80,7 @@ class PreviousRunInfoResolverTest {
     fun get_returnsNonFatalWhenNoExitInfo() {
         latestAppExitInfoProvider.setAsEmptyReason()
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false))
     }
@@ -83,15 +89,48 @@ class PreviousRunInfoResolverTest {
     fun get_returnsNullOnError() {
         latestAppExitInfoProvider.setAsErrorResult()
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isNull()
     }
 
     @Test
     @Config(sdk = [24])
-    fun get_belowApi30_returnsNull() {
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider).get()
+    fun get_belowApi30_returnsNullWhenNoPreviousStateWasPersisted() {
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun get_belowApi30_returnsNonFatalWhenStartedStateWasPersisted() {
+        previousRunInfoStateStore.writeState(LegacyPreviousRunState.Started)
+
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+
+        assertThat(result).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false))
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun get_belowApi30_returnsJvmCrashWhenCrashMarkerWasPersisted() {
+        previousRunInfoStateStore.writeState(LegacyPreviousRunState.Started)
+        previousRunInfoStateStore.writeState(LegacyPreviousRunState.JvmCrash)
+
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+
+        assertThat(result).isEqualTo(
+            PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
+        )
+    }
+
+    @Test
+    @Config(sdk = [24])
+    fun get_belowApi30_ignoresUnknownPersistedState() {
+        preferences.setString("io.bitdrift.capture.previous_run_info.state", "unknown", blocking = true)
+
+        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(result).isNull()
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/jvmcrash/CaptureUncaughtExceptionHandlerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/jvmcrash/CaptureUncaughtExceptionHandlerTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class CaptureUncaughtExceptionHandlerTest {
     private val crashListener: IJvmCrashListener = mock()
-    private val handler = CaptureUncaughtExceptionHandler
+    private val handler = CaptureUncaughtExceptionHandler()
     private lateinit var otherHandler: OtherCrashHandler
 
     @Before


### PR DESCRIPTION
## What

Resolves BIT-7703

Follow up to https://github.com/bitdriftlabs/capture-sdk/pull/922

Update `Capture.Logger.getPreviousRunInfo()` to return if app was terminated due to JVM crash on prior cold launch below OS 11.

## Verification

Verified with these session < OS 11

- [Session with crash](https://timeline.bitdrift.dev/session/84e04b04-1afe-4d91-b4be-5ece1825a5cf?utilization=0&expanded=-7843700512391339268)

<img width="388" height="219" alt="Screenshot 2026-04-15 at 16 04 35" src="https://github.com/user-attachments/assets/dcb13e52-0176-470b-8484-bbff826e2fb9" />

- [Next session after crash](https://timeline.bitdrift.dev/session/75d9a466-d8a0-42b3-939a-21cb1db531aa?utm_source=sdk&utilization=0&expanded=-493430855478208199&stacktrace=open)

<img width="370" height="185" alt="Screenshot 2026-04-15 at 16 05 36" src="https://github.com/user-attachments/assets/b0be999f-f37e-4c1a-8b62-a91b18413108" />
