### PR TITLE
[Tracing] Exclude tracing for configured paths

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
@@ -39,6 +39,18 @@ class CaptureOkHttpTracingInterceptor
 
         private val traceContextFactory by lazy { TraceContextFactory() }
 
+        private val excludedPathPrefixes by lazy {
+            val pathPrefixesToExcludeAsCsv =
+                runtimeProvider.getRuntimeStringConfigValue(
+                    RuntimeStringConfig.TRACING_EXCLUDED_PATH_PREFIXES_CSV,
+                )
+            if (pathPrefixesToExcludeAsCsv.isEmpty()) {
+                emptyList()
+            } else {
+                pathPrefixesToExcludeAsCsv.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+            }
+        }
+
         override fun intercept(chain: Interceptor.Chain): Response {
             val currentLogger = Capture.logger()
             val request = chain.request()
@@ -86,7 +98,15 @@ class CaptureOkHttpTracingInterceptor
         ): Boolean =
             currentLogger.isTracingActive &&
                 propagationMode != TracePropagationMode.NONE &&
-                !isBitdriftInternalRequest(request)
+                !isBitdriftInternalRequest(request) &&
+                !isTracingDisabledForRequest(request)
+
+        private fun isTracingDisabledForRequest(request: Request): Boolean =
+            if (excludedPathPrefixes.isEmpty()) {
+                false
+            } else {
+                excludedPathPrefixes.any { request.url.encodedPath.startsWith(it, ignoreCase = true) }
+            }
 
         private fun isBitdriftInternalRequest(request: Request): Boolean = request.header(BITDRIFT_API_KEY_HEADER) != null
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptorTest.kt
@@ -17,12 +17,18 @@ import io.bitdrift.capture.fakes.FakeOkHttpInterceptorChain
 import okhttp3.Request
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import java.util.concurrent.atomic.AtomicReference
 
 class CaptureOkHttpTracingInterceptorTest {
     private val runtimeProvider: IRuntimeProvider = mock()
+
+    @Before
+    fun setUp() {
+        setExcludedPathPrefixes("")
+    }
 
     @After
     fun tearDown() {
@@ -265,8 +271,93 @@ class CaptureOkHttpTracingInterceptorTest {
         assertThat(captured.headers.size).isEqualTo(request.headers.size)
     }
 
+    @Test
+    fun intercept_whenPathIsExcluded_shouldNotAddHeaders() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("w3c")
+        setExcludedPathPrefixes("/opentelemetry.proto.collector.")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain =
+            FakeOkHttpInterceptorChain(
+                Request.Builder().url("https://localhost/opentelemetry.proto.collector.trace.v1.TraceService/Export").build(),
+            )
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        assertThat(request.header("traceparent")).isNull()
+    }
+
+    @Test
+    fun intercept_whenPathIsNotExcluded_shouldAddHeaders() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("w3c")
+        setExcludedPathPrefixes("/opentelemetry.proto.collector.")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://localhost/api/users").build())
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        assertThat(request.header("traceparent")).isNotNull()
+    }
+
+    @Test
+    fun intercept_whenExcludedPathPrefixesCsvIsEmpty_shouldAddHeaders() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("w3c")
+        setExcludedPathPrefixes("")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        assertThat(request.header("traceparent")).isNotNull()
+    }
+
+    @Test
+    fun intercept_whenExcludedPathPrefixesCsvHasOnlyCommas_shouldAddHeaders() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("w3c")
+        setExcludedPathPrefixes(",,,")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com/api").build())
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        assertThat(request.header("traceparent")).isNotNull()
+    }
+
+    @Test
+    fun intercept_whenExcludedPathPrefixesCsvHasSpacesAroundCommas_shouldStillMatch() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("w3c")
+        setExcludedPathPrefixes(" /opentelemetry.proto.collector. , /v1/metrics ")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain =
+            FakeOkHttpInterceptorChain(
+                Request.Builder().url("https://localhost/opentelemetry.proto.collector.trace.v1.TraceService/Export").build(),
+            )
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        assertThat(request.header("traceparent")).isNull()
+    }
+
     private fun setPropagationMode(value: String) {
         whenever(runtimeProvider.getRuntimeStringConfigValue(RuntimeStringConfig.TRACE_PROPAGATION_MODE)).thenReturn(value)
+    }
+
+    private fun setExcludedPathPrefixes(value: String) {
+        whenever(runtimeProvider.getRuntimeStringConfigValue(RuntimeStringConfig.TRACING_EXCLUDED_PATH_PREFIXES_CSV)).thenReturn(value)
     }
 
     private fun setActiveTracingState(isActiveTracingEnabled: Boolean) {

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -141,6 +141,12 @@ sealed class RuntimeStringConfig(
      * - "b3-multi": use the Zipkin B3 `X-B3-*` headers
      */
     data object TRACE_PROPAGATION_MODE : RuntimeStringConfig("client_config.trace.propagation_mode", "w3c")
+
+    /**
+     * Comma-separated list of path prefixes to exclude from trace header injection.
+     * Requests whose path starts with any of these prefixes will not have trace propagation headers added.
+     */
+    data object TRACING_EXCLUDED_PATH_PREFIXES_CSV : RuntimeStringConfig("client_config.trace.excluded_path_prefixes_csv", "")
 }
 
 /**

--- a/platform/swift/source/RuntimeVariable.swift
+++ b/platform/swift/source/RuntimeVariable.swift
@@ -128,4 +128,10 @@ extension RuntimeVariable<String> {
         name: "client_config.trace.propagation_mode",
         defaultValue: "w3c"
     )
+
+    /// Comma-separated list of path prefixes to exclude from trace header injection.
+    static let tracingExcludedPathPrefixesCsv = RuntimeVariable(
+        name: "client_config.trace.excluded_path_prefixes_csv",
+        defaultValue: ""
+    )
 }

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -58,6 +58,16 @@ final class URLSessionIntegration {
     fileprivate static var swizzled = Atomic(false)
     static let shared = URLSessionIntegration()
 
+    private lazy var excludedPathPrefixes: [String] = {
+        guard let logger = Logger.getShared() as? Logger else { return [] }
+        let pathPrefixesToExcludeAsCsv = logger.runtimeValue(.tracingExcludedPathPrefixesCsv)
+        guard !pathPrefixesToExcludeAsCsv.isEmpty else { return [] }
+        return pathPrefixesToExcludeAsCsv
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }()
+
     var logger: Logging? {
         return self.underlyingLogger.load()
     }
@@ -81,6 +91,12 @@ final class URLSessionIntegration {
 
     var isTracingActive: Bool {
         (Logger.getShared() as? Logger)?.isTracingActive == true
+    }
+
+    func isTracingDisabledForRequest(_ url: URL?) -> Bool {
+        guard let path = url?.path else { return false }
+        if excludedPathPrefixes.isEmpty { return false }
+        return excludedPathPrefixes.contains { path.hasPrefix($0) }
     }
 
     func start(

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -63,6 +63,10 @@ final class URLSessionTaskTracker {
             return nil
         }
 
+        guard !integration.isTracingDisabledForRequest(task.originalRequest?.url) else {
+            return nil
+        }
+
         let traceContext = URLSessionTraceContext.make()
         task.cap_traceContext = traceContext
         return traceContext

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -40,6 +40,10 @@ extension URLSessionTask {
             return
         }
 
+        guard !integration.isTracingDisabledForRequest(self.originalRequest?.url) else {
+            return
+        }
+
         if URLSessionTracePropagation.hasExistingTraceHeaders(in: existingHeaders) {
             self.cap_hasExistingTraceHeaders = true
             if let sampledTraceID = URLSessionTracePropagation.extractSampledTraceID(from: existingHeaders) {


### PR DESCRIPTION
## What

Resolves BIT-8130

## Runtime configuration

`client_config.trace.excluded_path_prefixes_csv`

## Verification

Android verification with runtime config excluding `/data/2021/pep/population` 

[Session](https://timeline.bitdrift.dev/session/c1b082ec-ea15-45d4-bece-a291a6d3bb6b?utm_source=sdk&utilization=0&expanded=-7166318999005497722)

With excluded path 
<img width="992" height="80" alt="Screenshot 2026-04-30 at 12 52 48" src="https://github.com/user-attachments/assets/c496e6b4-50e4-4859-a27f-2220cdea2a0c" />

With valid path

<img width="898" height="72" alt="Screenshot 2026-04-30 at 12 49 07" src="https://github.com/user-attachments/assets/bf6d424b-cafc-4330-9617-f96aa0f8343a" />


---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.