### PR TITLE
Added hedron_compile_commands to generate compile_commands.json

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,7 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_rust", version = "0.65.0")
 bazel_dep(name = "rules_shell", version = "0.4.0")
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 
 # Required by android_artifacts for pom_file, it's not in bazel central registry
 bazel_dep(name = "google_bazel_common", version = "0.0.1")
@@ -88,6 +89,12 @@ git_override(
     module_name = "google_bazel_common",
     commit = "c35b0339ae7d7ac95761f69f4a0eed033163cc80",
     remote = "https://github.com/google/bazel-common",
+)
+
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "abb61a688167623088f8768cc9264798df6a9d10",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
 )
 
 http_archive(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,7 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_rust", version = "0.65.0")
 bazel_dep(name = "rules_shell", version = "0.4.0")
+
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 
 # Required by android_artifacts for pom_file, it's not in bazel central registry

--- a/platform/swift/source/BUILD
+++ b/platform/swift/source/BUILD
@@ -7,6 +7,7 @@ load("@sdk_version//:sdk_version.bzl", "SDK_VERSION")
 load("//bazel:bitdrift_build_system.bzl", "bitdrift_rust_library")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("//bazel:swift_header_collector.bzl", "swift_header_collector")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 swift_library(
     name = "ios_lib",
@@ -184,3 +185,11 @@ docc_archive(
     transform_for_static_hosting = True,
     visibility = ["//visibility:public"],
 )
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    targets = {
+        "//platform/swift/source/...": "",
+    },
+)
+

--- a/platform/swift/source/BUILD
+++ b/platform/swift/source/BUILD
@@ -7,7 +7,6 @@ load("@sdk_version//:sdk_version.bzl", "SDK_VERSION")
 load("//bazel:bitdrift_build_system.bzl", "bitdrift_rust_library")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("//bazel:swift_header_collector.bzl", "swift_header_collector")
-load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 
 swift_library(
     name = "ios_lib",
@@ -185,11 +184,3 @@ docc_archive(
     transform_for_static_hosting = True,
     visibility = ["//visibility:public"],
 )
-
-refresh_compile_commands(
-    name = "refresh_compile_commands",
-    targets = {
-        "//platform/swift/source/...": "",
-    },
-)
-

--- a/platform/swift/source/compile_commands/BUILD
+++ b/platform/swift/source/compile_commands/BUILD
@@ -1,0 +1,8 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+    name = "refresh",
+    targets = {
+        "//platform/swift/source/...": "",
+    },
+)

--- a/platform/swift/source/default/events/resource/ResourceUtilizationController.swift
+++ b/platform/swift/source/default/events/resource/ResourceUtilizationController.swift
@@ -9,7 +9,7 @@ internal import CapturePassable
 import Foundation
 
 final class ResourceUtilizationController {
-    private let queue: DispatchQueue = .serial(withLabelSuffix: "ResourceUtilizationTarget", target: .heavy)
+    private let queue: DispatchQueue
 
     private let storageProvider: StorageProvider
     private let timeProvider: TimeProvider
@@ -25,7 +25,12 @@ final class ResourceUtilizationController {
         }
     }
 
-    init(storageProvider: StorageProvider, timeProvider: TimeProvider) {
+    init(
+        storageProvider: StorageProvider,
+        timeProvider: TimeProvider,
+        queue: DispatchQueue = .serial(withLabelSuffix: "ResourceUtilizationTarget", target: .heavy)
+    ) {
+        self.queue = queue
         self.storageProvider = storageProvider
         self.timeProvider = timeProvider
 

--- a/test/platform/swift/unit_integration/core/ResourceUtilizationTargetTest.swift
+++ b/test/platform/swift/unit_integration/core/ResourceUtilizationTargetTest.swift
@@ -13,7 +13,8 @@ final class ResourceUtilizationTargetTest: XCTestCase {
     func testTargetDoesNotCrash() {
         let target = ResourceUtilizationController(
             storageProvider: MockStorageProvider(),
-            timeProvider: MockTimeProvider()
+            timeProvider: MockTimeProvider(),
+            queue: .main
         )
 
         let logger = MockCoreLogging()

--- a/test/platform/swift/unit_integration/core/bridge/ResourceUtilizationControllerTests.swift
+++ b/test/platform/swift/unit_integration/core/bridge/ResourceUtilizationControllerTests.swift
@@ -25,7 +25,8 @@ final class ResourceUtilizationControllerTests: XCTestCase {
 
         self.target = ResourceUtilizationController(
             storageProvider: self.storageProvider,
-            timeProvider: self.timeProvider
+            timeProvider: self.timeProvider,
+            queue: .main
         )
 
         self.target.logger = self.logger
@@ -35,16 +36,16 @@ final class ResourceUtilizationControllerTests: XCTestCase {
         run_resource_utilization_target_test(self.target)
     }
 
-    func testEmitsDiskUsageFieldsOnceEvery24H() {
+    func testEmitsDiskUsageFieldsOnceEvery24H() throws {
         let firstLogExpectation = self.expectation(description: "resource utilization log is emitted")
         self.logger.logResourceUtilizationExpectation = firstLogExpectation
 
         self.target.tick()
 
-        XCTAssertEqual(.completed, XCTWaiter().wait(for: [firstLogExpectation], timeout: 0.5))
+        wait(for: [firstLogExpectation], timeout: 1.0)
         XCTAssertEqual(1, self.logger.resourceUtilizationLogs.count)
-        XCTAssertNotNil(self.logger.resourceUtilizationLogs[0]
-                            .fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
+        let firstLog = try XCTUnwrap(self.logger.resourceUtilizationLogs.first)
+        XCTAssertNotNil(firstLog.fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
 
         let secondLogExpectation = self.expectation(description: "resource utilization log is not emitted")
         self.logger.logResourceUtilizationExpectation = secondLogExpectation
@@ -52,10 +53,10 @@ final class ResourceUtilizationControllerTests: XCTestCase {
         self.target.tick()
 
         // App Disk Usage fields are not emitted within 24 hours of the previous emission of these logs.
-        XCTAssertEqual(.completed, XCTWaiter().wait(for: [secondLogExpectation], timeout: 0.5))
+        wait(for: [secondLogExpectation], timeout: 1.0)
         XCTAssertEqual(2, self.logger.resourceUtilizationLogs.count)
-        XCTAssertNil(self.logger.resourceUtilizationLogs[1]
-                        .fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
+        let secondLog = try XCTUnwrap(self.logger.resourceUtilizationLogs.last)
+        XCTAssertNil(secondLog.fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
 
         // Advance by more than 24 hours
         self.timeProvider.advanceBy(timeInterval: 25 * 60 * 60)
@@ -67,10 +68,10 @@ final class ResourceUtilizationControllerTests: XCTestCase {
 
         self.target.tick()
 
-        XCTAssertEqual(.completed, XCTWaiter().wait(for: [thirdLogExpectation], timeout: 0.5))
+        wait(for: [thirdLogExpectation], timeout: 1.0)
         XCTAssertEqual(3, self.logger.resourceUtilizationLogs.count)
-        XCTAssertNotNil(self.logger.resourceUtilizationLogs[2]
-                            .fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
+        let thirdLog = try XCTUnwrap(self.logger.resourceUtilizationLogs.last)
+        XCTAssertNotNil(thirdLog.fields[DiskUsageSnapshot.FieldKey.documentsDirectory.rawValue])
     }
 
     func testMemorySnapshotIncludesIsMemoryLowFieldWhenThresholdProvided() {


### PR DESCRIPTION
# Overview
This PR simply adds `hedron_compile_commands` as a dev dependency to generate a `compile_commands.json` (already included in `.gitignore`) for the Swift/ObjC platform code. This enables clangd to provide go-to-definition and cross-file navigation in c/c++/objc/objc++ files in some IDEs (e.g. nvim or [VSCode](https://github.com/hedronvision/bazel-compile-commands-extractor?tab=readme-ov-file#vscode)) . To use it, simply run:
```bash
bazel run //platform/swift/source/compile_commands:refresh
```

FWIW: Whenever `BUILD` changes, it's necessary to recreate the `compile_commands.json`.

Edit: based on comments, I moved `refresh_compile_commands` to a dedicated package to avoid loading `hedron_compile_commands` in the main `BUILD` file.