### PR TITLE
Removing actool from being built in CI

### DIFF
--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -7,7 +7,7 @@ load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 APP_ICONS = glob(["AppAssets.xcassets/AppIcon.appiconset/**"])
 
-APP_ICONS = select({
+CI_APP_ICONS = select({
     "//bazel:is_ci": [],
     "//conditions:default": APP_ICONS,
 })
@@ -66,7 +66,7 @@ swift_library(
 
 ios_application(
     name = "ios_app",
-    app_icons = APP_ICONS,
+    app_icons = CI_APP_ICONS,
     bundle_id = "io.bitdrift.example.swiftapp.helloworld",
     bundle_name = "Bitdrift Sample App",
     entitlements = "Protected.entitlements",
@@ -104,7 +104,7 @@ swift_library(
 
 ios_application(
     name = "hello_world_app",
-    app_icons = APP_ICONS,
+    app_icons = CI_APP_ICONS,
     bundle_id = "io.bitdrift.example.swiftapp.helloworld",
     bundle_name = "Bitdrift Sample App",
     entitlements = "Protected.entitlements",

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -7,6 +7,11 @@ load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 APP_ICONS = glob(["AppAssets.xcassets/AppIcon.appiconset/**"])
 
+APP_ICONS = select({
+    "//bazel:is_ci": [],
+    "//conditions:default": APP_ICONS,
+})
+
 genrule(
     name = "expanded_xcframework",
     srcs = ["//:ios_xcframework_with_rust_symbols"],


### PR DESCRIPTION
# Overview
On `macos-26` runners, the `swift_hello_world` CI job was failing during `AssetCatalogCompile`. Seems that `actool` requires a simulator runtime that matches the active Xcode's SDK version. While Xcode 26.0.1 is installed on the runner and its iOS 26.0 SDK is available, the iOS 26.0 simulator runtime is not pre-installed.

To fix it, we basically dont include assets on CI builds. This has no impact on release or local builds, which continue to include the app icons as before.
