### PR TITLE
[Android] Ensure sessionIdChanged keeps emitting on the main thread

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/SessionStrategyConfiguration.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/SessionStrategyConfiguration.kt
@@ -23,8 +23,8 @@ internal sealed class SessionStrategyConfiguration {
         fun inactivityThresholdMins(): Long = sessionStrategy.inactivityThresholdMins
 
         fun sessionIdChanged(sessionId: String) {
-            mainThreadHandler.runCatching {
-                sessionStrategy.onSessionIdChanged?.invoke(sessionId)
+            mainThreadHandler.run {
+                runCatching { sessionStrategy.onSessionIdChanged?.invoke(sessionId) }
             }
         }
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionStrategyTest.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture.providers.session
 
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.Capture
@@ -19,9 +20,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.util.UUID
-import java.util.concurrent.CountDownLatch
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
@@ -67,7 +68,6 @@ class SessionStrategyTest {
 
     @Test
     fun activityBasedSessionStrategy() {
-        val strategyLatch = CountDownLatch(1)
         var observedSessionId: String? = null
 
         val logger =
@@ -80,14 +80,13 @@ class SessionStrategyTest {
                 sessionStrategy =
                     SessionStrategy.ActivityBased {
                         observedSessionId = it
-                        strategyLatch.countDown()
                     },
                 configuration = Configuration(),
                 preferences = mock(),
             )
 
         val sessionId = logger.sessionId
-        strategyLatch.await()
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertThat(sessionId).isEqualTo(observedSessionId)
 
@@ -95,6 +94,55 @@ class SessionStrategyTest {
         val newSessionId = logger.sessionId
 
         assertThat(sessionId).isNotEqualTo(newSessionId)
+    }
+
+    @Test
+    fun activityBasedSessionStrategy_callbackRunsOnMainThread() {
+        var callbackLooper: Looper? = null
+
+        val logger =
+            LoggerImpl(
+                apiKey = "test",
+                apiUrl = testServerUrl(),
+                fieldProviders = listOf(),
+                dateProvider = mock(),
+                context = ContextHolder.APP_CONTEXT,
+                sessionStrategy =
+                    SessionStrategy.ActivityBased {
+                        callbackLooper = Looper.myLooper()
+                    },
+                configuration = Configuration(),
+                preferences = mock(),
+            )
+
+        logger.sessionId
+        shadowOf(Looper.getMainLooper()).idle()
+        assertThat(callbackLooper).isEqualTo(Looper.getMainLooper())
+    }
+
+    @Test
+    fun activityBasedSessionStrategy_sessionIdChangedEmitsOnMainThread() {
+        var observedSessionId: String? = null
+        var callbackLooper: Looper? = null
+        val newSessionId = "test-session-123"
+        val activityBasedConfig =
+            SessionStrategyConfiguration.ActivityBased(
+                sessionStrategy =
+                    SessionStrategy.ActivityBased { sessionId ->
+                        observedSessionId = sessionId
+                        callbackLooper = Looper.myLooper()
+                    },
+            )
+
+        // Call from a background thread to simulate the bd-tokio/JNI thread invoking the callback.
+        Thread { activityBasedConfig.sessionIdChanged(newSessionId) }.apply {
+            start()
+            join()
+        }
+
+        shadowOf(Looper.getMainLooper()).idle()
+        assertThat(observedSessionId).isEqualTo(newSessionId)
+        assertThat(callbackLooper).isEqualTo(Looper.getMainLooper())
     }
 
     private fun testServerUrl(): HttpUrl =

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
@@ -10,6 +10,7 @@ package io.bitdrift.gradletestapp.init
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import android.widget.Toast
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.Capture.Logger.sessionUrl
 import io.bitdrift.capture.CaptureResult
@@ -95,7 +96,7 @@ object BitdriftInit {
         sharedPreferences: SharedPreferences,
         context: Context,
     ): Boolean {
-        val settingsResult = getPersistedCaptureSdkSettings(sharedPreferences)
+        val settingsResult = getPersistedCaptureSdkSettings(context, sharedPreferences)
         when (settingsResult) {
             is SdkConfigResult.Success -> {
                 val settings = settingsResult.captureSdkInitSettings
@@ -131,7 +132,7 @@ object BitdriftInit {
         }
     }
 
-    private fun getPersistedCaptureSdkSettings(sharedPreferences: SharedPreferences): SdkConfigResult {
+    private fun getPersistedCaptureSdkSettings(applicationContext: Context, sharedPreferences: SharedPreferences): SdkConfigResult {
         val apiKey =
             sharedPreferences.getString(
                 BITDRIFT_API_KEY,
@@ -152,7 +153,7 @@ object BitdriftInit {
                 true,
             )
 
-        val sessionStrategy = getSessionStrategy(sharedPreferences)
+        val sessionStrategy = getSessionStrategy(applicationContext, sharedPreferences)
         val webViewConfig = getWebViewConfiguration(sharedPreferences)
 
         @OptIn(ExperimentalBitdriftApi::class)
@@ -188,7 +189,9 @@ object BitdriftInit {
         false
     )
 
-    private fun getSessionStrategy(sharedPreferences: SharedPreferences): SessionStrategy =
+    private fun getSessionStrategy(
+        applicationContext: Context,
+        sharedPreferences: SharedPreferences): SessionStrategy =
         if (sharedPreferences.getString(
                 ConfigurationSettingsFragment.Companion.SESSION_STRATEGY_PREFS_KEY,
                 ConfigurationSettingsFragment.SessionStrategyPreferences.FIXED.displayName,
@@ -196,10 +199,16 @@ object BitdriftInit {
         ) {
             SessionStrategy.Fixed()
         } else {
+            val thresholdMins = sharedPreferences.getString(
+                ConfigurationSettingsFragment.INACTIVITY_THRESHOLD_PREFS_KEY,
+                "30",
+            )?.toLongOrNull() ?: 30L
             SessionStrategy.ActivityBased(
-                inactivityThresholdMins = 60L,
+                inactivityThresholdMins = thresholdMins,
                 onSessionIdChanged = { sessionId ->
-                    Timber.Forest.i("Bitdrift Logger session id updated: $sessionId")
+                    val message ="Bitdrift Logger session id updated due to inactivity: $sessionId. Callback triggered in ${Thread.currentThread().name} thread"
+                    Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
+                    Timber.Forest.i(message)
                 },
             )
         }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/ConfigurationSettingsFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/ConfigurationSettingsFragment.kt
@@ -99,6 +99,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         }
         backendCategory.addPreference(apiKeysPreference)
         backendCategory.addPreference(buildSessionStrategyList(context))
+        backendCategory.addPreference(buildInactivityThresholdPreference(context))
         backendCategory.addPreference(buildSwitchPreference(context))
         backendCategory.addPreference(buildSessionReplaySwitch(context))
         backendCategory.addPreference(buildDeferredStartSwitch(context))
@@ -108,13 +109,46 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun buildSessionStrategyList(context: Context): ListPreference {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         val listPreference = ListPreference(context)
         listPreference.key = SESSION_STRATEGY_PREFS_KEY
         listPreference.title = SESSION_STRATEGY_TITLE
         listPreference.entries = SESSION_STRATEGY_ENTRIES
         listPreference.entryValues = SESSION_STRATEGY_ENTRIES
         listPreference.setDefaultValue(SessionStrategyPreferences.FIXED.displayName)
+        listPreference.summary = sharedPreferences.getString(
+            SESSION_STRATEGY_PREFS_KEY,
+            SessionStrategyPreferences.FIXED.displayName,
+        )
+        listPreference.setOnPreferenceChangeListener { _, newValue ->
+            val isActivityBased = newValue == SessionStrategyPreferences.ACTIVITY_BASED.displayName
+            findPreference<EditTextPreference>(INACTIVITY_THRESHOLD_PREFS_KEY)?.isVisible = isActivityBased
+            listPreference.summary = newValue as String
+            true
+        }
         return listPreference
+    }
+
+    private fun buildInactivityThresholdPreference(context: Context): EditTextPreference {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val editTextPreference = EditTextPreference(context)
+        editTextPreference.key = INACTIVITY_THRESHOLD_PREFS_KEY
+        editTextPreference.title = "Inactivity Threshold (minutes)"
+        editTextPreference.setDefaultValue(DEFAULT_INACTIVITY_THRESHOLD_MINS.toString())
+        val currentValue = sharedPreferences.getString(INACTIVITY_THRESHOLD_PREFS_KEY, DEFAULT_INACTIVITY_THRESHOLD_MINS.toString())
+        editTextPreference.summary = "$currentValue minutes"
+        editTextPreference.setOnBindEditTextListener { edit ->
+            edit.inputType = android.text.InputType.TYPE_CLASS_NUMBER
+            edit.hint = DEFAULT_INACTIVITY_THRESHOLD_MINS.toString()
+        }
+        editTextPreference.setOnPreferenceChangeListener { _, newValue ->
+            val mins = newValue.toString().toLongOrNull() ?: DEFAULT_INACTIVITY_THRESHOLD_MINS
+            editTextPreference.summary = "$mins minutes"
+            true
+        }
+        val currentStrategy = sharedPreferences.getString(SESSION_STRATEGY_PREFS_KEY, SessionStrategyPreferences.FIXED.displayName)
+        editTextPreference.isVisible = currentStrategy == SessionStrategyPreferences.ACTIVITY_BASED.displayName
+        return editTextPreference
     }
 
     private fun buildSwitchPreference(
@@ -187,8 +221,10 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         const val SESSION_REPLAY_ENABLED_PREFS_KEY = "sessionReplayEnabled"
         const val WEBVIEW_MONITORING_PREFS_KEY = "webviewMonitoring"
 
+        const val INACTIVITY_THRESHOLD_PREFS_KEY = "inactivityThresholdMins"
         const val PREFS_SLEEP_MODE_ENABLED = "sleep_mode_enabled"
 
+        private const val DEFAULT_INACTIVITY_THRESHOLD_MINS = 30L
         private const val SESSION_STRATEGY_TITLE = "Session Strategy"
         private const val FATAL_ISSUE_TITLE = "Fatal Issue Reporter"
         private const val DEFERRED_START_TITLE = "Deferred SDK Start"


### PR DESCRIPTION
## What

This is a recent regression during recent shared-core changes, sessionIdChanged is currently emitting on bd-tokio but should remain on main thread

iOS is doing this correctly already

```
func sessionIDChanged(_ sessionID: String) {
    case let .activityBased(_, onSessionChanged):
        DispatchQueue.main.async {
            onSessionChanged?(sessionID)
        }
}
```

## Verification

- JUnit tests
- Validated with activity session and `inactivityThresholdMins`  of 2 minutes (it can be updated in gradle-test-app settings)

<img width="496" height="740" alt="Screenshot 2026-05-20 at 09 32 16" src="https://github.com/user-attachments/assets/697c15eb-7b69-49da-9f53-88759b7f6156" />

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.