### PR TITLE
[Android] Fix incorrect ANR "unknown" reason/Undetermined ANR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 **Fixed**
 
 - Fixed incorrect foreground/background state on fatal issues and app termination logs.
+- Fixed ANRs incorrectly classified as undetermined.
 
 ### iOS
 

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "cbe7f610c9a0d45d952619f11912d75f197e74ec0047fa54a80d8323117e6a1e",
+  "checksum": "4f8a6b8fdb6c3452cb541d5f1335f82f91da4545985a8e620ecf9d044d39a74a",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-api"
         }
@@ -1745,7 +1745,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1878,7 +1878,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1934,7 +1934,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -1998,7 +1998,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2104,7 +2104,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2180,7 +2180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2329,7 +2329,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2466,7 +2466,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2603,7 +2603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2696,7 +2696,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2760,7 +2760,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2925,7 +2925,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-device"
         }
@@ -2997,7 +2997,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-events"
         }
@@ -3145,7 +3145,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3376,7 +3376,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3455,7 +3455,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3587,7 +3587,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3647,7 +3647,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3735,7 +3735,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-log"
         }
@@ -3835,7 +3835,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3923,7 +3923,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4011,7 +4011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4071,7 +4071,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4164,7 +4164,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4421,7 +4421,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4481,7 +4481,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4529,7 +4529,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4577,7 +4577,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4646,7 +4646,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4706,7 +4706,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4808,7 +4808,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4918,7 +4918,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5050,7 +5050,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5122,7 +5122,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5220,7 +5220,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5344,7 +5344,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5428,7 +5428,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5525,7 +5525,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-session"
         }
@@ -5730,7 +5730,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5834,7 +5834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5890,7 +5890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-state"
         }
@@ -5999,7 +5999,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6072,7 +6072,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6288,7 +6288,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-time"
         }
@@ -6365,7 +6365,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "c834bbb68caf83291e35d447d582877fb32272af"
+            "Rev": "dc342bc721c617068336d7347586d0d69de7346b"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "base64",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=c834bbb68caf83291e35d447d582877fb32272af#c834bbb68caf83291e35d447d582877fb32272af"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=dc342bc721c617068336d7347586d0d69de7346b#dc342bc721c617068336d7347586d0d69de7346b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "c834bbb68caf83291e35d447d582877fb32272af" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "dc342bc721c617068336d7347586d0d69de7346b" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "0.10.0"
 env_logger = { version = "0.11.10", default-features = false }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -396,6 +396,7 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
         destinationPath: String,
         attributes: IClientAttributes,
         runningState: String?,
+        appExitDescription: String?,
     )
 
     /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IStreamingReportProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IStreamingReportProcessor.kt
@@ -22,6 +22,7 @@ interface IStreamingReportProcessor {
         destinationPath: String,
         attributes: IClientAttributes,
         runningState: String?,
+        appExitDescription: String?,
     )
 
     /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessor.kt
@@ -116,6 +116,7 @@ internal class IssueReporterProcessor(
                     reporterIssueStore.generateFatalIssueFilePath(),
                     clientAttributes,
                     runningState,
+                    applicationExit.description,
                 )
             } else if (fatalIssueType == ReportType.NativeCrash) {
                 val builder = FlatBufferBuilder(FBS_BUILDER_DEFAULT_SIZE)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessorTest.kt
@@ -248,6 +248,7 @@ class IssueReporterProcessorTest {
                     timestamp = FAKE_TIME_STAMP,
                     traceInputStream = buildTraceInputStringFromFile("app_exit_anr_deadlock_anr.txt"),
                     reason = ApplicationExitInfo.REASON_ANR,
+                    description = "Input dispatching timeout",
                 ),
         )
 
@@ -274,6 +275,7 @@ class IssueReporterProcessorTest {
                     timestamp = FAKE_TIME_STAMP,
                     traceInputStream = buildTraceInputStringFromFile("app_exit_anr_deadlock_anr.txt"),
                     reason = ApplicationExitInfo.REASON_ANR,
+                    description = "Input dispatching timeout",
                 ),
         )
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessorTest.kt
@@ -15,6 +15,7 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -180,6 +181,7 @@ class IssueReporterProcessorTest {
             eq("/some/path/foo.cap"),
             eq(attributes),
             eq("foreground"),
+            isNull(),
         )
     }
 
@@ -203,6 +205,7 @@ class IssueReporterProcessorTest {
             eq("/some/path/foo.cap"),
             eq(attributes),
             eq("cached"),
+            isNull(),
         )
     }
 
@@ -226,6 +229,7 @@ class IssueReporterProcessorTest {
             eq("/some/path/foo.cap"),
             eq(attributes),
             eq("foreground_service"),
+            isNull(),
         )
     }
 
@@ -540,7 +544,7 @@ class IssueReporterProcessorTest {
         doReturn("/some/path/foo.cap").`when`(issueReporterStorage).generateFatalIssueFilePath()
         doThrow(exception)
             .`when`(streamingReportProcessor)
-            .processAndPersistANR(any(), eq(FAKE_TIME_STAMP), eq("/some/path/foo.cap"), eq(attributes), any())
+            .processAndPersistANR(any(), eq(FAKE_TIME_STAMP), eq("/some/path/foo.cap"), eq(attributes), any(), any())
     }
 
     private fun createApplicationExitInfo(

--- a/platform/jvm/core/src/jni.rs
+++ b/platform/jvm/core/src/jni.rs
@@ -1447,6 +1447,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPers
   destination: JString<'_>,
   attributes: JObject<'_>,
   running_state: JString<'_>,
+  app_exit_description: JString<'_>,
 ) {
   let destination = match unsafe { env.get_string_unchecked(&destination) } {
     Ok(destination) => destination.to_string_lossy().to_string(),
@@ -1465,6 +1466,15 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPers
       .map(|s| s.to_string_lossy().to_string())
   };
 
+  let app_exit_description_str = if app_exit_description.is_null() {
+    None
+  } else {
+    unsafe { env.get_string_unchecked(&app_exit_description) }
+      .ok()
+      .map(|s| s.to_string_lossy().to_string())
+      .filter(|s| !s.is_empty())
+  };
+
   match report_processing::persist_anr(
     &mut env,
     &stream,
@@ -1472,6 +1482,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPers
     &destination,
     &attributes,
     running_state_str.as_deref(),
+    app_exit_description_str.as_deref(),
   ) {
     Ok(()) => {},
     Err(e) => {

--- a/platform/jvm/core/src/report_processing.rs
+++ b/platform/jvm/core/src/report_processing.rs
@@ -152,6 +152,7 @@ pub(crate) fn persist_anr(
   destination: &str,
   attributes: &JObject<'_>,
   running_state: Option<&str>,
+  app_exit_description: Option<&str>,
 ) -> anyhow::Result<()> {
   let mut builder = FlatBufferBuilder::new();
   let source_file = read_stream_to_file(env, source_stream)?;
@@ -168,6 +169,7 @@ pub(crate) fn persist_anr(
     &mut app_info,
     &mut device_info,
     source_view,
+    app_exit_description,
   )
   .map_err(|e| anyhow::anyhow!("failed to parse ANR report: {e}"))?;
 


### PR DESCRIPTION
## What

Resolves of BIT-8285

shared-core changes in https://github.com/bitdriftlabs/shared-core/pull/489

Fixes incorrect "unknown" reason and Undetermined ANR classification for ANR reports that have a valid description. The logic is closer now to https://github.com/bitdriftlabs/capture-sdk/pull/382 where this was the source to extract the reason.

## Verification

- On main this [background ANR](https://explorations.bitdrift.dev/issues/6165222315746749474/ee83288c-6b25-46e7-bc92-b2ed9080feb1?6165222315746749474-filter=foreground...is...0&6165222315746749474-filter=report_type...is...AppNotResponding%7E%7EJVMCrash%7E%7ENativeCrash&index=0&range=7d) as `Undetermined ANR` given this is a fake generated report.
After fix the ANR is properly classified as [Background ANR here](https://explorations.bitdrift.dev/issues/3357614631264546896/a7b74baa-0976-4094-bf22-5bf7ca8b73b9)

- Also tested other ANR reasons as well 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.