### PR TITLE
Added internal logging to the report enrichment process

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -120,7 +120,8 @@ jobs:
       - name: "Install dependencies"
         run: ./ci/mac_ci_setup.sh
       - name: Run iOS tests
-        run: env -u ANDROID_NDK_HOME ./bazelw test $(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)') --test_tag_filters=macos_only --test_output=errors --config ci --config ios
+        # Bypass rules_apple's hardcoded 60s simulator boot and 150s test-launch timeouts,
+        run: env -u ANDROID_NDK_HOME ./bazelw test $(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)') --test_tag_filters=macos_only --test_output=errors --config ci --config ios --test_env=REUSE_GLOBAL_SIMULATOR=1 --test_env=STARTUP_TIMEOUT_SEC=300
   verify_ios:
     runs-on: ubuntu-latest
     needs: ["tests", "swift_hello_world", "unit_tests"]

--- a/platform/swift/source/CoreLogging.swift
+++ b/platform/swift/source/CoreLogging.swift
@@ -241,12 +241,14 @@ extension CoreLogging {
     /// - parameter file:     The unique file identifier that has the form module/file.
     /// - parameter line:     The line number on which the log is emitted.
     /// - parameter function: The name of the declaration from within which the log is emitted.
+    /// - parameter fields:   The fields to log.
     func logInternal(
         level: LogLevel,
         message: @autoclosure () -> String,
         file: String? = #file,
         line: Int? = #line,
-        function: String? = #function
+        function: String? = #function,
+        fields: Fields? = nil
     )
     {
         self.log(
@@ -255,7 +257,7 @@ extension CoreLogging {
             file: file,
             line: line,
             function: function,
-            fields: nil,
+            fields: fields,
             error: nil,
             type: .internalsdk,
             blocking: false

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -270,7 +270,27 @@ public final class Logger {
                     sdkVersion: capture_get_sdk_version(),
                     eventTypes: .crash,
                     minimumHangSeconds: Double(hangDuration) / Double(MSEC_PER_SEC),
-                    useStackOverlapMatching: useStackOverlapMatching) { [weak self] in
+                    useStackOverlapMatching: useStackOverlapMatching,
+                    crashEnrichmentSummaryHandler: { [weak self] summary in
+                        let matcherMode = useStackOverlapMatching ? "base" : "exact"
+                        guard let self,
+                              let summary,
+                              let outcome = summary["outcome"],
+                              let reason = summary["reason"]
+                        else {
+                            return
+                        }
+
+                        self.underlyingLogger.logInternal(
+                            level: .debug,
+                            message: "[CrashEnrichment] MetricKit crash enrichment summary",
+                            fields: [
+                                "outcome": outcome,
+                                "reason": reason,
+                                "matcher_mode": matcherMode,
+                            ]
+                        )
+                    }) { [weak self] in
                     self?.underlyingLogger.processIssueReports(reportProcessingSession: .previousRun)
                 }
                 Logger.diagnosticReporter.update { val in

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.h
@@ -36,7 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The enhanced report (or the original metricKitReport if something went wrong).
  */
 + (NSDictionary<NSString *, id> *)enhancedMetricKitReport:(NSDictionary<NSString *, id> *)metricKitReport
-                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching;
+                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                                                   summaryOut:(NSDictionary<NSString *, NSString *> * _Nullable * _Nullable)summaryOut;
 
 /**
  * Start the in-process crash reporter, which captures supplemental

--- a/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
+++ b/platform/swift/source/crash_handler/BitdriftKSCrashHandler.m
@@ -46,7 +46,9 @@ uint64_t capture_cached_kscrash_timestamp(void);
 CacheResult capture_cache_kscrash_report(NSString *reportPath);
 
 /** Enhance a MetricKit report using the cached KSCrash report. */
-NSDictionary *_Nullable capture_enhance_metrickit_diagnostic_report(const NSDictionary *_Nullable report, BOOL useStackOverlapMatching);
+NSDictionary *_Nullable capture_enhance_metrickit_diagnostic_report(const NSDictionary *_Nullable report,
+                                                                    BOOL useStackOverlapMatching,
+                                                                    NSDictionary<NSString *, NSString *> * _Nullable * _Nullable summaryOut);
 
 #pragma mark Crash Handling
 
@@ -220,17 +222,24 @@ static void onCrash(struct KSCrash_MonitorContext *monitorContext) {
 }
 
 + (NSDictionary<NSString *, id> *)enhancedMetricKitReport:(NSDictionary<NSString *, id> *)metricKitReport
-                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching {
-    return [self.sharedInstance enhancedMetricKitReport:metricKitReport useStackOverlapMatching:useStackOverlapMatching];
+                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                                                   summaryOut:(NSDictionary<NSString *, NSString *> * _Nullable * _Nullable)summaryOut {
+    return [self.sharedInstance enhancedMetricKitReport:metricKitReport
+                               useStackOverlapMatching:useStackOverlapMatching
+                                            summaryOut:summaryOut];
 }
 
 - (NSDictionary<NSString *, id> *)enhancedMetricKitReport:(NSDictionary<NSString *, id> *)metricKitReport
-                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching {
+                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                                                   summaryOut:(NSDictionary<NSString *, NSString *> * _Nullable * _Nullable)summaryOut {
     if (self.kscrashReportFilePath == nil) {
+        if (summaryOut != nil) {
+            *summaryOut = nil;
+        }
         return metricKitReport;
     }
 
-    return capture_enhance_metrickit_diagnostic_report(metricKitReport, useStackOverlapMatching);
+    return capture_enhance_metrickit_diagnostic_report(metricKitReport, useStackOverlapMatching, summaryOut);
 }
 
 @end

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.h
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.h
@@ -35,8 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param useStackOverlapMatching Whether to use the base (prefix-matching) thread matcher instead of the exact matcher
  * @return The enhanced report (or the original metricKitReport if something went wrong).
  */
-+ (NSDictionary<NSString *, id> *)enhancedMetricKitReport:(NSDictionary<NSString *, id> *)metricKitReport
-                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching;
+ + (NSDictionary<NSString *, id> *)enhancedMetricKitReport:(NSDictionary<NSString *, id> *)metricKitReport
+                                       useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                                                summaryOut:(NSDictionary<NSString *, NSString *> * _Nullable * _Nullable)summaryOut;
 
 /**
  * Start the in-process crash reporter, which captures supplemental

--- a/platform/swift/source/reports/BitdriftKSCrashWrapper.m
+++ b/platform/swift/source/reports/BitdriftKSCrashWrapper.m
@@ -24,10 +24,16 @@
 }
 
 + (NSDictionary<NSString *, id> *)enhancedMetricKitReport:(NSDictionary<NSString *, id> *)metricKitReport
-                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching {
+                                      useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                                                   summaryOut:(NSDictionary<NSString *, NSString *> * _Nullable * _Nullable)summaryOut {
 #ifndef BITDRIFT_OMIT_KSCRASH
-    return [BitdriftKSCrashHandler enhancedMetricKitReport:metricKitReport useStackOverlapMatching:useStackOverlapMatching];
+    return [BitdriftKSCrashHandler enhancedMetricKitReport:metricKitReport
+                                  useStackOverlapMatching:useStackOverlapMatching
+                                               summaryOut:summaryOut];
 #else
+    if (summaryOut != nil) {
+        *summaryOut = nil;
+    }
     return metricKitReport;
 #endif
 }

--- a/platform/swift/source/reports/DiagnosticEventReporter.h
+++ b/platform/swift/source/reports/DiagnosticEventReporter.h
@@ -19,7 +19,7 @@ typedef NS_OPTIONS(NSUInteger, CAPDiagnosticType) {
     CAPDiagnosticTypeCPUException = 1 << 3,
 };
 
-typedef void (^CAPCrashEnrichmentSummaryHandler)(NSDictionary<NSString *, NSString *> *summary);
+typedef void (^CAPCrashEnrichmentSummaryHandler)(NSDictionary<NSString *, NSString *> * _Nullable summary);
 
 @interface DiagnosticEventReporter : NSObject<MXMetricManagerSubscriber>
 /**

--- a/platform/swift/source/reports/DiagnosticEventReporter.h
+++ b/platform/swift/source/reports/DiagnosticEventReporter.h
@@ -19,6 +19,8 @@ typedef NS_OPTIONS(NSUInteger, CAPDiagnosticType) {
     CAPDiagnosticTypeCPUException = 1 << 3,
 };
 
+typedef void (^CAPCrashEnrichmentSummaryHandler)(NSDictionary<NSString *, NSString *> *summary);
+
 @interface DiagnosticEventReporter : NSObject<MXMetricManagerSubscriber>
 /**
  * Create a new reporter, including the write directory for any detected reports and library metadata to
@@ -29,6 +31,7 @@ typedef NS_OPTIONS(NSUInteger, CAPDiagnosticType) {
  * @param types      event types to report
  * @param seconds    number of seconds required to report `CAPDiagnosticTypeHang` events
  * @param useStackOverlapMatching whether to use the base (prefix-matching) thread matcher for crash enrichment
+ * @param crashEnrichmentSummaryHandler block invoked after crash enrichment with the summary fields to log
  * @param completion block to invoke when report processing is completed
  */
 - (instancetype _Nonnull)initWithOutputDir:(NSURL *_Nonnull)path
@@ -36,6 +39,7 @@ typedef NS_OPTIONS(NSUInteger, CAPDiagnosticType) {
                                 eventTypes:(CAPDiagnosticType)types
                         minimumHangSeconds:(NSTimeInterval)seconds
                       useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                crashEnrichmentSummaryHandler:(CAPCrashEnrichmentSummaryHandler _Nullable)crashEnrichmentSummaryHandler
                          completionHandler:(void (^_Nullable)())completion;
 
 - (void)setMinimumHangSeconds:(NSTimeInterval)seconds;

--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -44,7 +44,8 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle,
                                        NSString *_Nonnull sdk_version,
                                        MXDiagnostic *_Nonnull event,
                                        NSTimeInterval timestamp,
-                                       BOOL useStackOverlapMatching)
+                                       BOOL useStackOverlapMatching,
+                                       CAPCrashEnrichmentSummaryHandler _Nullable crashEnrichmentSummaryHandler)
                                        API_AVAILABLE(ios(14.0), macos(12.0));
 
 static const char *name_for_diagnostic_type(ReportType type);
@@ -54,6 +55,7 @@ static const char *name_for_diagnostic_type(ReportType type);
 @property (nonnull, strong) NSString *sdkVersion;
 @property (nonnull, strong, nonatomic) NSMeasurement <NSUnitDuration *> *minimumHangDuration;
 @property (nullable, strong, nonatomic) void (^completionHandler)();
+@property (nullable, copy, nonatomic) CAPCrashEnrichmentSummaryHandler crashEnrichmentSummaryHandler;
 @property CAPDiagnosticType diagnosticTypes;
 @property BOOL useStackOverlapMatching;
 @end
@@ -64,6 +66,7 @@ static const char *name_for_diagnostic_type(ReportType type);
                                 eventTypes:(CAPDiagnosticType)types
                         minimumHangSeconds:(NSTimeInterval)seconds
                       useStackOverlapMatching:(BOOL)useStackOverlapMatching
+                crashEnrichmentSummaryHandler:(CAPCrashEnrichmentSummaryHandler _Nullable)crashEnrichmentSummaryHandler
                          completionHandler:(void (^_Nullable)())completionHandler {
   if (self = [super init]) {
     self.dir = dir;
@@ -71,6 +74,7 @@ static const char *name_for_diagnostic_type(ReportType type);
     self.diagnosticTypes = types;
     self.completionHandler = completionHandler;
     self.useStackOverlapMatching = useStackOverlapMatching;
+    self.crashEnrichmentSummaryHandler = crashEnrichmentSummaryHandler;
     [self setMinimumHangSeconds:seconds];
   }
   return self;
@@ -118,7 +122,14 @@ static const char *name_for_diagnostic_type(ReportType type);
 
 - (void)processDiagnostic:(MXDiagnostic *)event atTimestamp:(NSTimeInterval)timestamp {
   const void *handle = 0;
-  ReportType report_type = serialize_diagnostic(&handle, self.sdkVersion, event, timestamp, self.useStackOverlapMatching);
+  ReportType report_type = serialize_diagnostic(
+    &handle,
+    self.sdkVersion,
+    event,
+    timestamp,
+    self.useStackOverlapMatching,
+    self.crashEnrichmentSummaryHandler
+  );
   if (report_type != ReportTypeNone && handle != 0) {
     uint64_t length = 0;
     const uint8_t *contents = bdrw_get_completed_buffer(&handle, &length);
@@ -341,7 +352,12 @@ static BOOL crash_is_hang_termination(MXCrashDiagnostic *event) {
       || (event.terminationReason == nil && [event.exceptionCode isEqualToNumber:@0]));
 }
 
-static ReportType serialize_diagnostic(BDProcessorHandle handle, NSString *sdk_version, MXDiagnostic *event, NSTimeInterval timestamp, BOOL useStackOverlapMatching) {
+static ReportType serialize_diagnostic(BDProcessorHandle handle,
+                                       NSString *sdk_version,
+                                       MXDiagnostic *event,
+                                       NSTimeInterval timestamp,
+                                       BOOL useStackOverlapMatching,
+                                       CAPCrashEnrichmentSummaryHandler _Nullable crashEnrichmentSummaryHandler) {
   ReportType report_type = ReportTypeNone;
   if ([event isKindOfClass:[MXCrashDiagnostic class]]) {
     MXCrashDiagnostic *crash = (MXCrashDiagnostic *)event;
@@ -350,8 +366,13 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle, NSString *sdk_v
     bdrw_create_buffer_handle(handle, report_type, SDK_ID, cstring_from(sdk_version));
     NSString *name = is_hang ? DEFAULT_HANG_NAME : name_for_crash(crash);
     NSString *reason = reason_for_crash(crash, name);
+    NSDictionary<NSString *, NSString *> *summary = nil;
     NSDictionary *dictReport = [BitdriftKSCrashWrapper enhancedMetricKitReport:event.dictionaryRepresentation
-                                                           useStackOverlapMatching:useStackOverlapMatching];
+                                                           useStackOverlapMatching:useStackOverlapMatching
+                                                                        summaryOut:&summary];
+    if (summary != nil && crashEnrichmentSummaryHandler != nil) {
+      crashEnrichmentSummaryHandler(summary);
+    }
     serialize_error_threads(handle, dictReport, name, reason, FrameOrderInnerToOuter);
   } else if ([event isKindOfClass:[MXHangDiagnostic class]]) {
     report_type = ReportTypeAppNotResponding;

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -23,6 +23,83 @@ struct NamedThread {
   crashed: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EnrichmentOutcome {
+  Enhanced,
+  NoEffect,
+  NotAttempted,
+  Error,
+}
+
+impl EnrichmentOutcome {
+  const fn as_str(self) -> &'static str {
+    match self {
+      Self::Enhanced => "enhanced",
+      Self::NoEffect => "no_effect",
+      Self::NotAttempted => "not_attempted",
+      Self::Error => "error",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EnrichmentReason {
+  None,
+  MetadataMismatch,
+  NoNamedKSCrashThreads,
+  NoMatchFound,
+  MissingRequiredData,
+  InternalError,
+}
+
+impl EnrichmentReason {
+  const fn as_str(self) -> &'static str {
+    match self {
+      Self::None => "none",
+      Self::MetadataMismatch => "metadata_mismatch",
+      Self::NoNamedKSCrashThreads => "no_named_kscrash_threads",
+      Self::NoMatchFound => "no_match_found",
+      Self::MissingRequiredData => "missing_required_data",
+      Self::InternalError => "internal_error",
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct EnrichmentSummary {
+  outcome: EnrichmentOutcome,
+  reason: EnrichmentReason,
+}
+
+impl EnrichmentSummary {
+  const fn new(outcome: EnrichmentOutcome, reason: EnrichmentReason) -> Self {
+    Self { outcome, reason }
+  }
+
+  fn to_value(self) -> Value {
+    Value::Object(AHashMap::from([
+      (
+        "outcome".to_string(),
+        Value::String(self.outcome.as_str().to_string()),
+      ),
+      (
+        "reason".to_string(),
+        Value::String(self.reason.as_str().to_string()),
+      ),
+    ]))
+  }
+}
+
+struct EnhancedReportResult {
+  report: Option<AHashMap<String, Value>>,
+  summary: EnrichmentSummary,
+}
+
+struct EnhancedReportBridgeResult {
+  report_ptr: Option<*const Object>,
+  summary: EnrichmentSummary,
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheResult {
@@ -209,11 +286,18 @@ extern "C" fn capture_cache_kscrash_report(kscrash_report_path_ptr: *const Objec
 extern "C" fn capture_enhance_metrickit_diagnostic_report(
   metrickit_report_ptr: *const Object,
   use_stack_overlap_matching: bool,
+  summary_out: *mut *const Object,
 ) -> *const Object {
-  enhance_metrickit_diagnostic_report_impl(metrickit_report_ptr, use_stack_overlap_matching)
-    .inspect_err(|e| log::error!("Failed to enhance MetricKit report: {e}"))
-    .unwrap_or(Some(metrickit_report_ptr))
-    .unwrap_or(metrickit_report_ptr)
+  let result =
+    enhance_metrickit_diagnostic_report_impl(metrickit_report_ptr, use_stack_overlap_matching)
+      .inspect_err(|e| log::error!("Failed to enhance MetricKit report: {e}"))
+      .unwrap_or_else(|_| EnhancedReportBridgeResult {
+        report_ptr: None,
+        summary: EnrichmentSummary::new(EnrichmentOutcome::Error, EnrichmentReason::InternalError),
+      });
+
+  write_summary_bridge_out(summary_out, result.summary);
+  result.report_ptr.unwrap_or(metrickit_report_ptr)
 }
 
 #[no_mangle]
@@ -283,7 +367,7 @@ fn parse_cached_report(report_path: String) -> anyhow::Result<CacheResult> {
 fn enhance_metrickit_diagnostic_report_impl(
   metrickit_report_ptr: *const Object,
   use_stack_overlap_matching: bool,
-) -> anyhow::Result<Option<*const Object>> {
+) -> anyhow::Result<EnhancedReportBridgeResult> {
   let value = unsafe { objc_value_to_rust(metrickit_report_ptr) }
     .map_err(|e| anyhow::anyhow!("Failed to convert metrickit_report_ptr to Rust Value: {e}"))?;
 
@@ -293,27 +377,35 @@ fn enhance_metrickit_diagnostic_report_impl(
     ));
   };
 
-  let kscrash_report = CACHED_KSCRASH_REPORT
-    .lock()
-    .as_ref()
-    .ok_or_else(|| {
-      anyhow::anyhow!("No KSCrash report has been cached. Call capture_cache_kscrash_report first.")
-    })?
-    .clone();
+  let Some(kscrash_report) = CACHED_KSCRASH_REPORT.lock().as_ref().cloned() else {
+    return Ok(EnhancedReportBridgeResult {
+      report_ptr: None,
+      summary: EnrichmentSummary::new(
+        EnrichmentOutcome::NotAttempted,
+        EnrichmentReason::MissingRequiredData,
+      ),
+    });
+  };
 
-  let Some(enhanced_hashmap) = enhance_report(
+  let result = enhance_report_with_summary(
     &metrickit_report,
     &kscrash_report,
     use_stack_overlap_matching,
-  )?
-  else {
-    return Ok(None);
+  )?;
+  let report_ptr = match result.report {
+    Some(enhanced_hashmap) => {
+      let enhanced_report = Value::Object(enhanced_hashmap);
+      let strong_ptr = unsafe { rust_value_to_objc(&enhanced_report) }
+        .map_err(|e| anyhow::anyhow!("Failed to convert enhanced_report to Objective-C: {e}"))?;
+      Some(*strong_ptr as *const Object)
+    },
+    None => None,
   };
-  let enhanced_report = Value::Object(enhanced_hashmap);
 
-  let strong_ptr = unsafe { rust_value_to_objc(&enhanced_report) }
-    .map_err(|e| anyhow::anyhow!("Failed to convert enhanced_report to Objective-C: {e}"))?;
-  Ok(Some(*strong_ptr))
+  Ok(EnhancedReportBridgeResult {
+    report_ptr,
+    summary: result.summary,
+  })
 }
 
 fn cached_kscrash_timestamp_impl() -> anyhow::Result<u64> {
@@ -334,13 +426,19 @@ fn cached_kscrash_timestamp_impl() -> anyhow::Result<u64> {
   Ok(seconds)
 }
 
-fn enhance_report(
+fn enhance_report_with_summary(
   metrickit_report: &AHashMap<String, Value>,
   kscrash_report: &AHashMap<String, Value>,
   use_stack_overlap_matching: bool,
-) -> anyhow::Result<Option<AHashMap<String, Value>>> {
+) -> anyhow::Result<EnhancedReportResult> {
   if !diagnostic_metadata_matches_in_reports(metrickit_report, kscrash_report) {
-    return Ok(None);
+    return Ok(EnhancedReportResult {
+      report: None,
+      summary: EnrichmentSummary::new(
+        EnrichmentOutcome::NoEffect,
+        EnrichmentReason::MetadataMismatch,
+      ),
+    });
   }
 
   if use_stack_overlap_matching {
@@ -353,31 +451,65 @@ fn enhance_report(
 fn enhance_report_with_exact_matching(
   metrickit_report: &AHashMap<String, Value>,
   kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<Option<AHashMap<String, Value>>> {
+) -> anyhow::Result<EnhancedReportResult> {
   let named_threads = exact_named_threads_from_kscrash_report(kscrash_report)?;
 
   let Some(named_threads) = named_threads else {
-    return Ok(None);
+    return Ok(EnhancedReportResult {
+      report: None,
+      summary: EnrichmentSummary::new(
+        EnrichmentOutcome::NoEffect,
+        EnrichmentReason::NoNamedKSCrashThreads,
+      ),
+    });
   };
 
+  let named_before = count_named_metrickit_threads(metrickit_report)?;
   let enhanced_metrickit =
     inject_thread_names_into_metrickit_exact(metrickit_report.clone(), &named_threads)?;
-  Ok(Some(enhanced_metrickit))
+  let named_after = count_named_metrickit_threads(&enhanced_metrickit)?;
+  let (outcome, reason) = if named_after > named_before {
+    (EnrichmentOutcome::Enhanced, EnrichmentReason::None)
+  } else {
+    (EnrichmentOutcome::NoEffect, EnrichmentReason::NoMatchFound)
+  };
+
+  Ok(EnhancedReportResult {
+    report: Some(enhanced_metrickit),
+    summary: EnrichmentSummary::new(outcome, reason),
+  })
 }
 
 fn enhance_report_with_base_matching(
   metrickit_report: &AHashMap<String, Value>,
   kscrash_report: &AHashMap<String, Value>,
-) -> anyhow::Result<Option<AHashMap<String, Value>>> {
+) -> anyhow::Result<EnhancedReportResult> {
   let named_threads = named_threads_from_kscrash_report(kscrash_report)?;
 
   let Some(named_threads) = named_threads else {
-    return Ok(None);
+    return Ok(EnhancedReportResult {
+      report: None,
+      summary: EnrichmentSummary::new(
+        EnrichmentOutcome::NoEffect,
+        EnrichmentReason::NoNamedKSCrashThreads,
+      ),
+    });
   };
 
+  let named_before = count_named_metrickit_threads(metrickit_report)?;
   let enhanced_metrickit =
     inject_thread_names_into_metrickit_from_base(metrickit_report.clone(), &named_threads)?;
-  Ok(Some(enhanced_metrickit))
+  let named_after = count_named_metrickit_threads(&enhanced_metrickit)?;
+  let (outcome, reason) = if named_after > named_before {
+    (EnrichmentOutcome::Enhanced, EnrichmentReason::None)
+  } else {
+    (EnrichmentOutcome::NoEffect, EnrichmentReason::NoMatchFound)
+  };
+
+  Ok(EnhancedReportResult {
+    report: Some(enhanced_metrickit),
+    summary: EnrichmentSummary::new(outcome, reason),
+  })
 }
 
 fn diagnostic_metadata_matches_in_reports(
@@ -633,6 +765,37 @@ fn metrickit_threads_mut(
   Ok(threads)
 }
 
+fn metrickit_threads(metrickit_report: &AHashMap<String, Value>) -> anyhow::Result<&Vec<Value>> {
+  let Some(Value::Object(call_stack_tree)) = metrickit_report.get("callStackTree") else {
+    return Err(anyhow::anyhow!(
+      "MetricKit report missing 'callStackTree' object"
+    ));
+  };
+
+  let Some(Value::Array(threads)) = call_stack_tree.get("callStacks") else {
+    return Err(anyhow::anyhow!("CallStackTree missing 'callStacks' array"));
+  };
+
+  Ok(threads)
+}
+
+fn count_named_metrickit_threads(
+  metrickit_report: &AHashMap<String, Value>,
+) -> anyhow::Result<usize> {
+  Ok(
+    metrickit_threads(metrickit_report)?
+      .iter()
+      .filter(|thread| match thread {
+        Value::Object(thread) => match thread.get("name") {
+          Some(Value::String(name)) => !name.is_empty(),
+          _ => false,
+        },
+        _ => false,
+      })
+      .count(),
+  )
+}
+
 fn get_metrickit_thread(
   thread: &mut Value,
 ) -> anyhow::Result<Option<(&mut AHashMap<String, Value>, Vec<u64>)>> {
@@ -824,6 +987,24 @@ fn value_as_u64(value: &Value) -> Option<u64> {
     Value::Unsigned(value) => Some(*value),
     Value::Signed(value) => (*value >= 0).then_some(*value as u64),
     _ => None,
+  }
+}
+
+fn write_summary_bridge_out(summary_out: *mut *const Object, summary: EnrichmentSummary) {
+  if summary_out.is_null() {
+    return;
+  }
+
+  match unsafe { rust_value_to_objc(&summary.to_value()) } {
+    Ok(summary_ptr) => unsafe {
+      *summary_out = *summary_ptr;
+    },
+    Err(e) => {
+      log::error!("Failed to convert crash enrichment summary to Objective-C: {e}");
+      unsafe {
+        *summary_out = std::ptr::null();
+      };
+    },
   }
 }
 
@@ -1051,11 +1232,14 @@ mod tests {
       )],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, false)
-      .unwrap()
-      .expect("expected report");
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, false).unwrap();
+    let enhanced_report = result.report.expect("expected report");
 
     assert_eq!(metrickit_thread_name(&enhanced_report, 0), None);
+    assert_eq!(
+      result.summary,
+      EnrichmentSummary::new(EnrichmentOutcome::NoEffect, EnrichmentReason::NoMatchFound)
+    );
   }
 
   #[test]
@@ -1079,11 +1263,14 @@ mod tests {
       )],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, true)
-      .unwrap()
-      .expect("expected report");
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, true).unwrap();
+    let enhanced_report = result.report.expect("expected report");
 
     assert_eq!(metrickit_thread_name(&enhanced_report, 0), Some("worker"));
+    assert_eq!(
+      result.summary,
+      EnrichmentSummary::new(EnrichmentOutcome::Enhanced, EnrichmentReason::None)
+    );
   }
 
   #[test]
@@ -1104,9 +1291,16 @@ mod tests {
       vec![make_metrickit_thread(&[0x10, 0x20, 0x30, 0x40], false)],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, true).unwrap();
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, true).unwrap();
 
-    assert_eq!(enhanced_report, None);
+    assert_eq!(result.report, None);
+    assert_eq!(
+      result.summary,
+      EnrichmentSummary::new(
+        EnrichmentOutcome::NoEffect,
+        EnrichmentReason::MetadataMismatch
+      )
+    );
   }
 
   #[test]
@@ -1125,9 +1319,8 @@ mod tests {
       vec![make_metrickit_thread(&[0x10, 0x20, 0x30, 0x40], true)],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, true)
-      .unwrap()
-      .expect("expected report");
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, true).unwrap();
+    let enhanced_report = result.report.expect("expected report");
 
     assert_eq!(metrickit_thread_name(&enhanced_report, 0), None);
   }
@@ -1148,9 +1341,8 @@ mod tests {
       vec![make_metrickit_thread(&[0x10, 0x20, 0x30, 0x40], false)],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, true)
-      .unwrap()
-      .expect("expected report");
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, true).unwrap();
+    let enhanced_report = result.report.expect("expected report");
 
     assert_eq!(metrickit_thread_name(&enhanced_report, 0), None);
   }
@@ -1174,9 +1366,8 @@ mod tests {
       )],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, true)
-      .unwrap()
-      .expect("expected report");
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, true).unwrap();
+    let enhanced_report = result.report.expect("expected report");
 
     assert_eq!(metrickit_thread_name(&enhanced_report, 0), Some("worker"));
   }
@@ -1199,9 +1390,8 @@ mod tests {
       vec![make_metrickit_thread(&[0x10, 0x20, 0x30, 0x40], false)],
     );
 
-    let enhanced_report = enhance_report(&metrickit_report, &kscrash_report, true)
-      .unwrap()
-      .expect("expected report");
+    let result = enhance_report_with_summary(&metrickit_report, &kscrash_report, true).unwrap();
+    let enhanced_report = result.report.expect("expected report");
 
     assert_eq!(metrickit_thread_name(&enhanced_report, 0), None);
   }

--- a/test/platform/swift/unit_integration/core/DiagnosticEventReporterTests.swift
+++ b/test/platform/swift/unit_integration/core/DiagnosticEventReporterTests.swift
@@ -86,7 +86,8 @@ final class DiagnosticEventReporterTests: XCTestCase {
 
         let enhancedReport = BitdriftKSCrashHandler.enhancedMetricKitReport(
             metrickitReport,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            summaryOut: nil
         ) as! [String: any Equatable]
         XCTAssertNotNil(enhancedReport)
         XCTAssertFalse(dictsAreEqual(metrickitReport, enhancedReport))
@@ -118,7 +119,8 @@ final class DiagnosticEventReporterTests: XCTestCase {
             sdkVersion: "41.5.67",
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let crash = try MockCrashDiagnostic(signal: 9, exceptionType: nil, exceptionCode: nil, callStacks: [])
         reporter.didReceive([MockDiagnosticPayload(crashDiagnostics: [crash])])
@@ -142,7 +144,8 @@ final class DiagnosticEventReporterTests: XCTestCase {
             sdkVersion: "41.5.67",
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let crash = try MockCrashDiagnostic(signal: 9, exceptionType: nil, exceptionCode: nil, callStacks: [])
         let timestamp = dateFormatter.date(from: "1995-03-11")!
@@ -166,7 +169,8 @@ final class DiagnosticEventReporterTests: XCTestCase {
             sdkVersion: "41.5.67",
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let crash = try MockCrashDiagnostic(signal: 4, exceptionType: 1)
         reporter.didReceive([MockDiagnosticPayload(crashDiagnostics: [crash])])
@@ -188,7 +192,14 @@ final class DiagnosticEventReporterTests: XCTestCase {
 
     @available(iOS 17.0, *)
     func testNSExceptionNameInError() throws {
-        let reporter = DiagnosticEventReporter(outputDir: reportDir!, sdkVersion: "41.5.67", eventTypes: .crash, minimumHangSeconds: 2.5, useStackOverlapMatching: true)
+        let reporter = DiagnosticEventReporter(
+            outputDir: reportDir!,
+            sdkVersion: "41.5.67",
+            eventTypes: .crash,
+            minimumHangSeconds: 2.5,
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
+        )
         let crashReason = MockObjectiveCReason("NSRangeException", message: "index 5 out of range [0..2]")
         let crash = try MockCrashDiagnostic(signal: 4, exceptionType: 1, exceptionReason: crashReason)
 
@@ -230,7 +241,8 @@ ThermalInfo: (
             sdkVersion: "41.5.67",
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let crash = try MockCrashDiagnostic(signal: 9, exceptionType: 10, exceptionCode: 0, terminationReason: termContext)
         reporter.didReceive([MockDiagnosticPayload(crashDiagnostics: [crash])])
@@ -255,7 +267,8 @@ ThermalInfo: (
             sdkVersion: "41.5.67",
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let imageOffset: UInt64 = 165304
         let imageOffset2: UInt64 = 126721
@@ -329,7 +342,8 @@ ThermalInfo: (
             sdkVersion: "41.5.67",
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let imageOffset: UInt64 = 165304
         let imageOffset2: UInt64 = 126721
@@ -396,7 +410,8 @@ ThermalInfo: (
             sdkVersion: "41.5.67",
             eventTypes: [.hang, .crash],
             minimumHangSeconds: 1,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let timestamp = dateFormatter.date(from: "2022-04-07")!
         let hang = try MockHangDiagnostic(duration: 0.7, type: "Main Runloop Hang", callStacks: [
@@ -421,7 +436,8 @@ ThermalInfo: (
             sdkVersion: "41.5.67",
             eventTypes: [.hang, .crash],
             minimumHangSeconds: 1,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let timestamp = dateFormatter.date(from: "2008-11-25")!
         let imageOffset: UInt64 = 165304
@@ -504,7 +520,8 @@ ThermalInfo: (
             sdkVersion: "41.5.67",
             eventTypes: [.crash],
             minimumHangSeconds: 1,
-            useStackOverlapMatching: true
+            useStackOverlapMatching: true,
+            crashEnrichmentSummaryHandler: nil
         )
         let timestamp = dateFormatter.date(from: "2008-11-25")!
         let imageOffset: UInt64 = 165304

--- a/test/platform/swift/unit_integration/core/network/CaptureNetworkTests.swift
+++ b/test/platform/swift/unit_integration/core/network/CaptureNetworkTests.swift
@@ -18,14 +18,14 @@ final class CaptureNetworkTests: XCTestCase {
         let env = try NetworkTestEnvironment(networkIdleTimeout: 5)
 
         let streamID = await env.testServer.nextStream()
-        XCTAssertNotEqual(streamID, -1)
+        guard streamID != -1 else { XCTFail("Timed out waiting for initial stream"); return }
 
         // Server timeout is 1s in tests, waiting up to 3s for the stream to be closed.
         let streamClosed = await env.testServer.streamClosed(streamId: streamID, waitTimeMs: 10000)
         XCTAssertTrue(streamClosed)
 
         let streamID2 = await env.testServer.nextStream(timeout: 30)
-        XCTAssertNotEqual(streamID2, -1)
+        guard streamID2 != -1 else { XCTFail("Timed out waiting for reconnect stream"); return }
         try await env.testServer.handshake(streamId: streamID2)
     }
 
@@ -34,7 +34,7 @@ final class CaptureNetworkTests: XCTestCase {
         let env = try NetworkTestEnvironment(pingInterval: 0.1)
 
         let streamID = await env.testServer.nextStream()
-        XCTAssertNotEqual(streamID, -1)
+        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
         try await env.testServer.handshake(streamId: streamID)
 
         // Server timeout is 1s in tests, waiting up to 1.5s. This would have closed the

--- a/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
+++ b/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
@@ -93,7 +93,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
         _ = try self.setUpLogger()
 
         let streamID = await self.server.nextStream()
-        XCTAssertNotEqual(streamID, -1, "Timed out waiting for API stream")
+        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
         try await self.server.configureAggressiveUploads(streamId: streamID)
 
         // Collect logs until we've seen all expected initial logs.
@@ -141,7 +141,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
         logger.addField(withKey: "_dar", value: "value_dar")
 
         let streamID = await self.server.nextStream()
-        XCTAssertNotEqual(streamID, -1, "Timed out waiting for API stream")
+        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
         try await self.server.configureAggressiveUploads(streamId: streamID)
 
         // TODO(Augustyniak): Do `replayScreenshotLog.hasFields` in here after figuring out how to figure out
@@ -248,7 +248,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
         _ = try self.setUpLogger(fieldProviders: fieldProviders)
 
         let streamID = await self.server.nextStream()
-        XCTAssertNotEqual(streamID, -1, "Timed out waiting for API stream")
+        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
         try await self.server.configureAggressiveUploads(streamId: streamID)
 
         self.logger.log(level: .debug, message: "test field provider failure")

--- a/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
+++ b/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
@@ -51,7 +51,7 @@ public final class TestApiServer: @unchecked Sendable {
     /// - parameter timeout: The total amount of time to wait before giving up.
     ///
     /// - returns: The stream ID, or -1 on timeout.
-    public func nextStream(timeout: TimeInterval = 5) async -> Int32 {
+    public func nextStream(timeout: TimeInterval = 15) async -> Int32 {
         let deadline = Date().addingTimeInterval(timeout)
         var streamID = await awaitNextStream()
 

--- a/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
+++ b/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
@@ -64,7 +64,10 @@ public final class TestApiServer: @unchecked Sendable {
 
     private func awaitNextStream() async -> Int32 {
         await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
+            // Use a dedicated OS thread instead of DispatchQueue.global() to avoid starving the
+            // shared GCD thread pool. Blocking that pool prevents URLSession delegate callbacks
+            // (which complete the TLS handshake) from running while this call is waiting.
+            Thread.detachNewThread {
                 continuation.resume(returning: server_instance_await_next_stream(self.handle))
             }
         }
@@ -77,7 +80,7 @@ public final class TestApiServer: @unchecked Sendable {
     /// - throws: `TestServerError` if the handshake times out.
     public func handshake(streamId: Int32) async throws {
         let errorPtr = await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
+            Thread.detachNewThread {
                 continuation.resume(returning: server_instance_await_handshake(self.handle, streamId))
             }
         }
@@ -92,7 +95,7 @@ public final class TestApiServer: @unchecked Sendable {
     /// - returns: True if stream closed within the timeout.
     public func streamClosed(streamId: Int32, waitTimeMs: Int64) async -> Bool {
         await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
+            Thread.detachNewThread {
                 continuation.resume(returning: server_instance_await_stream_closed(self.handle, streamId, waitTimeMs))
             }
         }
@@ -105,7 +108,7 @@ public final class TestApiServer: @unchecked Sendable {
     /// - throws: `TestServerError` if the configuration fails.
     public func configureAggressiveUploads(streamId: Int32) async throws {
         let errorPtr = await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
+            Thread.detachNewThread {
                 continuation.resume(returning: server_instance_configure_aggressive_uploads(self.handle, streamId))
             }
         }
@@ -119,7 +122,7 @@ public final class TestApiServer: @unchecked Sendable {
     /// - throws: `TestServerError` if the test fails.
     public func runLargeUploadTest(loggerId: Int64) async throws {
         let errorPtr = await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
+            Thread.detachNewThread {
                 continuation.resume(
                     returning: server_instance_run_large_upload_test(self.handle, loggerId)
                 )
@@ -138,7 +141,7 @@ public final class TestApiServer: @unchecked Sendable {
     /// - returns: The uploaded log, or nil on timeout.
     public func nextUploadedLog() async -> UploadedLog? {
         await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
+            Thread.detachNewThread {
                 let log = UploadedLog()
                 guard server_instance_next_uploaded_log(self.handle, log) else {
                     continuation.resume(returning: nil)


### PR DESCRIPTION
# Overview
This PR is part of the effort to improve crash report enrichment on iOS ([PR](https://github.com/bitdriftlabs/capture-sdk/pull/973)).

The idea is to add some internal logging so we can later inspect internal metrics regarding how the matching process behaved. This will allow us to compare the effectiveness of one mechanism versus another, while also helping us identify issues in the new mechanism when they arise.