### PR TITLE
[Android] [WebView] Adding killswitch

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/webview/WebViewCapture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/webview/WebViewCapture.kt
@@ -14,11 +14,14 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.Capture.LOG_TAG
+import io.bitdrift.capture.CaptureRuntimeProvider
 import io.bitdrift.capture.IInternalLogger
 import io.bitdrift.capture.ILogger
+import io.bitdrift.capture.IRuntimeProvider
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.LogType
 import io.bitdrift.capture.LoggerImpl
+import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.fieldsOf
@@ -70,6 +73,7 @@ internal object WebViewCapture {
     fun instrument(
         webview: WebView,
         logger: ILogger? = null,
+        runtimeProvider: IRuntimeProvider = CaptureRuntimeProvider,
     ) {
         val effectiveLogger = logger ?: Capture.logger()
 
@@ -80,6 +84,10 @@ internal object WebViewCapture {
                 "WebView instrumentation skipped: SDK still not initialized. " +
                     "Call Capture.Logger.start() before instrumenting WebViews.",
             )
+            return
+        }
+
+        if (!runtimeProvider.isRuntimeFeatureEnabled(RuntimeFeature.WEBVIEW_INSTRUMENTATION)) {
             return
         }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/webview/WebViewCaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/webview/WebViewCaptureTest.kt
@@ -10,13 +10,17 @@ package io.bitdrift.capture.webview
 import android.content.Context
 import android.webkit.WebView
 import androidx.test.core.app.ApplicationProvider
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.ContextHolder
+import io.bitdrift.capture.IRuntimeProvider
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.LogType
 import io.bitdrift.capture.LoggerImpl
@@ -39,6 +43,7 @@ class WebViewCaptureTest {
     private lateinit var appContext: Context
     private val fieldsCaptor = argumentCaptor<ArrayFields>()
     private val messageCaptor = argumentCaptor<() -> String>()
+    private val runtimeProvider: IRuntimeProvider = mock()
 
     @Before
     fun setup() {
@@ -98,6 +103,26 @@ class WebViewCaptureTest {
             messageCaptor.capture(),
         )
         assertThat(messageCaptor.firstValue()).isEqualTo("WebView bridge script injected successfully")
+    }
+
+    @Test
+    fun instrument_withRuntimeFeatureDisabled_shouldSkipInstrumentation() {
+        startSdk(webViewConfiguration = WebViewConfiguration())
+        whenever(runtimeProvider.isRuntimeFeatureEnabled(any())).thenReturn(false)
+
+        WebViewCapture.instrument(webView, Capture.logger(), runtimeProvider)
+
+        assertThat(webView.settings.javaScriptEnabled).isFalse()
+    }
+
+    @Test
+    fun instrument_withRuntimeFeatureEnabled_shouldProceedWithInstrumentation() {
+        startSdk(webViewConfiguration = WebViewConfiguration())
+        whenever(runtimeProvider.isRuntimeFeatureEnabled(any())).thenReturn(true)
+
+        WebViewCapture.instrument(webView, Capture.logger(), runtimeProvider)
+
+        assertThat(webView.settings.javaScriptEnabled).isTrue()
     }
 
     private fun startSdk(webViewConfiguration: WebViewConfiguration?) {

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -62,6 +62,11 @@ sealed class RuntimeFeature(
      * Whether Dropped Frames reporting is enabled
      */
     data object DROPPED_EVENTS_MONITORING : RuntimeFeature("client_feature.android.dropped_frames_reporting", defaultValue = true)
+
+    /**
+     * Whether WebView Instrumentation is enabled
+     */
+    data object WEBVIEW_INSTRUMENTATION : RuntimeFeature("client_feature.android.webview_instrumentation", defaultValue = true)
 }
 
 /**


### PR DESCRIPTION
## What

Resolves BIT-7295

Adding a killswitch for webview instrumentation in Android (`client_feature.android.webview_instrumentation`).

## Verification

- [Session with flag enabled](https://timeline.bitdrift.dev/session/ce8539ce-e512-41dc-aeb1-4445bf0bad3f?utm_source=sdk&utilization=0&expanded=6665255354122774715)
- [Session with flag disabled](https://timeline.bitdrift.dev/s/34f34892-c934-4b10-9aeb-d11c2d0895e7?utm_source=sdk)
- [Session with local plugin changes](https://timeline.bitdrift.dev/session/aada38a0-ef00-447a-b469-0f2434a5acee?utm_source=sdk&utilization=0&expanded=-5526678415853765941)
 
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.