### PR TITLE
(iOS) fix missing `_span_name` on network res/req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Fixed `Span Name` for network request/responses.
 
 ## [0.22.16]
 

--- a/platform/swift/source/logging/HTTPRequestInfo.swift
+++ b/platform/swift/source/logging/HTTPRequestInfo.swift
@@ -114,9 +114,16 @@ public struct HTTPRequestInfo {
     ///
     /// - returns: Fields to share with response logs.
     func toCommonFields(spanType: HTTPSpanType) -> Fields {
+        let spanName: String = if self.headers?["X-APOLLO-OPERATION-NAME"] != nil {
+            "_graphql"
+        } else {
+            "_http"
+        }
+
         var fields: [String: Encodable] = [
             "_method": self.method,
             "_span_id": self.spanID,
+            "_span_name": spanName,
             "_span_type": spanType.rawValue,
         ]
 

--- a/test/platform/swift/unit_integration/core/LoggerTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerTests.swift
@@ -253,6 +253,7 @@ final class LoggerTests: XCTestCase {
             "_method": "POST",
             "_path": "/ping/12345",
             "_span_id": requestInfo.spanID,
+            "_span_name": "_http",
             "_span_type": "start",
             "_query": "bar",
             "foo": "bar",
@@ -309,6 +310,7 @@ final class LoggerTests: XCTestCase {
             "_path": "/ping/12345",
             "_result": "success",
             "_span_id": requestInfo.spanID,
+            "_span_name": "_http",
             "_span_type": "end",
             "_status_code": "200",
             "_query": "bar",
@@ -320,6 +322,7 @@ final class LoggerTests: XCTestCase {
             "_request._method": "POST",
             "_request._path": "/ping/12345",
             "_request._span_id": requestInfo.spanID,
+            "_request._span_name": "_http",
             "_request._span_type": "start",
             "_request._query": "bar",
         ], try log.matchingFields?.toDictionary())

--- a/test/platform/swift/unit_integration/core/logging/HTTPRequestInfoTests.swift
+++ b/test/platform/swift/unit_integration/core/logging/HTTPRequestInfoTests.swift
@@ -22,6 +22,7 @@ final class HTTPRequestInfoTests: XCTestCase {
         XCTAssertEqual(
             [
                 "_method": "method",
+                "_span_name": "_http",
                 "_span_type": "start",
                 "key": "value",
             ],
@@ -51,6 +52,7 @@ final class HTTPRequestInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "start",
                 "key": "value",
             ],
@@ -78,6 +80,7 @@ final class HTTPRequestInfoTests: XCTestCase {
             "_path": "/test/12345",
             "_path_template": "/test/{explicit_id}",
             "_query": "q=foo",
+            "_span_name": "_http",
             "_span_type": "start",
         ], fields)
     }

--- a/test/platform/swift/unit_integration/core/logging/HTTPResponseInfoTests.swift
+++ b/test/platform/swift/unit_integration/core/logging/HTTPResponseInfoTests.swift
@@ -30,6 +30,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_method": "GET",
                 "_duration_ms": "123",
                 "_result": "success",
+                "_span_name": "_http",
                 "_span_type": "end",
             ],
             fields
@@ -38,7 +39,7 @@ final class HTTPResponseInfoTests: XCTestCase {
         var matchingFields = try XCTUnwrap(responseInfo.toMatchingFields() as? [String: String])
         XCTAssertNotNil(matchingFields.removeValue(forKey: "_request._span_id"))
 
-        XCTAssertEqual(["_request._method": "GET", "_request._span_type": "start"], matchingFields)
+        XCTAssertEqual(["_request._method": "GET", "_request._span_name": "_http", "_request._span_type": "start"], matchingFields)
     }
 
     func testHTTPResponseSuccess() throws {
@@ -62,6 +63,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "key2": "value2",
                 "_status_code": "200",
@@ -79,6 +81,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_name": "_http",
                 "_request._span_type": "start",
                 "_request.key": "value",
                 "_headers.header_1": "value_1",
@@ -120,6 +123,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path_template": "/testing/<id>",
                 "_query": "query",
                 "_span_id": "foo",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "success",
@@ -147,6 +151,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "success",
@@ -178,6 +183,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path_template": "/foo_path/{explicit_id}",
                 "_query": "foo_query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "success",
@@ -212,6 +218,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_duration_ms": "456",
                 "_result": "canceled",
@@ -227,6 +234,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_name": "_http",
                 "_request._span_type": "start",
                 "_request.key": "value",
                 "_request._headers.request_header": "request_value",
@@ -258,6 +266,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_status_code": "400",
                 "_duration_ms": "789",
@@ -274,6 +283,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_name": "_http",
                 "_request._span_type": "start",
                 "_request.key": "value",
                 "_request._headers.request_header": "request_value",
@@ -312,6 +322,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_path": "/path/12345",
                 "_query": "query",
                 "_span_id": "span_id",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_duration_ms": "135",
                 "_result": "failure",
@@ -329,6 +340,7 @@ final class HTTPResponseInfoTests: XCTestCase {
                 "_request._method": "method",
                 "_request._path": "/path/12345",
                 "_request._span_id": "span_id",
+                "_request._span_name": "_http",
                 "_request._span_type": "start",
                 "_request.key": "value",
                 "_request._headers.request_header": "request_value",

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -222,6 +222,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_method": "GET",
                 "_path": "/fe/ping",
                 "_query": "q=test",
+                "_span_name": "_http",
                 "_span_type": "start",
             ],
             requestInfoFields
@@ -687,6 +688,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_method": "GET",
                 "_path": "/fe/ping",
                 "_query": "q=test",
+                "_span_name": "_http",
                 "_span_type": "start",
             ],
             requestInfoFields
@@ -710,6 +712,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_path": "/fe/ping",
                 "_query": "q=test",
                 "_result": "success",
+                "_span_name": "_http",
                 "_span_type": "end",
                 "_status_code": "200",
             ],
@@ -756,6 +759,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_method": "GET",
                 "_path": "/fe/ping",
                 "_query": "q=test",
+                "_span_name": "_http",
                 "_span_type": "start",
             ],
             requestInfoFields
@@ -779,6 +783,7 @@ final class URLSessionIntegrationTests: XCTestCase {
                 "_path": "/fe/ping",
                 "_query": "q=test",
                 "_result": "canceled",
+                "_span_name": "_http",
                 "_span_type": "end",
             ],
             remainingResponseFields


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.