### PR TITLE
Expose SDK status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 **Added**
 
 - Add optional `startResult` callback to `start` method that reports success with the logger instance or failure with error details.
+- Add `getSdkStatus()` API that returns a point-in-time snapshot of the SDK's operational status, including initialization state (`NotStarted`, `Loaded`, `Running`, `Disabled`), last handshake time, and last config delivery time.
 
 **Changed**
 

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "492bd12db07daf3f7c559caf806d15778eba6977fde0bf74a49dea5dc00417a2",
+  "checksum": "506d3700c78a259a095ff1f7497d3fc268fecd5e5e2fe979b413e980e695aec7",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-api"
         }
@@ -1745,7 +1745,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1878,7 +1878,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1934,7 +1934,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -1998,7 +1998,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2104,7 +2104,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2180,7 +2180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2329,7 +2329,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2466,7 +2466,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2603,7 +2603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2696,7 +2696,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2760,7 +2760,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2925,7 +2925,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-device"
         }
@@ -2997,7 +2997,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-events"
         }
@@ -3145,7 +3145,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3376,7 +3376,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3455,7 +3455,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3587,7 +3587,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3647,7 +3647,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3735,7 +3735,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-log"
         }
@@ -3835,7 +3835,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3923,7 +3923,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4011,7 +4011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4071,7 +4071,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4164,7 +4164,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4421,7 +4421,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4481,7 +4481,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4529,7 +4529,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4577,7 +4577,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4646,7 +4646,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4706,7 +4706,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4808,7 +4808,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4918,7 +4918,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5050,7 +5050,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5122,7 +5122,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5220,7 +5220,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5344,7 +5344,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5428,7 +5428,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5525,7 +5525,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-session"
         }
@@ -5730,7 +5730,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5834,7 +5834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5890,7 +5890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-state"
         }
@@ -5999,7 +5999,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6072,7 +6072,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6288,7 +6288,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-time"
         }
@@ -6365,7 +6365,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b0be4381c95f30ff9532171771265c08aae97d01bccd1871f6e8022480a3d840",
+  "checksum": "3c5a37d0e13d0ead814d94f86aac1d6a20295b2c38ef5d13f7d51d10698581cf",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-api"
         }
@@ -1745,7 +1745,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1878,7 +1878,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1934,7 +1934,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -1998,7 +1998,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2104,7 +2104,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2180,7 +2180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2329,7 +2329,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2466,7 +2466,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2603,7 +2603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2696,7 +2696,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2760,7 +2760,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2925,7 +2925,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-device"
         }
@@ -2997,7 +2997,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-events"
         }
@@ -3145,7 +3145,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3376,7 +3376,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3455,7 +3455,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3587,7 +3587,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3647,7 +3647,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3735,7 +3735,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-log"
         }
@@ -3835,7 +3835,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3923,7 +3923,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4011,7 +4011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4071,7 +4071,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4164,7 +4164,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4421,7 +4421,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4481,7 +4481,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4529,7 +4529,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4577,7 +4577,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4646,7 +4646,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4706,7 +4706,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4808,7 +4808,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4918,7 +4918,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5050,7 +5050,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5122,7 +5122,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5220,7 +5220,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5344,7 +5344,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5428,7 +5428,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5525,7 +5525,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-session"
         }
@@ -5730,7 +5730,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5834,7 +5834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5890,7 +5890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-state"
         }
@@ -5999,7 +5999,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6072,7 +6072,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6288,7 +6288,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-time"
         }
@@ -6365,7 +6365,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "0de96efe2e49b6e88d0d63658925f40a6e354966"
+            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3c5a37d0e13d0ead814d94f86aac1d6a20295b2c38ef5d13f7d51d10698581cf",
+  "checksum": "492bd12db07daf3f7c559caf806d15778eba6977fde0bf74a49dea5dc00417a2",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-api"
         }
@@ -1745,7 +1745,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1878,7 +1878,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1934,7 +1934,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -1998,7 +1998,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2104,7 +2104,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2180,7 +2180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2329,7 +2329,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2466,7 +2466,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2603,7 +2603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2696,7 +2696,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2760,7 +2760,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2925,7 +2925,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-device"
         }
@@ -2997,7 +2997,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-events"
         }
@@ -3145,7 +3145,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3376,7 +3376,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3455,7 +3455,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3587,7 +3587,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3647,7 +3647,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3735,7 +3735,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-log"
         }
@@ -3835,7 +3835,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3923,7 +3923,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4011,7 +4011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4071,7 +4071,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4164,7 +4164,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4421,7 +4421,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4481,7 +4481,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4529,7 +4529,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4577,7 +4577,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4646,7 +4646,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4706,7 +4706,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4808,7 +4808,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4918,7 +4918,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5050,7 +5050,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5122,7 +5122,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5220,7 +5220,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5344,7 +5344,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5428,7 +5428,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5525,7 +5525,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-session"
         }
@@ -5730,7 +5730,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5834,7 +5834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5890,7 +5890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-state"
         }
@@ -5999,7 +5999,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6072,7 +6072,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6288,7 +6288,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-time"
         }
@@ -6365,7 +6365,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "6649c49d5f6eedc3350b6a990920d6e241d68c80"
+            "Rev": "79d500785e785afe68fa7d0e19b01c80ca2cdc79"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "base64",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "anyhow",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "anyhow",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "anyhow",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "anyhow",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "base64",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "anyhow",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "anyhow",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "anyhow",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "anyhow",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=79d500785e785afe68fa7d0e19b01c80ca2cdc79#79d500785e785afe68fa7d0e19b01c80ca2cdc79"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "base64",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "anyhow",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "anyhow",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "anyhow",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "anyhow",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=0de96efe2e49b6e88d0d63658925f40a6e354966#0de96efe2e49b6e88d0d63658925f40a6e354966"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6649c49d5f6eedc3350b6a990920d6e241d68c80#6649c49d5f6eedc3350b6a990920d6e241d68c80"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "0.10.0"
 env_logger = { version = "0.11.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "79d500785e785afe68fa7d0e19b01c80ca2cdc79" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "0.10.0"
 env_logger = { version = "0.11.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "0de96efe2e49b6e88d0d63658925f40a6e354966" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6649c49d5f6eedc3350b6a990920d6e241d68c80" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "0.10.0"
 env_logger = { version = "0.11.10", default-features = false }

--- a/examples/android/MainActivity.kt
+++ b/examples/android/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.testTag
 import io.bitdrift.capture.Capture.Logger
 import io.bitdrift.capture.CaptureResult
+import io.bitdrift.capture.InitializationState
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.common.ErrorHandler
 import io.bitdrift.capture.network.okhttp.CaptureOkHttpEventListenerFactory
@@ -48,6 +49,9 @@ import java.io.IOException
 import kotlin.system.exitProcess
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class MainActivity : ComponentActivity() {
 
@@ -88,6 +92,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var client: OkHttpClient
     private lateinit var sessionIdTextView: TextView
     private lateinit var deviceCodeTextView: TextView
+    private lateinit var sdkStatusLabel: TextView
     private lateinit var logLevelSpinner: Spinner
     private lateinit var appExitReasonSpinner: Spinner
 
@@ -102,6 +107,9 @@ class MainActivity : ComponentActivity() {
         sessionIdTextView.text = Logger.sessionId
 
         deviceCodeTextView = findViewById(R.id.device_code)
+
+        sdkStatusLabel = findViewById(R.id.sdk_status)
+        checkSdkStatus()
 
         logLevelSpinner = findViewById(R.id.spinner)
         logLevelSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, LogLevel.values())
@@ -176,6 +184,33 @@ class MainActivity : ComponentActivity() {
     fun startNewSession(@Suppress("UNUSED_PARAMETER") view: View) {
         Logger.startNewSession()
         sessionIdTextView.text = Logger.sessionId
+    }
+
+    fun checkSdkStatus(@Suppress("UNUSED_PARAMETER") view: View? = null) {
+        val status = Logger.getSdkStatus()
+        val timeFormat = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+
+        val state = when (status.initializationState) {
+            InitializationState.NOT_STARTED -> "Not Started"
+            InitializationState.LOADED -> "Loaded"
+            InitializationState.RUNNING -> "Running"
+        }
+
+        val text = buildString {
+            append("State: $state")
+
+            status.lastHandshakeTimeMs?.let {
+                append("\nLast handshake: ${timeFormat.format(Date(it))}")
+            } ?: append("\nNo handshake yet")
+
+            status.lastConfigDeliveryTimeMs?.let {
+                append("\nLast config: ${timeFormat.format(Date(it))}")
+            } ?: append("\nNo config delivery yet")
+
+            append("\nChecked at: ${timeFormat.format(Date())}")
+        }
+
+        sdkStatusLabel.text = text
     }
 
     fun generateTmpDeviceCode(view: View) {

--- a/examples/android/MainActivity.kt
+++ b/examples/android/MainActivity.kt
@@ -194,6 +194,7 @@ class MainActivity : ComponentActivity() {
             InitializationState.NOT_STARTED -> "Not Started"
             InitializationState.LOADED -> "Loaded"
             InitializationState.RUNNING -> "Running"
+            InitializationState.DISABLED -> "Disabled"
         }
 
         val text = buildString {

--- a/examples/android/res/layout/android_main.xml
+++ b/examples/android/res/layout/android_main.xml
@@ -6,12 +6,47 @@
     android:orientation="vertical"
     tools:context=".MainActivity"
     >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_margin="3dp"
+        android:padding="8dp"
+        android:background="#1A000000">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SDK State"
+            android:textStyle="bold"
+            android:textSize="14sp"
+            />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/sdk_status"
+            android:text="Not checked yet"
+            android:textSize="12sp"
+            android:fontFamily="monospace"
+            />
+
+        <Button
+            android:text="Check SDK State"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="checkSdkStatus"
+            />
+    </LinearLayout>
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/session_id"
         android:layout_margin="3dp"
         />
+
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/examples/objective-c/CAPViewController.m
+++ b/examples/objective-c/CAPViewController.m
@@ -465,6 +465,9 @@ NSString *logLevelToString(LogLevel level) {
         case CAPInitializationStateRunning:
             stateStr = @"Running";
             break;
+        case CAPInitializationStateDisabled:
+            stateStr = @"Disabled";
+            break;
         default:
             stateStr = @"Unknown";
             break;

--- a/examples/objective-c/CAPViewController.m
+++ b/examples/objective-c/CAPViewController.m
@@ -65,6 +65,7 @@ NSString *logLevelToString(LogLevel level) {
 @property (nonatomic, weak) UIButton *pickSessionStrategyButton;
 @property (nonatomic, weak) UITextField *apiKeyTextField;
 @property (nonatomic, weak) UITextField *apiURLTextField;
+@property (nonatomic, weak) UILabel *sdkStatusLabel;
 @property (nonatomic, strong) CAPIssueLogger *issueLogger;
 @property (nonatomic, assign) BOOL watchdogExitArmed;
 @property (nonatomic, assign) CAPSampleSessionStrategy sessionStrategy;
@@ -127,13 +128,14 @@ NSString *logLevelToString(LogLevel level) {
     rootView.backgroundColor = [UIColor whiteColor];
 
     UIView *configurationView = [self createConfigurationView];
+    UIView *sdkStatusView = [self createSdkStatusView];
     UIView *sendLogView = [self createSendLogView];
     UIView *copySessionURLView = [self createCopySessionURLView];
     UIView *crashActionsView = [self createCrashActionsView];
     UIView *copySessionIDView = [self createCopySessionIDView];
 
     UIStackView *contentStack = [[UIStackView alloc]
-                                 initWithArrangedSubviews:@[configurationView, sendLogView, crashActionsView, copySessionURLView, copySessionIDView]];
+                                 initWithArrangedSubviews:@[configurationView, sdkStatusView, sendLogView, crashActionsView, copySessionURLView, copySessionIDView]];
     contentStack.axis = UILayoutConstraintAxisVertical;
     contentStack.spacing = 16;
     contentStack.translatesAutoresizingMaskIntoConstraints = NO;
@@ -171,6 +173,7 @@ NSString *logLevelToString(LogLevel level) {
     [super viewWillAppear:animated];
 
     [self refresh];
+    [self checkSdkStatus];
 }
 
 - (void)setSelectedLogLevel:(LogLevel)selectedLogLevel {
@@ -285,6 +288,32 @@ NSString *logLevelToString(LogLevel level) {
     self.pickSessionStrategyButton = pickSessionStrategyButton;
 
     return configurationView;
+}
+
+- (UIView *)createSdkStatusView {
+    UILabel *titleLabel = [UILabel new];
+    titleLabel.text = @"SDK State";
+    titleLabel.font = [UIFont boldSystemFontOfSize:14];
+
+    UILabel *sdkStatusLabel = [UILabel new];
+    sdkStatusLabel.text = @"Not checked yet";
+    sdkStatusLabel.font = [UIFont monospacedSystemFontOfSize:12 weight:UIFontWeightRegular];
+    sdkStatusLabel.numberOfLines = 0;
+    sdkStatusLabel.textColor = UIColor.darkGrayColor;
+
+    UIButton *checkButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    checkButton.backgroundColor = UIColor.systemTealColor;
+    checkButton.tintColor = UIColor.whiteColor;
+    [checkButton setTitle:@"Check SDK State" forState:UIControlStateNormal];
+    [checkButton addTarget:self action:@selector(checkSdkStatus) forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *sdkStatusView = [[UIStackView alloc] initWithArrangedSubviews:@[titleLabel, sdkStatusLabel, checkButton]];
+    sdkStatusView.axis = UILayoutConstraintAxisVertical;
+    sdkStatusView.spacing = 8;
+
+    self.sdkStatusLabel = sdkStatusLabel;
+
+    return sdkStatusView;
 }
 
 - (UIView *)createSendLogView {
@@ -421,6 +450,47 @@ NSString *logLevelToString(LogLevel level) {
 }
 
 // MARK: - Actions
+
+- (void)checkSdkStatus {
+    CAPSdkStatus *status = [CAPLogger getSdkStatus];
+
+    NSString *stateStr;
+    switch (status.initializationState) {
+        case CAPInitializationStateNotStarted:
+            stateStr = @"Not Started";
+            break;
+        case CAPInitializationStateLoaded:
+            stateStr = @"Loaded";
+            break;
+        case CAPInitializationStateRunning:
+            stateStr = @"Running";
+            break;
+        default:
+            stateStr = @"Unknown";
+            break;
+    }
+
+    NSDateFormatter *formatter = [NSDateFormatter new];
+    formatter.dateFormat = @"HH:mm:ss";
+
+    NSMutableString *text = [NSMutableString stringWithFormat:@"State: %@", stateStr];
+
+    if (status.lastHandshakeTime) {
+        [text appendFormat:@"\nLast handshake: %@", [formatter stringFromDate:status.lastHandshakeTime]];
+    } else {
+        [text appendString:@"\nNo handshake yet"];
+    }
+
+    if (status.lastConfigDeliveryTime) {
+        [text appendFormat:@"\nLast config: %@", [formatter stringFromDate:status.lastConfigDeliveryTime]];
+    } else {
+        [text appendString:@"\nNo config delivery yet"];
+    }
+
+    [text appendFormat:@"\nChecked at: %@", [formatter stringFromDate:[NSDate date]]];
+
+    self.sdkStatusLabel.text = text;
+}
 
 - (void)sendLog {
     switch (self.selectedLogLevel) {

--- a/examples/swift/hello_world/ContentView.swift
+++ b/examples/swift/hello_world/ContentView.swift
@@ -22,6 +22,7 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             PanelScreen {
+                SdkStatusPanelView()
                 SessionPanelView(loggerCustomer: self.loggerCustomer)
                 ManualCapturePanelView(loggerCustomer: self.loggerCustomer)
                 AutomaticCapturePanelView(loggerCustomer: self.loggerCustomer)

--- a/examples/swift/hello_world/SdkStatusPanelView.swift
+++ b/examples/swift/hello_world/SdkStatusPanelView.swift
@@ -1,0 +1,115 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import Capture
+import SwiftUI
+
+struct SdkStatusPanelView: View {
+    @State private var sdkStatus: SdkStatus?
+    @State private var lastCheckTime: Date?
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    var body: some View {
+        PanelSection(title: "SDK State") {
+            PanelCard(background: Color.black.opacity(0.24)) {
+                if let status = sdkStatus {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("State:")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundColor(Theme.textSecondary)
+                            Text(stateLabel(for: status.initializationState))
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundColor(
+                                    status.initializationState == .running
+                                        ? Theme.primary
+                                        : Theme.textSecondary
+                                )
+                        }
+
+                        if let handshake = status.lastHandshakeTime {
+                            HStack {
+                                Text("Last handshake:")
+                                    .font(.caption)
+                                    .foregroundColor(Theme.textSecondary)
+                                Text(dateFormatter.string(from: handshake))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(Theme.textPrimary)
+                            }
+                        } else {
+                            Text("No handshake yet")
+                                .font(.caption)
+                                .foregroundColor(Theme.textSecondary)
+                        }
+
+                        if let configDelivery = status.lastConfigDeliveryTime {
+                            HStack {
+                                Text("Last config delivery:")
+                                    .font(.caption)
+                                    .foregroundColor(Theme.textSecondary)
+                                Text(dateFormatter.string(from: configDelivery))
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(Theme.textPrimary)
+                            }
+                        } else {
+                            Text("No config delivery yet")
+                                .font(.caption)
+                                .foregroundColor(Theme.textSecondary)
+                        }
+
+                        if let checkTime = lastCheckTime {
+                            Text("Checked at: \(dateFormatter.string(from: checkTime))")
+                                .font(.caption2)
+                                .foregroundColor(Theme.textSecondary.opacity(0.7))
+                        }
+                    }
+                } else {
+                    Text("Not checked yet")
+                        .font(.subheadline)
+                        .foregroundColor(Theme.textSecondary)
+                }
+
+                Button(action: checkSdkStatus) {
+                    Text("Check SDK State")
+                }
+                .buttonStyle(
+                    OutlineButtonStyle(
+                        stroke: Theme.secondary,
+                        foreground: Theme.textPrimary,
+                        background: Theme.secondary.opacity(0.10)
+                    )
+                )
+            }
+        }
+        .onAppear {
+            checkSdkStatus()
+        }
+    }
+
+    private func checkSdkStatus() {
+        sdkStatus = Capture.Logger.getSdkStatus()
+        lastCheckTime = Date()
+    }
+
+    private func stateLabel(for state: InitializationState) -> String {
+        switch state {
+        case .notStarted:
+            return "Not Started"
+        case .loaded:
+            return "Loaded"
+        case .running:
+            return "Running"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+}

--- a/examples/swift/hello_world/SdkStatusPanelView.swift
+++ b/examples/swift/hello_world/SdkStatusPanelView.swift
@@ -108,6 +108,8 @@ struct SdkStatusPanelView: View {
             return "Loaded"
         case .running:
             return "Running"
+        case .disabled:
+            return "Disabled"
         @unknown default:
             return "Unknown"
         }

--- a/platform/jvm/capture/consumer-rules.pro
+++ b/platform/jvm/capture/consumer-rules.pro
@@ -73,6 +73,11 @@
    public <init>(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Map);
 }
 
+# Accessed from Rust/JNI — constructor must remain stable.
+-keep class io.bitdrift.capture.SdkStatus {
+   public <init>(int, long, long);
+}
+
 -keep, includedescriptorclasses class io.bitdrift.capture.IEventsListenerTarget {
    public <methods>;
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -281,9 +281,6 @@ object Capture {
 
         /**
          * Returns a point-in-time snapshot of the SDK's operational status.
-         *
-         * This is a synchronous polling API that returns the current state of the SDK.
-         * Returns [InitializationState.NOT_STARTED] if the SDK has not been started.
          */
         @JvmStatic
         fun getSdkStatus(): SdkStatus =

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -280,6 +280,17 @@ object Capture {
         fun getPreviousRunInfo(): PreviousRunInfo? = (logger() as? LoggerImpl)?.getPreviousRunInfo()
 
         /**
+         * Returns a point-in-time snapshot of the SDK's operational status.
+         *
+         * This is a synchronous polling API that returns the current state of the SDK.
+         * Returns [InitializationState.NOT_STARTED] if the SDK has not been started.
+         */
+        @JvmStatic
+        fun getSdkStatus(): SdkStatus =
+            (logger() as? LoggerImpl)?.getSdkStatus()
+                ?: SdkStatus(InitializationState.NOT_STARTED, null, null)
+
+        /**
          * Adds a field that should be attached to all logs emitted by the logger going forward.
          * If a field with a given key has already been registered with the logger, its value is
          * overridden with the new value.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -88,6 +88,14 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
     external fun startLogger(loggerId: Long)
 
     /**
+     * Returns a point-in-time snapshot of the SDK's operational status.
+     *
+     * @param loggerId the ID of the logger to query.
+     * @return an [SdkStatus] object with the current SDK state.
+     */
+    external fun getSdkStatus(loggerId: Long): SdkStatus
+
+    /**
      * Destroys the logger associated with the provided logger id. If called more than once for a
      * given logger, subsequent calls will be no-ops.
      *

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -334,6 +334,8 @@ internal class LoggerImpl(
     override val isTracingActive: Boolean
         get() = CaptureJniLibrary.isTracingActive(this.loggerId)
 
+    fun getSdkStatus(): SdkStatus = CaptureJniLibrary.getSdkStatus(this.loggerId)
+
     override fun startNewSession() {
         CaptureJniLibrary.startNewSession(this.loggerId)
     }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/SdkStatus.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/SdkStatus.kt
@@ -1,0 +1,51 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+/**
+ * The SDK's initialization state.
+ */
+enum class InitializationState {
+    /** The SDK has not been started yet. */
+    NOT_STARTED,
+
+    /** The SDK library has been loaded but log processing has not yet begun. */
+    LOADED,
+
+    /** The SDK is fully running and processing logs. */
+    RUNNING,
+}
+
+/**
+ * A point-in-time snapshot of the SDK's operational status.
+ *
+ * @property initializationState The current initialization state of the SDK.
+ * @property lastHandshakeTimeMs The wall-clock time (epoch millis) of the last successful
+ *           handshake, or `null` if no handshake has occurred.
+ * @property lastConfigDeliveryTimeMs The wall-clock time (epoch millis) of the last successful
+ *           config delivery from the backend, or `null` if none has occurred.
+ */
+data class SdkStatus(
+    val initializationState: InitializationState,
+    val lastHandshakeTimeMs: Long?,
+    val lastConfigDeliveryTimeMs: Long?,
+) {
+    /**
+     * JNI constructor that accepts the initialization state as an integer ordinal
+     * and timestamps where -1 means not available.
+     */
+    internal constructor(
+        initializationStateOrdinal: Int,
+        lastHandshakeTimeMs: Long,
+        lastConfigDeliveryTimeMs: Long,
+    ) : this(
+        initializationState = InitializationState.entries[initializationStateOrdinal],
+        lastHandshakeTimeMs = lastHandshakeTimeMs.takeIf { it >= 0 },
+        lastConfigDeliveryTimeMs = lastConfigDeliveryTimeMs.takeIf { it >= 0 },
+    )
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/SdkStatus.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/SdkStatus.kt
@@ -19,6 +19,9 @@ enum class InitializationState {
 
     /** The SDK is fully running and processing logs. */
     RUNNING,
+
+    /** The SDK has been force-disabled by the server (e.g., authentication failure). */
+    DISABLED,
 }
 
 /**

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -42,6 +42,7 @@ class CaptureTest {
     @Before
     fun tearDown() {
         latestAppExitInfoProvider.reset()
+        Logger.resetShared()
     }
 
     // This Test needs to run first since the following tests need to initialize
@@ -126,6 +127,9 @@ class CaptureTest {
             capturedResult = result
         }
 
+        val status = Logger.getSdkStatus()
+        assertThat(status.initializationState).isNotEqualTo(InitializationState.NOT_STARTED)
+
         val logger = Capture.logger()
         assertThat(logger).isNotNull()
         assertThat(Logger.deviceId).isNotNull()
@@ -189,5 +193,14 @@ class CaptureTest {
         val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
         assertThat(previousRunInfo).isNull()
+    }
+
+    @Test
+    fun getSdkStatus_beforeStart_returnsNotStarted() {
+        val status = Logger.getSdkStatus()
+
+        assertThat(status.initializationState).isEqualTo(InitializationState.NOT_STARTED)
+        assertThat(status.lastHandshakeTimeMs).isNull()
+        assertThat(status.lastConfigDeliveryTimeMs).isNull()
     }
 }

--- a/platform/jvm/core/src/jni.rs
+++ b/platform/jvm/core/src/jni.rs
@@ -62,7 +62,7 @@ use jni::sys::{
 };
 use jni::{JNIEnv, JavaVM};
 use platform_shared::metadata::Mobile;
-use platform_shared::{LoggerHolder, LoggerId};
+use platform_shared::{date_to_unix_milliseconds, LoggerHolder, LoggerId};
 use protobuf::Enum as _;
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
@@ -212,6 +212,9 @@ static REPORT_PROCESSING_SESSION_PREVIOUS_RUN: OnceLock<CachedClass> = OnceLock:
 static ISSUE_REPORT_DISPATCHER_DISPATCH: OnceLock<CachedMethod> = OnceLock::new();
 static ISSUE_REPORT_CLASS: OnceLock<CachedClass> = OnceLock::new();
 static ISSUE_REPORT_CONSTRUCTOR: OnceLock<CachedMethod> = OnceLock::new();
+
+static SDK_STATUS_CLASS: OnceLock<CachedClass> = OnceLock::new();
+static SDK_STATUS_CONSTRUCTOR: OnceLock<CachedMethod> = OnceLock::new();
 
 pub(crate) fn initialize_method_handle<
   'local,
@@ -384,6 +387,20 @@ fn jni_load_inner(vm: &JavaVM) -> anyhow::Result<jint> {
     "<init>",
     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V",
     &ISSUE_REPORT_CONSTRUCTOR,
+  )?;
+
+  let sdk_status_class = initialize_class(
+    &mut env,
+    "io/bitdrift/capture/SdkStatus",
+    Some(&SDK_STATUS_CLASS),
+  )?;
+
+  initialize_method_handle(
+    &mut env,
+    &sdk_status_class.class,
+    "<init>",
+    "(IJJ)V",
+    &SDK_STATUS_CONSTRUCTOR,
   )?;
 
   key_value_storage::initialize(&mut env)?;
@@ -882,6 +899,50 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_startLogger(
 ) {
   let logger = unsafe { LoggerId::from_raw(logger_id) };
   logger.start();
+}
+
+#[no_mangle]
+pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_getSdkStatus(
+  mut env: JNIEnv<'_>,
+  _class: JClass<'_>,
+  logger_id: jlong,
+) -> jobject {
+  with_handle_unexpected_or(
+    || {
+      let logger = unsafe { LoggerId::from_raw(logger_id) };
+      let status = logger.get_sdk_status();
+
+      let initialization_state = status.initialization_state as i32;
+      let last_handshake_time = date_to_unix_milliseconds(status.last_handshake_time);
+      let last_config_delivery_time = date_to_unix_milliseconds(status.last_config_delivery_time);
+
+      let sdk_status_class = SDK_STATUS_CLASS.get().ok_or(InvariantError::Invariant)?;
+      let obj = unsafe {
+        env.new_object_unchecked(
+          &sdk_status_class.class,
+          SDK_STATUS_CONSTRUCTOR
+            .get()
+            .ok_or(InvariantError::Invariant)?
+            .method_id,
+          &[
+            jvalue {
+              i: initialization_state,
+            },
+            jvalue {
+              j: last_handshake_time,
+            },
+            jvalue {
+              j: last_config_delivery_time,
+            },
+          ],
+        )?
+      };
+
+      Ok(obj.as_raw())
+    },
+    JObject::null().as_raw(),
+    "jni get_sdk_status",
+  )
 }
 
 #[no_mangle]

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -38,6 +38,8 @@ sealed class SessionAction : AppAction {
     object GenerateDeviceCode : SessionAction()
 
     object CopySessionUrl : SessionAction()
+
+    object CheckConnectivity : SessionAction()
 }
 
 sealed class DiagnosticsAction : AppAction {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/SessionState.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/SessionState.kt
@@ -7,6 +7,8 @@
 
 package io.bitdrift.gradletestapp.data.model
 
+import io.bitdrift.capture.SdkStatus
+
 /** Session feature state */
 data class SessionState(
     val isSdkInitialized: Boolean = false,
@@ -15,4 +17,6 @@ data class SessionState(
     val deviceCode: String? = null,
     val isDeviceCodeValid: Boolean = false,
     val deviceCodeError: String? = null,
+    val sdkStatus: SdkStatus? = null,
+    val lastConnectivityCheckTimeMs: Long = -1,
 )

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
@@ -70,6 +70,7 @@ object BitdriftInit {
 
             Capture.Logger.setEntityId(userUuid)
 
+            Capture.Logger.getSdkStatus()
             @OptIn(ExperimentalBitdriftApi::class)
             Capture.Logger.getPreviousRunInfo()?.let { previousRunInfo ->
                 val hasFatallyTerminated = previousRunInfo.hasFatallyTerminated.toString()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
@@ -24,7 +24,6 @@ import io.bitdrift.capture.reports.Report
 import io.bitdrift.capture.timber.CaptureTree
 import io.bitdrift.capture.webview.WebViewConfiguration
 import io.bitdrift.gradletestapp.BuildConfig
-import java.util.concurrent.Executors
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_CONSOLE_LOGS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_ERRORS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_LONG_TASKS_KEY
@@ -41,6 +40,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
 import java.util.UUID
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * Starts bitdrift's Captures SDK with the persisted config settings
@@ -70,7 +70,6 @@ object BitdriftInit {
 
             Capture.Logger.setEntityId(userUuid)
 
-            Capture.Logger.getSdkStatus()
             @OptIn(ExperimentalBitdriftApi::class)
             Capture.Logger.getPreviousRunInfo()?.let { previousRunInfo ->
                 val hasFatallyTerminated = previousRunInfo.hasFatallyTerminated.toString()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
@@ -252,6 +252,7 @@ private fun HomeTabContent(
             SdkStatusCard(
                 uiState = uiState,
                 onInitializeSdk = { onAction(ConfigAction.InitializeSdk) },
+                onCheckSdkState = { onAction(SessionAction.CheckConnectivity) },
                 onOpenSettings = onOpenSettings,
             )
         }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/SdkStatusCard.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/SdkStatusCard.kt
@@ -151,6 +151,7 @@ private fun SdkStateSection(
                     InitializationState.NOT_STARTED -> "Not Started"
                     InitializationState.LOADED -> "Loaded"
                     InitializationState.RUNNING -> "Running"
+                    InitializationState.DISABLED -> "Disabled"
                 }
 
                 Text(

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/SdkStatusCard.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/SdkStatusCard.kt
@@ -16,19 +16,26 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import io.bitdrift.gradletestapp.R
+import io.bitdrift.capture.InitializationState
+import io.bitdrift.capture.SdkStatus
+import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.gradletestapp.data.model.AppState
 import io.bitdrift.gradletestapp.ui.theme.BitdriftColors
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * SDK Status Card component that displays the current SDK state
  */
+@OptIn(ExperimentalBitdriftApi::class)
 @Composable
 fun SdkStatusCard(
     uiState: AppState,
     onInitializeSdk: () -> Unit,
+    onCheckSdkState: () -> Unit,
     onOpenSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -51,7 +58,7 @@ fun SdkStatusCard(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "SDK Status",
+                text = "SDK State",
                 style = MaterialTheme.typography.titleMedium,
                 color = BitdriftColors.TextPrimary,
             )
@@ -62,18 +69,9 @@ fun SdkStatusCard(
                 apiUrl = uiState.config.apiUrl,
             )
 
-            val isValid = uiState.session.isDeviceCodeValid
-            val error = uiState.session.deviceCodeError
-            val deviceStatusText =
-                if (isValid) {
-                    stringResource(id = R.string.device_code_valid)
-                } else {
-                    error ?: stringResource(id = R.string.device_code_invalid)
-                }
-            Text(
-                text = deviceStatusText,
-                style = MaterialTheme.typography.bodySmall,
-                color = if (isValid) BitdriftColors.Primary else BitdriftColors.Error,
+            SdkStateSection(
+                sdkStatus = uiState.session.sdkStatus,
+                lastCheckTimeMs = uiState.session.lastConnectivityCheckTimeMs,
             )
 
             if (uiState.config.isDeferredStart && !uiState.session.isSdkInitialized) {
@@ -93,6 +91,19 @@ fun SdkStatusCard(
                 }
             }
 
+            Button(
+                onClick = onCheckSdkState,
+                enabled = uiState.session.isSdkInitialized,
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = BitdriftColors.Primary,
+                        contentColor = Color.White,
+                    ),
+            ) {
+                Text("Check SDK State")
+            }
+
             OutlinedButton(
                 onClick = onOpenSettings,
                 modifier = Modifier.fillMaxWidth(),
@@ -103,6 +114,93 @@ fun SdkStatusCard(
             ) {
                 Text("Settings")
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalBitdriftApi::class)
+@Composable
+private fun SdkStateSection(
+    sdkStatus: SdkStatus?,
+    lastCheckTimeMs: Long,
+) {
+    if (lastCheckTimeMs < 0) return
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = BitdriftColors.BackgroundPaper,
+        ),
+        border = BorderStroke(
+            width = 1.dp,
+            color = BitdriftColors.Border.copy(alpha = 0.2f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            if (sdkStatus == null) {
+                Text(
+                    text = "Not checked yet",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = BitdriftColors.TextTertiary,
+                )
+            } else {
+                val stateLabel = when (sdkStatus.initializationState) {
+                    InitializationState.NOT_STARTED -> "Not Started"
+                    InitializationState.LOADED -> "Loaded"
+                    InitializationState.RUNNING -> "Running"
+                }
+
+                Text(
+                    text = stateLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (sdkStatus.initializationState == InitializationState.RUNNING) {
+                        BitdriftColors.Primary
+                    } else {
+                        BitdriftColors.TextTertiary
+                    },
+                )
+
+                sdkStatus.lastHandshakeTimeMs?.let { timeMs ->
+                    Text(
+                        text = "Last handshake: ${formatEpochMs(timeMs)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BitdriftColors.TextSecondary,
+                    )
+                }
+
+                sdkStatus.lastConfigDeliveryTimeMs?.let { timeMs ->
+                    Text(
+                        text = "Last config delivery: ${formatEpochMs(timeMs)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BitdriftColors.TextSecondary,
+                    )
+                }
+
+                if (sdkStatus.lastHandshakeTimeMs == null) {
+                    Text(
+                        text = "No handshake yet",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BitdriftColors.TextTertiary,
+                    )
+                }
+
+                if (sdkStatus.lastHandshakeTimeMs == null && sdkStatus.lastConfigDeliveryTimeMs == null) {
+                    Text(
+                        text = "No config delivery yet",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BitdriftColors.TextTertiary,
+                    )
+                }
+            }
+
+            Text(
+                text = "Checked at: ${formatEpochMs(lastCheckTimeMs)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = BitdriftColors.TextTertiary,
+            )
         }
     }
 }
@@ -145,12 +243,12 @@ private fun SdkStatusBadge(
         ) {
             Icon(
                 imageVector = if (isInitialized) Icons.Filled.CheckCircle else Icons.Filled.Close,
-                contentDescription = "SDK Status",
+                contentDescription = "SDK State",
                 modifier = Modifier.size(24.dp),
                 tint = if (isInitialized) BitdriftColors.Primary else MaterialTheme.colorScheme.error,
             )
             Text(
-                text = if (isInitialized) "Started" else "Not Started",
+                text = if (isInitialized) "Initialized" else "Not Initialized",
                 style = MaterialTheme.typography.titleSmall,
                 color = if (isInitialized) BitdriftColors.Primary else MaterialTheme.colorScheme.error,
             )
@@ -169,4 +267,9 @@ private fun SdkStatusBadge(
             )
         }
     }
+}
+
+private fun formatEpochMs(epochMs: Long): String {
+    val sdf = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+    return sdf.format(Date(epochMs))
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -74,11 +74,10 @@ class MainViewModel(
         val persistedFields = sdkRepository.restoreGlobalFields()
         _uiState.update { it.copy(globalFields = persistedFields) }
         updateSdkState()
-        checkAutoInitialization()
-
-        if (sdkRepository.isSdkInitialized()) {
-            runHealthCheck()
+        if (_uiState.value.session.isSdkInitialized) {
+            checkConnectivity()
         }
+        checkAutoInitialization()
     }
 
     private fun checkAutoInitialization() {
@@ -108,6 +107,7 @@ class MainViewModel(
             is SessionAction.StartNewSession -> startNewSession()
             is SessionAction.GenerateDeviceCode -> generateDeviceCode()
             is SessionAction.CopySessionUrl -> copySessionUrl()
+            is SessionAction.CheckConnectivity -> checkConnectivity()
 
             is DiagnosticsAction.LogSingleMessage -> logSingleMessage()
             is DiagnosticsAction.LogManyMessages -> logManyMessages()
@@ -210,7 +210,7 @@ class MainViewModel(
             val success = sdkRepository.initializeSdk(config.apiKey, config.apiUrl)
             if (success) {
                 updateSdkState()
-                runHealthCheck()
+                checkConnectivity()
                 _uiState.update { it.copy(isLoading = false, error = null) }
             } else {
                 _uiState.update {
@@ -230,7 +230,6 @@ class MainViewModel(
             val sessionId = sdkRepository.startNewSession()
             if (sessionId != null) {
                 updateSdkState()
-                runHealthCheck()
                 _uiState.update { it.copy(isLoading = false) }
             } else {
                 _uiState.update {
@@ -240,22 +239,16 @@ class MainViewModel(
         }
     }
 
-    private fun runHealthCheck() {
-        viewModelScope.launch {
-            // GenerateDeviceCode is a good proxy to determine connectivity
-            val result = sdkRepository.generateDeviceCode()
-            val isValid = result.isSuccess
-            val errorMessage = result.exceptionOrNull()?.message
-            _uiState.update { state ->
-                state.copy(
-                    session =
-                        state.session.copy(
-                            isDeviceCodeValid = isValid,
-                            deviceCodeError = if (!isValid) errorMessage else null,
-                            deviceCode = if (isValid) result.getOrNull() else state.session.deviceCode,
-                        ),
-                )
-            }
+    private fun checkConnectivity() {
+        val status = Logger.getSdkStatus()
+        val now = System.currentTimeMillis()
+        _uiState.update { state ->
+            state.copy(
+                session = state.session.copy(
+                    sdkStatus = status,
+                    lastConnectivityCheckTimeMs = now,
+                ),
+            )
         }
     }
 

--- a/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
@@ -37,8 +37,8 @@
     <string name="generate_device_code">Generate Device Code</string>
     <string name="network_testing">Network Testing</string>
     <string name="navigation">Navigation to other screens</string>
-    <string name="started">Started</string>
-    <string name="not_started">Not Started</string>
+    <string name="started">Initialized</string>
+    <string name="not_started">Not Initialized</string>
     <string name="testing_tools">Log Level and Fatal Issue Testing</string>
     <string name="stress_test" translatable="false">Stress Test</string>
     <string name="open_stress_test" translatable="false">Open Stress Test</string>

--- a/platform/shared/src/lib.rs
+++ b/platform/shared/src/lib.rs
@@ -178,6 +178,11 @@ impl LoggerHolder {
     self.logger.runtime_snapshot()
   }
 
+  /// Returns a point-in-time snapshot of the SDK's operational status.
+  pub fn get_sdk_status(&self) -> bd_client_common::sdk_status::SdkStatus {
+    self.logger.get_sdk_status()
+  }
+
   /// Given a valid logger ID, destroys the logger and frees the memory associated with it.
   ///
   /// # Safety
@@ -251,4 +256,13 @@ impl<'a> From<LoggerId<'a>> for i64 {
   fn from(logger: LoggerId<'a>) -> Self {
     logger.value
   }
+}
+
+/// Converts an optional `OffsetDateTime` to epoch milliseconds.
+/// Returns -1 if the time is `None`.
+#[must_use]
+pub fn date_to_unix_milliseconds(time: Option<time::OffsetDateTime>) -> i64 {
+  time.map_or(-1, |t| {
+    t.unix_timestamp() * 1000 + i64::from(t.millisecond())
+  })
 }

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -120,6 +120,15 @@ extension Logger {
         return Self.getShared()?.deviceID
     }
 
+    /// Returns a point-in-time snapshot of the SDK's operational status.
+    /// Returns `InitializationState.notStarted` if the SDK has not been started.
+    ///
+    /// - returns: The current SDK status.
+    public static func getSdkStatus() -> SdkStatus {
+        return Self.getShared()?.getSdkStatus()
+            ?? SdkStatus(initializationState: .notStarted, lastHandshakeTime: nil, lastConfigDeliveryTime: nil)
+    }
+
     /// Reports previous app run status.
     ///
     /// This API is in experimental phase and may change in the future.

--- a/platform/swift/source/CaptureRustBridge.h
+++ b/platform/swift/source/CaptureRustBridge.h
@@ -223,6 +223,21 @@ NSString *capture_get_device_id(logger_id logger_id);
  */
 NSString *capture_get_sdk_version();
 
+/**
+ * A C-compatible representation of the SDK status.
+ * Timestamps are epoch milliseconds, or -1 if not yet available.
+ */
+typedef struct {
+    int32_t initialization_state;
+    int64_t last_handshake_time_ms;
+    int64_t last_config_delivery_time_ms;
+} SdkStatusFFI;
+
+/**
+ * Returns a point-in-time snapshot of the SDK's operational status.
+ */
+SdkStatusFFI capture_get_sdk_status(logger_id logger_id);
+
 /*
  * Adds a field that should be attached to all logs emitted by the logger going forward.
  * If a field with a given key has already been registered with the logger, its value is

--- a/platform/swift/source/CoreLogger.swift
+++ b/platform/swift/source/CoreLogger.swift
@@ -154,6 +154,10 @@ extension CoreLogger: CoreLogging {
         self.underlyingLogger.getDeviceID()
     }
 
+    func getSdkStatus() -> SdkStatus {
+        self.underlyingLogger.getSdkStatus()
+    }
+
     func addField(withKey key: String, value: String) {
         self.underlyingLogger.addField(withKey: key, value: value)
     }

--- a/platform/swift/source/CoreLogging.swift
+++ b/platform/swift/source/CoreLogging.swift
@@ -123,6 +123,11 @@ protocol CoreLogging: AnyObject {
     /// - returns: Unique device ID.
     func getDeviceID() -> String
 
+    /// Returns a point-in-time snapshot of the SDK's operational status.
+    ///
+    /// - returns: The current SDK status.
+    func getSdkStatus() -> SdkStatus
+
     /// Adds a field to all logs emitted by the logger from this point forward.
     /// If a field with a given key has already been registered with the logger, its value is
     /// replaced with the new one.

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -498,6 +498,10 @@ extension Logger: Logging {
         return self.underlyingLogger.getDeviceID()
     }
 
+    public func getSdkStatus() -> SdkStatus {
+        return self.underlyingLogger.getSdkStatus()
+    }
+
     public func log(
         level: LogLevel,
         message: @autoclosure () -> String,

--- a/platform/swift/source/LoggerBridge.swift
+++ b/platform/swift/source/LoggerBridge.swift
@@ -240,6 +240,11 @@ final class LoggerBridge: LoggerBridging {
         capture_get_device_id(self.loggerID)
     }
 
+    func getSdkStatus() -> SdkStatus {
+        let ffi = capture_get_sdk_status(self.loggerID)
+        return SdkStatus.from(ffi: ffi)
+    }
+
     func addField(withKey key: String, value: String) {
         capture_add_log_field(self.loggerID, key, value)
     }

--- a/platform/swift/source/LoggerBridging.swift
+++ b/platform/swift/source/LoggerBridging.swift
@@ -58,6 +58,8 @@ protocol LoggerBridging {
 
     func getDeviceID() -> String
 
+    func getSdkStatus() -> SdkStatus
+
     func addField(withKey key: String, value: String)
 
     func removeField(withKey key: String)

--- a/platform/swift/source/LoggerObjc.swift
+++ b/platform/swift/source/LoggerObjc.swift
@@ -276,6 +276,14 @@ public final class LoggerObjc: NSObject {
         return capture_get_sdk_version()
     }
 
+    /// Returns a point-in-time snapshot of the SDK's operational status.
+    ///
+    /// - returns: The current SDK status.
+    @objc
+    public static func getSdkStatus() -> SdkStatus {
+        return Capture.Logger.getSdkStatus()
+    }
+
     /// Defines the initialization of a new session within the current configured logger.
     /// If no logger is configured, this is a no-op.
     @objc

--- a/platform/swift/source/Logging.swift
+++ b/platform/swift/source/Logging.swift
@@ -25,6 +25,11 @@ public protocol Logging {
     /// the same device.
     var deviceID: String { get }
 
+    /// Returns a point-in-time snapshot of the SDK's operational status.
+    ///
+    /// - returns: The current SDK status.
+    func getSdkStatus() -> SdkStatus
+
     /// Logs a message at a specified level to the default logger instance.
     ///
     /// - parameter level:    The severity of the log.

--- a/platform/swift/source/SdkStatus.swift
+++ b/platform/swift/source/SdkStatus.swift
@@ -1,0 +1,63 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+internal import CaptureLoggerBridge
+import Foundation
+
+/// The SDK's initialization state.
+@objc(CAPInitializationState)
+public enum InitializationState: Int {
+    /// The SDK has not been started yet.
+    case notStarted = 0
+    /// The SDK library has been loaded and the logger is being constructed,
+    /// but log processing has not yet begun.
+    case loaded = 1
+    /// The SDK is fully running and processing logs.
+    case running = 2
+}
+
+/// A point-in-time snapshot of the SDK's operational status.
+@objc(CAPSdkStatus)
+public final class SdkStatus: NSObject {
+    /// The current initialization state of the SDK.
+    @objc public let initializationState: InitializationState
+
+    /// The time of the last successful handshake with the backend, or nil if none yet.
+    @objc public let lastHandshakeTime: Date?
+
+    /// The time of the last successful config delivery, or nil if none yet.
+    @objc public let lastConfigDeliveryTime: Date?
+
+    init(initializationState: InitializationState, lastHandshakeTime: Date?, lastConfigDeliveryTime: Date?) {
+        self.initializationState = initializationState
+        self.lastHandshakeTime = lastHandshakeTime
+        self.lastConfigDeliveryTime = lastConfigDeliveryTime
+    }
+
+    /// Creates an `SdkStatus` from the FFI struct returned by Rust.
+    ///
+    /// - parameter ffi: The C-compatible struct from the Rust bridge.
+    ///
+    /// - returns: A new `SdkStatus` instance.
+    static func from(ffi: SdkStatusFFI) -> SdkStatus {
+        let state = InitializationState(rawValue: Int(ffi.initialization_state)) ?? .notStarted
+
+        let handshakeTime: Date? = ffi.last_handshake_time_ms >= 0
+            ? Date(timeIntervalSince1970: Double(ffi.last_handshake_time_ms) / 1000.0)
+            : nil
+
+        let configDeliveryTime: Date? = ffi.last_config_delivery_time_ms >= 0
+            ? Date(timeIntervalSince1970: Double(ffi.last_config_delivery_time_ms) / 1000.0)
+            : nil
+
+        return SdkStatus(
+            initializationState: state,
+            lastHandshakeTime: handshakeTime,
+            lastConfigDeliveryTime: configDeliveryTime
+        )
+    }
+}

--- a/platform/swift/source/SdkStatus.swift
+++ b/platform/swift/source/SdkStatus.swift
@@ -18,6 +18,8 @@ public enum InitializationState: Int {
     case loaded = 1
     /// The SDK is fully running and processing logs.
     case running = 2
+    /// The SDK has been force-disabled by the server (e.g., authentication failure).
+    case disabled = 3
 }
 
 /// A point-in-time snapshot of the SDK's operational status.

--- a/platform/swift/source/src/bridge.rs
+++ b/platform/swift/source/src/bridge.rs
@@ -44,7 +44,7 @@ use platform_shared::javascript_error::{
   DeviceMetadata,
 };
 use platform_shared::metadata::{self, Mobile};
-use platform_shared::{LoggerHolder, LoggerId};
+use platform_shared::{date_to_unix_milliseconds, LoggerHolder, LoggerId};
 use protobuf::Enum as _;
 use std::borrow::{Borrow, Cow};
 use std::boxed::Box;
@@ -932,6 +932,25 @@ extern "C" fn capture_get_sdk_version() -> *const Object {
   make_nsstring(&metadata::SDK_VERSION)
     .unwrap_or_else(|_| make_empty_nsstring())
     .autorelease()
+}
+
+/// A C-compatible representation of the SDK status returned to Swift.
+/// Timestamps are epoch milliseconds, or -1 if not yet available.
+#[repr(C)]
+pub struct SdkStatusFFI {
+  pub initialization_state: i32,
+  pub last_handshake_time_ms: i64,
+  pub last_config_delivery_time_ms: i64,
+}
+
+#[no_mangle]
+extern "C" fn capture_get_sdk_status(logger_id: LoggerId<'_>) -> SdkStatusFFI {
+  let status = logger_id.get_sdk_status();
+  SdkStatusFFI {
+    initialization_state: status.initialization_state as i32,
+    last_handshake_time_ms: date_to_unix_milliseconds(status.last_handshake_time),
+    last_config_delivery_time_ms: date_to_unix_milliseconds(status.last_config_delivery_time),
+  }
 }
 
 #[no_mangle]

--- a/test/platform/swift/unit_integration/core/LoggerSharedTests.swift
+++ b/test/platform/swift/unit_integration/core/LoggerSharedTests.swift
@@ -20,6 +20,25 @@ final class LoggerSharedTests: XCTestCase {
         Logger.resetShared()
     }
 
+    func testGetSdkStatus_beforeStart_returnsNotStarted() {
+        Logger.resetShared()
+
+        let status = Capture.Logger.getSdkStatus()
+
+        XCTAssertEqual(status.initializationState, InitializationState.notStarted)
+        XCTAssertNil(status.lastHandshakeTime)
+        XCTAssertNil(status.lastConfigDeliveryTime)
+    }
+
+    func testGetSdkStatus_afterStart_returnsNonNotStartedState() {
+        Logger.resetShared()
+        self.startLoggerWithIsolatedDirectory(apiKey: "test_api_key")
+
+        let status = Capture.Logger.getSdkStatus()
+
+        XCTAssertNotEqual(status.initializationState, InitializationState.notStarted)
+    }
+
     func testIntegrationsAreEnabledOnlyOnce() throws {
         var integrationStartsCount = 0
         let integration = Integration { _, _, _ in

--- a/test/platform/swift/unit_integration/mocks/MockCoreLogging.swift
+++ b/test/platform/swift/unit_integration/mocks/MockCoreLogging.swift
@@ -86,6 +86,10 @@ extension MockCoreLogging: CoreLogging {
 
     public func getDeviceID() -> String { "deviceID" }
 
+    public func getSdkStatus() -> SdkStatus {
+        SdkStatus(initializationState: .notStarted, lastHandshakeTime: nil, lastConfigDeliveryTime: nil)
+    }
+
     public func log(
         level: LogLevel,
         message: @autoclosure () -> String,

--- a/test/platform/swift/unit_integration/mocks/MockLoggerBridging.swift
+++ b/test/platform/swift/unit_integration/mocks/MockLoggerBridging.swift
@@ -64,6 +64,10 @@ extension MockLoggerBridging: LoggerBridging {
 
     public func getDeviceID() -> String { "deviceID" }
 
+    public func getSdkStatus() -> SdkStatus {
+        SdkStatus(initializationState: .notStarted, lastHandshakeTime: nil, lastConfigDeliveryTime: nil)
+    }
+
     public func log(
         level: LogLevel,
         message: @autoclosure () -> String,

--- a/test/platform/swift/unit_integration/mocks/MockLogging.swift
+++ b/test/platform/swift/unit_integration/mocks/MockLogging.swift
@@ -70,6 +70,10 @@ extension MockLogging: Logging {
 
     public var deviceID: String { "deviceID" }
 
+    public func getSdkStatus() -> SdkStatus {
+        SdkStatus(initializationState: .notStarted, lastHandshakeTime: nil, lastConfigDeliveryTime: nil)
+    }
+
     public func log(
         level: LogLevel,
         message: @autoclosure () -> String,


### PR DESCRIPTION
## What 

Resolves BIT-8084

Depends on https://github.com/bitdriftlabs/shared-core/pull/491

Exposing API to retrieve the latest SDK status at any time.

```
val status: SdkStatus = Capture.Logger.getSdkStatus()

data class SdkStatus(
    val initializationState: InitializationState,
    val lastHandshakeTimeMs: Long?,       // epoch millis, null if no handshake yet
    val lastConfigDeliveryTimeMs: Long?,   // epoch millis, null if no config delivery yet
)
enum class InitializationState {
    NOT_STARTED,  // SDK has not been started
    LOADED,       // Logger constructed, log processing not yet begun
    RUNNING,      // Fully running and processing logs
    DISABLED,     // The SDK has been force-disabled by the server (e.g., authentication failure).
}
```

## Verification

| Android gradle-test-app | Android Bazel Release | iOS Swift Sample app | iOS Obj-C Sample App
| -------------------------|  -------------------------|  -------------------------|  -------------------------| 
| <img width="714" height="880" alt="Screenshot 2026-05-18 at 14 58 04" src="https://github.com/user-attachments/assets/2f3e5a85-4520-437a-9523-03262c0fbd6c" /> | <img width="880" height="880" alt="Screenshot 2026-05-18 at 15 15 03" src="https://github.com/user-attachments/assets/603af31c-e9c6-46d3-9c28-2ae2145914f9" /> | <img width="651" height="602" alt="Screenshot 2026-05-18 at 14 57 46" src="https://github.com/user-attachments/assets/a21fc80d-14d1-4563-aaee-2d33268f626f" /> | <img width="663" height="845" alt="Screenshot 2026-05-18 at 14 56 02" src="https://github.com/user-attachments/assets/7d1dc6bd-863e-462e-be16-ada38060d8ba" />

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.