### PR TITLE
[binary size] Move bd-test-helpers to optional dep behind test-utils feature

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "506d3700c78a259a095ff1f7497d3fc268fecd5e5e2fe979b413e980e695aec7",
+  "checksum": "95244576e64716024542a39c9e8fedde319fd5e80b0e599bec182696abc401fd",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-api"
         }
@@ -1745,7 +1745,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1878,7 +1878,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1934,7 +1934,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -1998,7 +1998,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2104,7 +2104,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2180,7 +2180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2329,7 +2329,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2466,7 +2466,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2603,7 +2603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2696,7 +2696,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2760,7 +2760,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2925,7 +2925,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-device"
         }
@@ -2997,7 +2997,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-events"
         }
@@ -3145,7 +3145,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3376,7 +3376,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3455,7 +3455,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3587,7 +3587,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3647,7 +3647,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3735,7 +3735,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-log"
         }
@@ -3835,7 +3835,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3923,7 +3923,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4011,7 +4011,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4071,7 +4071,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4164,7 +4164,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4421,7 +4421,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4481,7 +4481,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4529,7 +4529,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4577,7 +4577,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4646,7 +4646,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4706,7 +4706,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4808,7 +4808,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4918,7 +4918,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5050,7 +5050,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5122,7 +5122,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5220,7 +5220,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5344,7 +5344,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5428,7 +5428,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5525,7 +5525,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-session"
         }
@@ -5730,7 +5730,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5834,7 +5834,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5890,7 +5890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-state"
         }
@@ -5999,7 +5999,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6072,7 +6072,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6288,7 +6288,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-time"
         }
@@ -6365,7 +6365,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "5a55f902ebb933684a0d05b379458d222751d604"
+            "Rev": "bc2acb782798ee8e40714a2728c72365abd972cc"
           },
           "strip_prefix": "bd-workflows"
         }
@@ -6450,10 +6450,6 @@
             {
               "id": "bd-stats-common 1.0.0",
               "target": "bd_stats_common"
-            },
-            {
-              "id": "bd-test-helpers 1.0.0",
-              "target": "bd_test_helpers"
             },
             {
               "id": "bd-time 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -466,7 +466,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -496,7 +496,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -669,7 +669,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "base64",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -981,7 +981,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1091,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=5a55f902ebb933684a0d05b379458d222751d604#5a55f902ebb933684a0d05b379458d222751d604"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=bc2acb782798ee8e40714a2728c72365abd972cc#bc2acb782798ee8e40714a2728c72365abd972cc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1206,7 +1206,6 @@ dependencies = [
  "bd-shutdown",
  "bd-state",
  "bd-stats-common",
- "bd-test-helpers",
  "bd-time",
  "bd-workspace-hack",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "5a55f902ebb933684a0d05b379458d222751d604" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "bc2acb782798ee8e40714a2728c72365abd972cc" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "0.10.0"
 env_logger = { version = "0.11.10", default-features = false }


### PR DESCRIPTION
Evaluating size improvements

1. Moving bd-test-heleers to dev-deps

TBF

2. Moving bd-test-heleers to dev-deps + OTel feature gate in bd-log

TBF

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.