### PR TITLE
[Session Replay] Capture immediate screen replay state within logScreenView calls

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -93,7 +93,7 @@ internal class LoggerImpl(
     sharedOkHttpClient: OkHttpClient = OkHttpClient(),
     private val apiClient: OkHttpApiClient = OkHttpApiClient(apiUrl, apiKey, client = sharedOkHttpClient),
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
-    private val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
+    activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     bridge: IBridge = CaptureJniLibrary,
     private val eventListenerDispatcher: CaptureDispatchers.CommonBackground = CaptureDispatchers.CommonBackground,
     windowManager: IWindowManager = WindowManager(errorHandler),
@@ -349,6 +349,8 @@ internal class LoggerImpl(
     }
 
     override fun logScreenView(screenName: String) {
+        // TODO(Fran): BIT-7953 reset replay timer
+        sessionReplayTarget.captureScreen()
         jankStatsMonitor?.trackScreenNameChanged(screenName)
         CaptureJniLibrary.writeScreenViewLog(this.loggerId, screenName)
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture
 
+import android.content.ContextWrapper
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.util.concurrent.MoreExecutors
@@ -18,7 +19,9 @@ import com.nhaarman.mockitokotlin2.timeout
 import com.nhaarman.mockitokotlin2.verify
 import io.bitdrift.capture.attributes.ClientAttributes
 import io.bitdrift.capture.attributes.NetworkAttributes
+import io.bitdrift.capture.common.IWindowManager
 import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.common.WindowManager
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponse
 import io.bitdrift.capture.network.HttpResponseInfo
@@ -89,9 +92,11 @@ class CaptureLoggerTest {
         fieldProvider: FieldProvider? = null,
         dateProvider: DateProvider = systemDateProvider,
         sessionStrategy: SessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
+        context: android.content.Context = ContextHolder.APP_CONTEXT,
+        windowManager: IWindowManager = WindowManager(ErrorHandler()),
         block: (LoggerImpl) -> T,
     ): T {
-        val logger = buildLogger(fieldProvider, dateProvider, sessionStrategy)
+        val logger = buildLogger(fieldProvider, dateProvider, sessionStrategy, context, windowManager)
         try {
             return block(logger)
         } finally {
@@ -243,11 +248,12 @@ class CaptureLoggerTest {
             @Suppress("UNUSED_VARIABLE")
             val deviceId = logger.deviceId
             val apiStreamId = CaptureTestJniLibrary.awaitNextApiStream()
+            assertThat(apiStreamId).isNotEqualTo(-1)
             assertThat(
                 CaptureTestJniLibrary.awaitApiServerReceivedHandshake(
                     apiStreamId,
                     mapOf(
-                        "app_id" to "io.bitdrift.capture",
+                        "app_id" to ContextHolder.APP_CONTEXT.packageName,
                         "app_version" to "?.?.?",
                         "os" to "android",
                         "device_id" to deviceId,
@@ -462,6 +468,16 @@ class CaptureLoggerTest {
             assertThat(JniRuntime(logger.loggerId).isEnabled(RuntimeFeature.SESSION_REPLAY_COMPOSE)).isFalse
         }
 
+    @Test
+    fun `logScreenView captures screen`() {
+        val windowManager = mock<IWindowManager>()
+        val context = ContextWrapper(ContextHolder.APP_CONTEXT)
+        withLogger(context = context, windowManager = windowManager) { logger ->
+            logger.logScreenView("test_screen")
+            verify(windowManager, timeout(1000)).getAllRootViews()
+        }
+    }
+
     private fun testServerUrl(): HttpUrl =
         HttpUrl
             .Builder()
@@ -474,6 +490,8 @@ class CaptureLoggerTest {
         fieldProvider: FieldProvider? = null,
         dateProvider: DateProvider = mock<DateProvider>(),
         sessionStrategy: SessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
+        context: android.content.Context = ContextHolder.APP_CONTEXT,
+        windowManager: IWindowManager = WindowManager(ErrorHandler()),
     ): LoggerImpl {
         val fieldProviders = fieldProvider?.let { listOf(it) }.orEmpty()
         val loggerImpl =
@@ -482,9 +500,10 @@ class CaptureLoggerTest {
                 apiUrl = testServerUrl(),
                 fieldProviders = fieldProviders,
                 sessionStrategy = sessionStrategy,
-                context = ContextHolder.APP_CONTEXT,
+                context = context,
                 dateProvider = dateProvider,
                 configuration = Configuration(),
+                windowManager = windowManager,
             )
         val sdkConfiguredDuration =
             LoggerImpl.SdkConfiguredDuration(

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -571,6 +571,8 @@ extension Logger: Logging {
     }
 
     public func logScreenView(screenName: String) {
+        // TODO(Fran): BIT-7953 reset replay timer
+        self.sessionReplayController?.captureScreen()
         self.underlyingLogger.logScreenView(screenName: screenName)
     }
 

--- a/test/platform/swift/unit_integration/core/LoggerTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerTests.swift
@@ -388,6 +388,21 @@ final class LoggerTests: XCTestCase {
         XCTAssertEqual(.completeUntilFirstUserAuthentication,
                        try! protection(at: bufferFile.path))
     }
+
+    func testLogScreenViewCapturesScreen() throws {
+        let logger = try Logger.testLogger(withAPIKey: "test_api_key")
+
+        let mockCoreLogging = MockCoreLogging()
+        let replayController = try XCTUnwrap(logger.sessionReplayController)
+        replayController.logger = mockCoreLogging
+
+        let expectation = self.expectation(description: "session replay screen log is emitted")
+        mockCoreLogging.logSessionReplayScreenExpectation = expectation
+
+        logger.logScreenView(screenName: "test_screen")
+
+        XCTAssertEqual(.completed, XCTWaiter().wait(for: [expectation], timeout: 1))
+    }
 }
 
 extension [Field] {


### PR DESCRIPTION
## What

Ensure we capture the most up to date session replay within manual `Capture.Logger.logScreenView` calls

## Verification

- [Android session](https://timeline.bitdrift.dev/session/02965b3c-ba49-4538-af60-e8f3ef2fbfb4?utm_source=sdk&utilization=0)
- [iOS session](https://timeline.bitdrift.dev/session/01ef272b-f202-46d2-ad49-e7a0d7bead51?utm_source=sdk)

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.