### PR TITLE
Add start/failure callback result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 **Added**
 
-- Nothing yet!
+- Add optional `startResult` callback to `start` method that reports success with the logger instance or failure with error details.
 
 **Changed**
 

--- a/examples/objective-c/CAPViewController.m
+++ b/examples/objective-c/CAPViewController.m
@@ -197,7 +197,14 @@ NSString *logLevelToString(LogLevel level) {
      sessionStrategy:self.sessionStrategy == CAPSampleSessionStrategyActivityBased
          ? [CAPSessionStrategy activityBased]
          : [CAPSessionStrategy fixed]
-      configuration: config
+      configuration:config
+        startResult:^(NSError * _Nullable error) {
+            if (error) {
+                NSLog(@"Capture SDK start failed: %@", error.localizedDescription);
+            } else {
+                NSLog(@"Capture SDK started successfully");
+            }
+        }
     ];
 
     [CAPLogger logInfo:@"An objective-c example app is launching" fields:nil];

--- a/examples/swift/hello_world/LoggerCustomer.swift
+++ b/examples/swift/hello_world/LoggerCustomer.swift
@@ -102,7 +102,18 @@ final class LoggerCustomer: NSObject, URLSessionDelegate {
                     apiURL: apiURL,
                     issueCallbackConfiguration: issueCallbackConfiguration
                 ),
-                fieldProviders: [CustomFieldProvider()]
+                fieldProviders: [CustomFieldProvider()],
+                startResult: { result in
+                    switch result {
+                    case .success(let logger):
+                        print("SDK started successfully. " +
+                                "sessionID=\(logger.sessionID), " +
+                                "sessionURL=\(logger.sessionURL), " +
+                                "deviceID=\(logger.deviceID)")
+                    case .failure(let error):
+                        print("SDK failed to start: \(error)")
+                    }
+                }
             )?
             .enableIntegrations(
                 [.urlSession(

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -132,7 +132,11 @@ object Capture {
          *               instructed otherwise during discussions with bitdrift. Defaults to bitdrift's hosted
          *               Compose API base URL.
          * @param context an optional context reference. You should provide the context if called from
-         * a [android.content.ContentProvider]
+         * a [android.content.ContentProvider].
+         * @param startResult an optional callback invoked with the result of the SDK initialization.
+         *                     The callback is always called on the calling thread before [start] returns.
+         *                     On success, it receives a [CaptureResult.Success] containing an [ILogger] instance.
+         *                     On failure, it receives a [CaptureResult.Failure] with a [SdkStartFailure].
          */
         @Synchronized
         @JvmStatic
@@ -145,6 +149,7 @@ object Capture {
             dateProvider: DateProvider? = null,
             apiUrl: HttpUrl = defaultCaptureApiUrl,
             context: Context? = null,
+            startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
         ) {
             start(
                 apiKey,
@@ -155,6 +160,7 @@ object Capture {
                 apiUrl,
                 CaptureJniLibrary,
                 context,
+                startResult,
             )
         }
 
@@ -172,13 +178,13 @@ object Capture {
             apiUrl: HttpUrl = defaultCaptureApiUrl,
             bridge: IBridge,
             context: Context? = null,
+            startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
         ) {
             // There's nothing we can do if we don't have yet access to the application context.
             if (hasInvalidContext(context)) {
-                Log.w(
-                    LOG_TAG,
-                    "Attempted to initialize Capture with a null context",
-                )
+                val errorMessage = "Attempted to initialize Capture with a null context"
+                Log.w(LOG_TAG, errorMessage)
+                startResult?.invoke(CaptureResult.Failure(SdkStartFailure(errorMessage)))
                 return
             }
 
@@ -193,6 +199,7 @@ object Capture {
                     apiUrl = apiUrl,
                     bridge = bridge,
                     context = context,
+                    startResult = startResult,
                 )
             } else {
                 Log.w(LOG_TAG, "Multiple attempts to start Capture")
@@ -658,6 +665,7 @@ object Capture {
         apiUrl: HttpUrl,
         bridge: IBridge,
         context: Context?,
+        startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
     ) {
         try {
             val startSdkTimer = TimeSource.Monotonic.markNow()
@@ -710,9 +718,13 @@ object Capture {
                 sdkConfiguredDuration = sdkConfiguredDuration,
                 captureStartThread = Thread.currentThread().name,
             )
-        } catch (e: Throwable) {
-            Log.w(LOG_TAG, "Failed to start Capture", e)
+
+            startResult?.invoke(CaptureResult.Success(loggerImpl))
+        } catch (throwable: Throwable) {
+            val errorDetails = "Failed to start Capture: ${throwable.message}"
+            Log.w(LOG_TAG, errorDetails, throwable)
             default.set(LoggerState.StartFailure)
+            startResult?.invoke(CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)))
         }
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Models.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Models.kt
@@ -77,3 +77,16 @@ sealed class ApiError(
  * Represents a failed operation due to the SDK not being started
  */
 data object SdkNotStartedError : Error("SDK not started")
+
+/**
+ * Represents a failure during SDK initialization.
+ * This error is returned via the [Capture.Logger.start] result callback when the SDK
+ * fails to initialize.
+ *
+ * @param reason A message describing what went wrong during initialization.
+ * @param cause The underlying throwable that caused the failure, if any.
+ */
+data class SdkStartFailure(
+    val reason: String,
+    val cause: Throwable? = null,
+) : Error(reason)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -59,6 +59,25 @@ class CaptureTest {
         assertThat(Capture.logger()).isNull()
     }
 
+    @Test
+    fun aStart_withNullContext_emitsFailureCallback() {
+        var capturedResult: CaptureResult<ILogger>? = null
+
+        Logger.start(
+            apiKey = "test1",
+            sessionStrategy = SessionStrategy.Fixed(),
+            dateProvider = null,
+            context = null,
+        ) { result ->
+            capturedResult = result
+        }
+
+        assertThat(capturedResult).isInstanceOf(CaptureResult.Failure::class.java)
+        val failure = capturedResult as CaptureResult.Failure
+        assertThat(failure.error).isInstanceOf(SdkStartFailure::class.java)
+        assertThat(failure.error.message).contains("null context")
+    }
+
     // Accessing fields prior to the configuration of the logger may lead to crash since it can
     // potentially call into a native method that's used to sanitize passed url path.
     @Test
@@ -97,15 +116,26 @@ class CaptureTest {
 
         assertThat(Capture.logger()).isNull()
 
+        var capturedResult: CaptureResult<ILogger>? = null
+
         Logger.start(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
-        )
+        ) { result ->
+            capturedResult = result
+        }
 
         val logger = Capture.logger()
         assertThat(logger).isNotNull()
         assertThat(Logger.deviceId).isNotNull()
+
+        // Verify completion callback emits success with expected properties.
+        assertThat(capturedResult).isInstanceOf(CaptureResult.Success::class.java)
+        val success = capturedResult as CaptureResult.Success
+        assertThat(success.value.sessionId).isNotEmpty()
+        assertThat(success.value.sessionUrl).isNotEmpty()
+        assertThat(success.value.deviceId).isNotEmpty()
 
         Logger.start(
             apiKey = "test2",

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
@@ -118,6 +118,52 @@ class ConfigurationTest {
         )
     }
 
+    @Test
+    fun startResult_emitsFailure_whenBridgeReturnsInvalidLogger() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+
+        val bridge: IBridge = mock {}
+        whenever(
+            bridge.createLogger(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+            ),
+        ).thenReturn(-1L)
+
+        var capturedResult: CaptureResult<ILogger>? = null
+
+        Capture.Logger.start(
+            apiKey = "test1",
+            sessionStrategy = SessionStrategy.Fixed(),
+            dateProvider = null,
+            bridge = bridge,
+        ) { result ->
+            capturedResult = result
+        }
+
+        Assertions.assertThat(capturedResult).isInstanceOf(CaptureResult.Failure::class.java)
+        val failure = capturedResult as CaptureResult.Failure
+        val error = failure.error as SdkStartFailure
+        Assertions.assertThat(error.reason).startsWith("Failed to start Capture:")
+        Assertions.assertThat(error.cause).isNotNull()
+    }
+
     @After
     fun tearDown() {
         Capture.Logger.resetShared()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
@@ -12,6 +12,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.Capture.Logger.sessionUrl
+import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.providers.FieldProvider
@@ -105,7 +106,20 @@ object BitdriftInit {
                     sessionStrategy = settings.sessionStrategy,
                     fieldProviders = settings.fieldProviders,
                     context = context,
-                )
+                ) { result ->
+                    when (result) {
+                        is CaptureResult.Success -> {
+                            val logger = result.value
+                            Log.i("GradleTestApp", "SDK started successfully. " +
+                                "sessionId=${logger.sessionId}, " +
+                                "sessionUrl=${logger.sessionUrl}, " +
+                                "deviceId=${logger.deviceId}")
+                        }
+                        is CaptureResult.Failure -> {
+                            Log.e("GradleTestApp", "SDK failed to start: ${result.error.message}")
+                        }
+                    }
+                }
                 Log.i("GradleTestApp", "Session initialized " + Capture.Logger.sessionUrl)
                 return true
             }

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -43,6 +43,9 @@ extension Logger {
     /// - parameter fieldProviders:  An optional array of additional FieldProviders to include on the default
     ///                              Logger.
     /// - parameter dateProvider:    An optional date provider to set on the default logger.
+    /// - parameter startResult:     An optional callback invoked with the result of the SDK initialization.
+    ///                              The callback is always called on the calling thread before `start` returns.
+    ///                              On success, it receives a `Logging` instance. On failure, it receives an error.
     ///
     /// - returns: A logger integrator that can be used to enable various SDK integration.
     @discardableResult
@@ -51,7 +54,8 @@ extension Logger {
         sessionStrategy: SessionStrategy,
         configuration: Configuration = .init(),
         fieldProviders: [FieldProvider] = [],
-        dateProvider: DateProvider? = nil
+        dateProvider: DateProvider? = nil,
+        startResult: ((Result<Logging, Swift.Error>) -> Void)? = nil
     ) -> LoggerIntegrator?
     {
         return self.start(
@@ -60,7 +64,8 @@ extension Logger {
             configuration: configuration,
             fieldProviders: fieldProviders,
             dateProvider: dateProvider,
-            loggerBridgingFactoryProvider: LoggerBridgingFactory()
+            loggerBridgingFactoryProvider: LoggerBridgingFactory(),
+            startResult: startResult
         )
     }
 
@@ -71,10 +76,11 @@ extension Logger {
         configuration: Configuration,
         fieldProviders: [FieldProvider],
         dateProvider: DateProvider?,
-        loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider
+        loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider,
+        startResult: ((Result<Logging, Swift.Error>) -> Void)? = nil
     ) -> LoggerIntegrator?
     {
-        return self.createOnce {
+        return self.createOnce(startResult: startResult) {
             let logger = Logger(
                 withAPIKey: apiKey,
                 configuration: configuration,

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -122,8 +122,8 @@ public final class Logger {
         storageProvider: StorageProvider,
         timeProvider: TimeProvider,
         networkDelegateQueue: DispatchQueue = .network,
-        loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider = LoggerBridgingFactory()
-    )
+        loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider = LoggerBridgingFactory(),
+        )
     {
         self.timeProvider = timeProvider
         let start = timeProvider.uptime()
@@ -358,7 +358,10 @@ public final class Logger {
 
     // MARK: - Static
 
-    static func createOnce(_ createLogger: () -> Logger?) -> LoggerIntegrator? {
+    static func createOnce(
+        startResult: ((Result<Logging, Swift.Error>) -> Void)? = nil,
+        _ createLogger: () -> Logger?
+    ) -> LoggerIntegrator? {
         let state = self.syncedShared.update { state in
             guard case .notStarted = state else {
                 return
@@ -371,11 +374,13 @@ public final class Logger {
             }
         }
 
-        return switch state {
-        case .started(let logger):
-            logger
+        switch state {
+        case .started(let integrator):
+            startResult?(.success(integrator.logger))
+            return integrator
         case .notStarted, .startFailure:
-            nil
+            startResult?(.failure(SDKNotStartedfError()))
+            return nil
         }
     }
 

--- a/platform/swift/source/LoggerObjc.swift
+++ b/platform/swift/source/LoggerObjc.swift
@@ -192,6 +192,73 @@ public final class LoggerObjc: NSObject {
         }
     }
 
+    /// Initializes the Capture SDK with the specified API key and session strategy.
+    /// Calling other SDK methods has no effect unless the logger has been initialized.
+    /// Subsequent calls to this function will have no effect.
+    ///
+    /// - parameter apiKey:          The API key provided by bitdrift.
+    /// - parameter sessionStrategy: A session strategy for the management of session IDs.
+    /// - parameter startResult:     A callback invoked with the result of the SDK initialization.
+    ///                              Called on the calling thread before `start` returns.
+    ///                              Receives nil on success, or an error on failure.
+    @objc
+    public static func start(
+        withAPIKey apiKey: String,
+        sessionStrategy: SessionStrategyObjc,
+        startResult: @escaping (Error?) -> Void
+    ) {
+        Capture.Logger
+            .start(
+                withAPIKey: apiKey,
+                sessionStrategy: sessionStrategy.underlyingSessionStrategy,
+                startResult: { result in
+                    switch result {
+                    case .success:
+                        startResult(nil)
+                    case .failure(let error):
+                        startResult(error)
+                    }
+                }
+            )
+    }
+
+    /// Initializes the Capture SDK with the specified API key and session strategy.
+    /// Calling other SDK methods has no effect unless the logger has been initialized.
+    /// Subsequent calls to this function will have no effect.
+    ///
+    /// - parameter apiKey:          The API key provided by bitdrift.
+    /// - parameter sessionStrategy: A session strategy for the management of session IDs.
+    /// - parameter configuration:   Additional options for the Capture Logger.
+    /// - parameter startResult:     A callback invoked with the result of the SDK initialization.
+    ///                              Called on the calling thread before `start` returns.
+    ///                              Receives nil on success, or an error on failure.
+    @objc
+    public static func start(
+        withAPIKey apiKey: String,
+        sessionStrategy: SessionStrategyObjc,
+        configuration: CAPConfiguration,
+        startResult: @escaping (Error?) -> Void
+    ) {
+        let logger = Capture.Logger
+            .start(
+                withAPIKey: apiKey,
+                sessionStrategy: sessionStrategy.underlyingSessionStrategy,
+                configuration: configuration.underlyingConfig,
+                startResult: { result in
+                    switch result {
+                    case .success:
+                        startResult(nil)
+                    case .failure(let error):
+                        startResult(error)
+                    }
+                }
+            )
+
+        if let logger, configuration.enableURLSessionIntegration {
+            logger.enableIntegrations([.urlSession()], disableSwizzling: false)
+        }
+    }
+
     /// Sets the operation mode of the logger, where activating sleep mode
     /// reduces activity to a minimal level
     ///


### PR DESCRIPTION
## What

Part of BIT-8084

Adds optional `startResult` callback to `Capture.Logger.start`. Customers can use this to determine if sdk was started successfully

Separate "status" sync API is implemented in https://github.com/bitdriftlabs/capture-sdk/pull/984

## Verification

Check logcat/println in sample apps

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.