### PR TITLE
[Android] PreviousRunInfo < API 30 clean ups

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -267,9 +267,6 @@ object Capture {
          *
          * Must be called after [start]. Returns `null` if the logger is not initialized.
          *
-         * Note: on API 30, native crashes are reported as a fatal termination reason but do not
-         * trigger an `onBeforeSend` callback with the crash report. The `onBeforeSend` callback
-         * for native crashes is only available on API >= 31.
          */
         @JvmStatic
         @ExperimentalBitdriftApi

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
@@ -114,7 +114,7 @@ internal class PreviousRunInfoBelowApi30Store(
     private val preferences: IPreferences,
 ) {
     fun getPreviousState(): PreviousRunInfoBelowApi30State? =
-        preferences.getString(STATE_KEY)?.let(PreviousRunInfoBelowApi30State::fromName)
+        preferences.getString(STATE_KEY)?.let { PreviousRunInfoBelowApi30State.valueOf(it) }
 
     fun writeState(state: PreviousRunInfoBelowApi30State) {
         val blocking = state == PreviousRunInfoBelowApi30State.JvmCrash
@@ -131,10 +131,6 @@ internal enum class PreviousRunInfoBelowApi30State {
     Started,
     JvmCrash,
     ;
-
-    companion object {
-        fun fromName(value: String): PreviousRunInfoBelowApi30State? = runCatching { valueOf(value) }.getOrNull()
-    }
 }
 
 /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
@@ -9,33 +9,37 @@ package io.bitdrift.capture.reports.exitinfo
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
 import io.bitdrift.capture.IPreferences
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.IJvmCrashListener
+import io.bitdrift.capture.utils.BuildVersionChecker
 
 /**
  * Provides [PreviousRunInfo] for the previous app session.
  *
- * On API >= 30, uses [ApplicationExitInfo] directly.
- * On API < 30, relies on manually persisted previous-run state, including when a JVM crash was recorded.
+ * On API >= 30, uses [android.app.ApplicationExitInfo] directly.
+ * On API < 30, relies on manually persisted previous-run state and only reports JVM crashes as a
+ * fatal termination reason.
  */
 internal class PreviousRunInfoResolver(
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider,
     preferences: IPreferences,
     captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler,
+    private val buildVersionChecker: BuildVersionChecker = BuildVersionChecker(),
 ) : IPreviousRunInfoResolver,
     IJvmCrashListener {
-    private val previousRunInfoLegacyStore by lazy { LegacyPreviousRunStateStore(preferences) }
+    private val previousRunInfoBelowApi30Store by lazy { PreviousRunInfoBelowApi30Store(preferences) }
 
-    private val legacyPreviousRunState: LegacyPreviousRunState?
+    private val previousRunInfoBelowApi30State: PreviousRunInfoBelowApi30State?
 
     init {
         if (isBelowApi30()) {
-            legacyPreviousRunState = previousRunInfoLegacyStore.getPreviousState()
-            previousRunInfoLegacyStore.writeState(LegacyPreviousRunState.Started)
+            previousRunInfoBelowApi30State = previousRunInfoBelowApi30Store.getPreviousState()
+            previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.Started)
             captureUncaughtExceptionHandler.install(this)
         } else {
-            legacyPreviousRunState = null
+            previousRunInfoBelowApi30State = null
         }
     }
 
@@ -53,22 +57,22 @@ internal class PreviousRunInfoResolver(
         thread: Thread,
         throwable: Throwable,
     ) {
-        previousRunInfoLegacyStore.writeState(LegacyPreviousRunState.JvmCrash)
+        previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.JvmCrash)
     }
 
-    private fun isBelowApi30() = Build.VERSION.SDK_INT < Build.VERSION_CODES.R
+    private fun isBelowApi30() = !buildVersionChecker.isAtLeast(Build.VERSION_CODES.R)
 
     private fun getFromLegacyState(): PreviousRunInfo? {
-        val previousState = legacyPreviousRunState ?: return null
+        val previousState = previousRunInfoBelowApi30State ?: return null
 
         return when (previousState) {
-            LegacyPreviousRunState.JvmCrash ->
+            PreviousRunInfoBelowApi30State.JvmCrash ->
                 PreviousRunInfo(
                     hasFatallyTerminated = true,
                     terminationReason = ExitReason.JvmCrash,
                 )
 
-            LegacyPreviousRunState.Started -> PreviousRunInfo(hasFatallyTerminated = false)
+            PreviousRunInfoBelowApi30State.Started -> PreviousRunInfo(hasFatallyTerminated = false)
         }
     }
 
@@ -107,14 +111,16 @@ data class PreviousRunInfo(
     val terminationReason: ExitReason? = null,
 )
 
-internal class LegacyPreviousRunStateStore(
+@VisibleForTesting
+internal class PreviousRunInfoBelowApi30Store(
     private val preferences: IPreferences,
 ) {
-    fun getPreviousState(): LegacyPreviousRunState? = preferences.getString(STATE_KEY)?.let(LegacyPreviousRunState::fromStorageValue)
+    fun getPreviousState(): PreviousRunInfoBelowApi30State? =
+        preferences.getString(STATE_KEY)?.let(PreviousRunInfoBelowApi30State::fromName)
 
-    fun writeState(state: LegacyPreviousRunState) {
-        val blocking = state == LegacyPreviousRunState.JvmCrash
-        preferences.setString(STATE_KEY, state.value, blocking = blocking)
+    fun writeState(state: PreviousRunInfoBelowApi30State) {
+        val blocking = state == PreviousRunInfoBelowApi30State.JvmCrash
+        preferences.setString(STATE_KEY, state.name, blocking = blocking)
     }
 
     private companion object {
@@ -122,16 +128,14 @@ internal class LegacyPreviousRunStateStore(
     }
 }
 
-internal enum class LegacyPreviousRunState(
-    /** Stable text representation*/
-    val value: String,
-) {
-    Started("started"),
-    JvmCrash("jvm_crash"),
+@VisibleForTesting
+internal enum class PreviousRunInfoBelowApi30State {
+    Started,
+    JvmCrash,
     ;
 
     companion object {
-        fun fromStorageValue(value: String): LegacyPreviousRunState? = entries.firstOrNull { it.value == value }
+        fun fromName(value: String): PreviousRunInfoBelowApi30State? = runCatching { valueOf(value) }.getOrNull()
     }
 }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
@@ -114,7 +114,7 @@ internal class PreviousRunInfoBelowApi30Store(
     private val preferences: IPreferences,
 ) {
     fun getPreviousState(): PreviousRunInfoBelowApi30State? =
-        preferences.getString(STATE_KEY)?.let { PreviousRunInfoBelowApi30State.valueOf(it) }
+        preferences.getString(STATE_KEY)?.let { runCatching { PreviousRunInfoBelowApi30State.valueOf(it) }.getOrNull() }
 
     fun writeState(state: PreviousRunInfoBelowApi30State) {
         val blocking = state == PreviousRunInfoBelowApi30State.JvmCrash
@@ -130,7 +130,6 @@ internal class PreviousRunInfoBelowApi30Store(
 internal enum class PreviousRunInfoBelowApi30State {
     Started,
     JvmCrash,
-    ;
 }
 
 /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
@@ -34,7 +34,7 @@ internal class PreviousRunInfoResolver(
     private val previousRunInfoBelowApi30State: PreviousRunInfoBelowApi30State?
 
     init {
-        if (isBelowApi30()) {
+        if (!buildVersionChecker.isAtLeast(Build.VERSION_CODES.R)) {
             previousRunInfoBelowApi30State = previousRunInfoBelowApi30Store.getPreviousState()
             previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.Started)
             captureUncaughtExceptionHandler.install(this)
@@ -44,10 +44,10 @@ internal class PreviousRunInfoResolver(
     }
 
     override fun get(): PreviousRunInfo? =
-        if (isBelowApi30()) {
-            getFromLegacyState()
-        } else {
+        if (buildVersionChecker.isAtLeast(Build.VERSION_CODES.R)) {
             getFromAppExitInfo()
+        } else {
+            getFromBelowApi30State()
         }
 
     /**
@@ -60,9 +60,7 @@ internal class PreviousRunInfoResolver(
         previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.JvmCrash)
     }
 
-    private fun isBelowApi30() = !buildVersionChecker.isAtLeast(Build.VERSION_CODES.R)
-
-    private fun getFromLegacyState(): PreviousRunInfo? {
+    private fun getFromBelowApi30State(): PreviousRunInfo? {
         val previousState = previousRunInfoBelowApi30State ?: return null
 
         return when (previousState) {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -220,7 +220,7 @@ class AppExitLoggerTest {
         previousRunInfoStateStore.writeState(PreviousRunInfoBelowApi30State.Started)
         previousRunInfoStateStore.writeState(PreviousRunInfoBelowApi30State.JvmCrash)
 
-        assertThat(preferences.getString("io.bitdrift.capture.previous_run_info.state")).isEqualTo("jvm_crash")
+        assertThat(preferences.getString("io.bitdrift.capture.previous_run_info.state")).isEqualTo("JvmCrash")
     }
 
     @Test

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -15,7 +15,6 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.IInternalLogger
@@ -36,8 +35,8 @@ import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.reports.IssueReporterState
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitInfoProvider.Companion.EXIT_REASON_EXCEPTION_MESSAGE
-import io.bitdrift.capture.reports.exitinfo.LegacyPreviousRunState
-import io.bitdrift.capture.reports.exitinfo.LegacyPreviousRunStateStore
+import io.bitdrift.capture.reports.exitinfo.PreviousRunInfoBelowApi30State
+import io.bitdrift.capture.reports.exitinfo.PreviousRunInfoBelowApi30Store
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.utils.BuildVersionChecker
 import io.bitdrift.capture.utils.toStringMap
@@ -216,10 +215,10 @@ class AppExitLoggerTest {
 
     @Test
     fun previousRunInfoStateStore_persistsLegacyJvmCrashMarker() {
-        val previousRunInfoStateStore = LegacyPreviousRunStateStore(preferences)
+        val previousRunInfoStateStore = PreviousRunInfoBelowApi30Store(preferences)
 
-        previousRunInfoStateStore.writeState(LegacyPreviousRunState.Started)
-        previousRunInfoStateStore.writeState(LegacyPreviousRunState.JvmCrash)
+        previousRunInfoStateStore.writeState(PreviousRunInfoBelowApi30State.Started)
+        previousRunInfoStateStore.writeState(PreviousRunInfoBelowApi30State.JvmCrash)
 
         assertThat(preferences.getString("io.bitdrift.capture.previous_run_info.state")).isEqualTo("jvm_crash")
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
@@ -10,13 +10,16 @@ package io.bitdrift.capture.reports.exitinfo
 import android.app.ApplicationExitInfo
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
+import io.bitdrift.capture.utils.BuildVersionChecker
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -26,19 +29,27 @@ import org.robolectric.annotation.Config
 class PreviousRunInfoResolverTest {
     private val latestAppExitInfoProvider = FakeLatestAppExitInfoProvider()
     private val preferences = MockPreferences()
-    private val previousRunInfoStateStore = LegacyPreviousRunStateStore(preferences)
+    private val previousRunInfoBelowApi30Store = PreviousRunInfoBelowApi30Store(preferences)
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler = mock()
+    private val buildVersionChecker: BuildVersionChecker = mock()
 
     @Before
     fun tearDown() {
         latestAppExitInfoProvider.reset()
+        whenever(buildVersionChecker.isAtLeast(anyInt())).thenReturn(true)
     }
 
     @Test
     fun get_returnsFatalForCrashReason() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_CRASH)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
@@ -49,7 +60,13 @@ class PreviousRunInfoResolverTest {
     fun get_returnsFatalForNativeCrash() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_CRASH_NATIVE)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.NativeCrash),
@@ -60,7 +77,13 @@ class PreviousRunInfoResolverTest {
     fun get_returnsFatalForAnr() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_ANR)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.AppNotResponding),
@@ -71,7 +94,13 @@ class PreviousRunInfoResolverTest {
     fun get_returnsNonFatalForUserRequested() {
         latestAppExitInfoProvider.setAsValidReason(exitReasonType = ApplicationExitInfo.REASON_USER_REQUESTED)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = false, terminationReason = ExitReason.UserRequested),
@@ -82,7 +111,13 @@ class PreviousRunInfoResolverTest {
     fun get_returnsNonFatalWhenNoExitInfo() {
         latestAppExitInfoProvider.setAsEmptyReason()
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false))
     }
@@ -91,36 +126,61 @@ class PreviousRunInfoResolverTest {
     fun get_returnsNullOnError() {
         latestAppExitInfoProvider.setAsErrorResult()
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isNull()
     }
 
     @Test
-    @Config(sdk = [24])
     fun get_belowApi30_returnsNullWhenNoPreviousStateWasPersisted() {
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        whenever(buildVersionChecker.isAtLeast(android.os.Build.VERSION_CODES.R)).thenReturn(false)
+
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isNull()
     }
 
     @Test
-    @Config(sdk = [24])
     fun get_belowApi30_returnsNonFatalWhenStartedStateWasPersisted() {
-        previousRunInfoStateStore.writeState(LegacyPreviousRunState.Started)
+        whenever(buildVersionChecker.isAtLeast(android.os.Build.VERSION_CODES.R)).thenReturn(false)
+        previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.Started)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false))
     }
 
     @Test
-    @Config(sdk = [24])
     fun get_belowApi30_returnsJvmCrashWhenCrashMarkerWasPersisted() {
-        previousRunInfoStateStore.writeState(LegacyPreviousRunState.Started)
-        previousRunInfoStateStore.writeState(LegacyPreviousRunState.JvmCrash)
+        whenever(buildVersionChecker.isAtLeast(android.os.Build.VERSION_CODES.R)).thenReturn(false)
+        previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.Started)
+        previousRunInfoBelowApi30Store.writeState(PreviousRunInfoBelowApi30State.JvmCrash)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isEqualTo(
             PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
@@ -128,27 +188,33 @@ class PreviousRunInfoResolverTest {
     }
 
     @Test
-    @Config(sdk = [24])
     fun get_belowApi30_ignoresUnknownPersistedState() {
+        whenever(buildVersionChecker.isAtLeast(android.os.Build.VERSION_CODES.R)).thenReturn(false)
         preferences.setString("io.bitdrift.capture.previous_run_info.state", "unknown", blocking = true)
 
-        val result = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
+        val result =
+            PreviousRunInfoResolver(
+                latestAppExitInfoProvider,
+                preferences,
+                captureUncaughtExceptionHandler,
+                buildVersionChecker,
+            ).get()
 
         assertThat(result).isNull()
     }
 
     @Test
-    @Config(sdk = [24])
     fun init_belowApi30_shouldInstallCrashHandler() {
-        val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler)
+        whenever(buildVersionChecker.isAtLeast(android.os.Build.VERSION_CODES.R)).thenReturn(false)
+
+        val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler, buildVersionChecker)
 
         verify(captureUncaughtExceptionHandler).install(resolver)
     }
 
     @Test
-    @Config(sdk = [30])
     fun init_Api30_shouldNotInstallCrashHandler() {
-        val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler)
+        val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler, buildVersionChecker)
 
         verify(captureUncaughtExceptionHandler, never()).install(resolver)
     }


### PR DESCRIPTION
## What

Addressing follow up nits from https://github.com/bitdriftlabs/capture-sdk/pull/944

## Verification

Verified again with helloworld release app 

- [Regular launch](https://timeline.bitdrift.dev/session/55818dc7-1519-4cdf-8f48-ab8b5b3da607?utm_source=sdk&utilization=0&expanded=8401691852684409464) 
- [Launch after crash](https://timeline.bitdrift.dev/session/96a4c400-df7b-43be-8316-3e75d558e0a7?utm_source=sdk&utilization=0&expanded=-6041269444413404957) 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.