### PR TITLE
[Android] Avoid sending incorrect battery level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed incorrect foreground/background state on fatal issues and app termination logs.
 - Fixed ANRs incorrectly classified as undetermined.
+- Fixed battery level fields emitting invalid values when BatteryManager cannot determine capacity.
 
 ### iOS
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/device/DeviceStateListenerLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/device/DeviceStateListenerLogger.kt
@@ -29,6 +29,7 @@ import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldOf
 import io.bitdrift.capture.providers.fieldsOf
+import io.bitdrift.capture.providers.fieldsOfOptional
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicReference
 
@@ -93,8 +94,8 @@ internal class DeviceStateListenerLogger(
                     log(
                         combineFields(
                             fieldOf("_state", "charging"),
-                            fieldsOf(batteryMonitor.batteryValAttribute()),
-                            fieldsOf(batteryMonitor.batteryLevelAttribute()),
+                            fieldsOfOptional(batteryMonitor.batteryValAttribute()),
+                            fieldsOfOptional(batteryMonitor.batteryLevelAttribute()),
                         ),
                         BATTERY_CHANGE,
                     )
@@ -103,8 +104,8 @@ internal class DeviceStateListenerLogger(
                     log(
                         combineFields(
                             fieldOf("_state", "unplugged"),
-                            fieldsOf(batteryMonitor.batteryValAttribute()),
-                            fieldsOf(batteryMonitor.batteryLevelAttribute()),
+                            fieldsOfOptional(batteryMonitor.batteryValAttribute()),
+                            fieldsOfOptional(batteryMonitor.batteryLevelAttribute()),
                         ),
                         BATTERY_CHANGE,
                     )
@@ -119,8 +120,8 @@ internal class DeviceStateListenerLogger(
                     log(
                         combineFields(
                             fieldsOf(powerMonitor.isPowerSaveModeEnabledAttribute()),
-                            fieldsOf(batteryMonitor.batteryValAttribute()),
-                            fieldsOf(batteryMonitor.batteryLevelAttribute()),
+                            fieldsOfOptional(batteryMonitor.batteryValAttribute()),
+                            fieldsOfOptional(batteryMonitor.batteryLevelAttribute()),
                             fieldsOf(batteryMonitor.isBatteryChargingAttribute()),
                         ),
                         BATTERY_LOW,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/BatteryMonitor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/BatteryMonitor.kt
@@ -17,9 +17,9 @@ internal class BatteryMonitor(
 ) {
     private val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
 
-    fun batteryValAttribute(): Pair<String, String> = "_battery_val" to batteryPercentage().toString()
+    fun batteryValAttribute(): Pair<String, String?> = "_battery_val" to batteryLevelCapacity()?.let { (it / 100.0f).toString() }
 
-    fun batteryLevelAttribute(): Pair<String, String> = "_battery_level" to batteryLevelCapacity().toString()
+    fun batteryLevelAttribute(): Pair<String, String?> = "_battery_level" to batteryLevelCapacity()?.toString()
 
     fun isBatteryChargingAttribute(): Pair<String, String> = Pair("_state", if (isBatteryCharging()) "charging" else "unplugged")
 
@@ -32,7 +32,10 @@ internal class BatteryMonitor(
         return (status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL)
     }
 
-    private fun batteryPercentage(): Float = batteryLevelCapacity() / 100.0f
-
-    private fun batteryLevelCapacity(): Int = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+    // BatteryManager.getIntProperty returns Integer.MIN_VALUE (API 28+) or 0 (older APIs)
+    // when the value cannot be determined. Return null to avoid emitting bogus battery fields.
+    private fun batteryLevelCapacity(): Int? {
+        val level = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        return if (level in 0..100) level else null
+    }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTarget.kt
@@ -17,6 +17,7 @@ import io.bitdrift.capture.events.common.PowerMonitor
 import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldsOf
+import io.bitdrift.capture.providers.fieldsOfOptional
 import java.util.concurrent.ExecutorService
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -41,8 +42,8 @@ internal class ResourceUtilizationTarget(
                         memorySnapshot,
                         diskUsageMonitor.getDiskUsage(),
                         fieldsOf(powerMonitor.isPowerSaveModeEnabledAttribute()),
-                        fieldsOf(batteryMonitor.batteryValAttribute()),
-                        fieldsOf(batteryMonitor.batteryLevelAttribute()),
+                        fieldsOfOptional(batteryMonitor.batteryValAttribute()),
+                        fieldsOfOptional(batteryMonitor.batteryLevelAttribute()),
                         fieldsOf(batteryMonitor.isBatteryChargingAttribute()),
                     )
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTargetTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/ResourceUtilizationTargetTest.kt
@@ -125,6 +125,39 @@ class ResourceUtilizationTargetTest {
     }
 
     @Test
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+    fun resourceUtilizationWithNullBatteryValueShouldOmitBatteryFields() {
+        whenever(batteryMonitor.batteryValAttribute()).thenReturn(Pair("_battery_val", null))
+        whenever(batteryMonitor.batteryLevelAttribute()).thenReturn(Pair("_battery_level", null))
+        whenever(batteryMonitor.isBatteryChargingAttribute()).thenReturn(Pair("_state", "charging"))
+        whenever(powerMonitor.isPowerSaveModeEnabledAttribute()).thenReturn(Pair("_low_power_enabled", "1"))
+        whenever(diskUsageMonitor.getDiskUsage()).thenReturn(ArrayFields.EMPTY)
+
+        reporter.tick()
+
+        executor.awaitTermination(1, TimeUnit.SECONDS)
+
+        val expectedMap =
+            mapOf(
+                "_jvm_used_kb" to "50",
+                "_jvm_total_kb" to "100",
+                "_jvm_max_kb" to "100",
+                "_jvm_used_percent" to "50",
+                "_native_used_kb" to "200",
+                "_native_total_kb" to "500",
+                "_memory_class" to "1",
+                "_is_memory_low" to "0",
+                "_state" to "charging",
+                "_low_power_enabled" to "1",
+            )
+
+        verify(logger).logResourceUtilization(
+            argThat<ArrayFields> { toStringMap() == expectedMap },
+            Duration(any<Long>()),
+        )
+    }
+
+    @Test
     fun resourceUtilizationTickSnapshotFails() {
         val exception = IllegalArgumentException()
         memoryMetricsProvider.setException(exception)


### PR DESCRIPTION
## What

Resolves BIT-8290

Android `BatteryManager.getIntProperty` can return `Integer.MIN_VALUE` when value cannot be determined. 

Changing this to omit emitting the field if we don't have an accurate reading

## Verification

Tested on emulator changing battery levels. See [session](https://timeline.bitdrift.dev/s/b07836e0-56f4-4bd9-b22c-50ce42c13fc3?utm_source=sdk)

<img width="441" height="173" alt="Screenshot 2026-05-14 at 22 44 52" src="https://github.com/user-attachments/assets/5674805f-eba2-45b7-a587-c56ce443a937" />

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.