### PR TITLE
[BIT-8351] Support Xcode 26 Swiftui rendering changes affecting session replay

### DIFF
--- a/examples/swift/hello_world/AutomaticCapturePanelView.swift
+++ b/examples/swift/hello_world/AutomaticCapturePanelView.swift
@@ -23,6 +23,15 @@ struct AutomaticCapturePanelView: View {
             }
             .buttonStyle(PressableCardButtonStyle())
 
+            NavigationLink(destination: ReplayPreviewView()) {
+                PanelRow(
+                    title: "Replay preview",
+                    subtitle: "Browse all ViewType elements to validate session replay rendering.",
+                    showsChevron: true
+                )
+            }
+            .buttonStyle(PressableCardButtonStyle())
+
             PanelCard {
                 Text("App launch TTI is logged automatically on startup. Relaunch the app if you want to generate that signal again.")
                     .font(.footnote)

--- a/examples/swift/hello_world/ContentView.swift
+++ b/examples/swift/hello_world/ContentView.swift
@@ -46,11 +46,21 @@ struct ContentView: View {
                             )
                             .clipShape(Capsule())
                     }
-                }
+                }.removeToolBarItemGlassStyle()
             }
         }
         .navigationViewStyle(.stack)
         .accentColor(Theme.primary)
         .onAppear { self.loggerCustomer.logAppLaunchTTI() }
+    }
+}
+
+extension ToolbarContent {
+    func removeToolBarItemGlassStyle() -> some ToolbarContent {
+        if #available(iOS 26.0, *) {
+            return self.sharedBackgroundVisibility(.hidden)
+        } else {
+            return self
+        }
     }
 }

--- a/examples/swift/hello_world/ReplayPreviewView.swift
+++ b/examples/swift/hello_world/ReplayPreviewView.swift
@@ -1,0 +1,174 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import MapKit
+import SwiftUI
+import WebKit
+
+struct ReplayPreviewView: View {
+    @State private var toggleOff = false
+    @State private var toggleOn = true
+    @State private var textFieldText = "TextField value"
+    @State private var textEditorText = "TextEditor\nmultiline content"
+    @State private var selectedDate = Date()
+    @State private var pickerSelection = "A"
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                PanelSection(title: "Label") {
+                    VStack(spacing: 8) {
+                        self.row(Text("Plain Text element"))
+                        self.row(Label("Label with SF icon", systemImage: "heart.fill"))
+                        self.row(Text("Bold text").bold())
+                        self.row(Text("Secondary text").foregroundStyle(Theme.textSecondary))
+                    }
+                }
+
+                PanelSection(title: "Button") {
+                    VStack(spacing: 8) {
+                        self.row(Button("Plain button") {})
+                        self.row(Button("Bordered button") {}.buttonStyle(.bordered))
+                        self.row(Button("Bordered prominent") {}.buttonStyle(.borderedProminent))
+                        // swiftlint:disable:next use_static_string_url_init force_unwrapping
+                        self.row(Link("Link element", destination: URL(string: "https://bitdrift.io")!))
+                    }
+                }
+
+                PanelSection(title: "Text Input") {
+                    VStack(spacing: 8) {
+                        self.row(
+                            TextField("Placeholder", text: self.$textFieldText)
+                                .foregroundStyle(Theme.textPrimary)
+                        )
+                        self.row(
+                            TextEditor(text: self.$textEditorText)
+                                .foregroundStyle(Theme.textPrimary)
+                                .frame(height: 70)
+                        )
+                    }
+                }
+
+                PanelSection(title: "Image") {
+                    VStack(spacing: 8) {
+                        self.row(
+                            Image(systemName: "star.fill")
+                                .resizable()
+                                .frame(width: 36, height: 36)
+                                .foregroundStyle(Theme.primary)
+                        )
+                        self.row(
+                            Image(systemName: "photo")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 60)
+                                .foregroundStyle(Theme.textSecondary)
+                        )
+                    }
+                }
+
+                PanelSection(title: "Switch") {
+                    VStack(spacing: 8) {
+                        self.row(Toggle("Toggle off", isOn: self.$toggleOff))
+                        self.row(Toggle("Toggle on", isOn: self.$toggleOn))
+                    }
+                }
+
+                PanelSection(title: "Picker") {
+                    VStack(spacing: 8) {
+                        self.row(
+                            Picker("Segmented", selection: self.$pickerSelection) {
+                                Text("A").tag("A")
+                                Text("B").tag("B")
+                                Text("C").tag("C")
+                            }
+                            .pickerStyle(.segmented)
+                        )
+                        self.row(
+                            DatePicker("Date", selection: self.$selectedDate, displayedComponents: .date)
+                                .foregroundStyle(Theme.textPrimary)
+                        )
+                    }
+                }
+
+                if #available(iOS 17, *) {
+                    PanelSection(title: "Map") {
+                        Map()
+                            .frame(height: 150)
+                            .cornerRadius(12)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Theme.border, lineWidth: 1)
+                            )
+                    }
+                }
+
+                PanelSection(title: "WebView") {
+                    ReplayPreviewWebView()
+                        .frame(height: 80)
+                        .cornerRadius(12)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Theme.border, lineWidth: 1)
+                        )
+                }
+
+                PanelSection(title: "Navigation (chevron)") {
+                    VStack(spacing: 8) {
+                        NavigationLink(destination: Text("Detail").foregroundStyle(Theme.textPrimary)) {
+                            PanelRow(title: "Row with chevron", subtitle: "Navigates to a detail screen", showsChevron: true)
+                        }
+                        .buttonStyle(PressableCardButtonStyle())
+                        NavigationLink(destination: Text("Detail").foregroundStyle(Theme.textPrimary)) {
+                            PanelRow(title: "Another row", showsChevron: true)
+                        }
+                        .buttonStyle(PressableCardButtonStyle())
+                    }
+                }
+
+                PanelSection(title: "Transparent View") {
+                    ZStack {
+                        Theme.secondary.opacity(0.15)
+                            .frame(height: 70)
+                            .cornerRadius(12)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Theme.border, lineWidth: 1)
+                            )
+                        Theme.primary.opacity(0.3)
+                            .frame(width: 100, height: 40)
+                            .cornerRadius(8)
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .background(Theme.background.ignoresSafeArea())
+        .navigationTitle("Replay Preview")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func row<Content: View>(_ content: Content) -> some View {
+        content
+            .foregroundStyle(Theme.textPrimary)
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 16).fill(Theme.surface))
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Theme.border, lineWidth: 1))
+    }
+}
+
+private struct ReplayPreviewWebView: UIViewRepresentable {
+    func makeUIView(context _: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.loadHTMLString("<html><body style='background:#1a1a1a;color:#fff;font-family:sans-serif;padding:12px'><p>WebView content</p></body></html>", baseURL: nil)
+        return webView
+    }
+
+    func updateUIView(_: WKWebView, context _: Context) {}
+}

--- a/platform/swift/source/replay/Replay.swift
+++ b/platform/swift/source/replay/Replay.swift
@@ -43,10 +43,16 @@ package final class Replay {
     ///            more information about the bytes structure.
     package func capture() -> Data {
         let startTime = CFAbsoluteTimeGetCurrent()
+        let result = self.capture(windows: UIApplication.shared.sessionReplayWindows())
+        self.renderTime = CFAbsoluteTimeGetCurrent() - startTime
+        return result
+    }
+
+    package func capture(windows: [UIWindow]) -> Data {
         var buffer = Data()
         rectToBytes(type: .view, buffer: &buffer, frame: UIScreen.main.bounds)
 
-        for window in UIApplication.shared.sessionReplayWindows() {
+        for window in windows {
             let windowClass = NSStringFromClass(type(of: window))
             if window.isHidden || window.alpha < 0.1 || kIgnoredWindows.contains(windowClass) {
                 continue
@@ -55,7 +61,6 @@ package final class Replay {
             self.traverse(into: &buffer, parent: window, parentPosition: .zero, clipTo: window.frame)
         }
 
-        self.renderTime = CFAbsoluteTimeGetCurrent() - startTime
         return buffer
     }
 

--- a/platform/swift/source/replay/Replay.swift
+++ b/platform/swift/source/replay/Replay.swift
@@ -82,6 +82,15 @@ package final class Replay {
     private func traverse(into buffer: inout Data, parent: UIView, parentPosition: CGPoint, clipTo: CGRect,
                           ignoreViewType: Bool = false)
     {
+        // iOS 26+ (liquid glass): orphan CALayers (not backed by a UIView) must be traversed before
+        // UIView subviews so that background glass layers are painted beneath the content, not on top.
+        let backedLayerIDs = Set(parent.subviews.map { ObjectIdentifier($0.layer) })
+        if let sublayers = parent.layer.sublayers {
+            for layer in sublayers where !backedLayerIDs.contains(ObjectIdentifier(layer)) {
+                self.traverseLayer(into: &buffer, layer: layer, parentPosition: parentPosition, clipTo: clipTo)
+            }
+        }
+
         for view in parent.subviews {
             if view.isHidden || view.alpha < 0.1 {
                 continue
@@ -135,6 +144,48 @@ package final class Replay {
                 frame.origin.y -= view.bounds.minY
                 self.traverse(into: &buffer, parent: view, parentPosition: frame.origin, clipTo: childClipTo,
                               ignoreViewType: ignoreViewType || aType.ignoreChildrenViews)
+            }
+        }
+    }
+
+    private func traverseLayer(
+        into buffer: inout Data,
+        layer: CALayer,
+        parentPosition: CGPoint,
+        clipTo: CGRect)
+    {
+        guard !layer.isHidden, layer.opacity > 0.1 else { return }
+
+        var frame = layer.frame
+        frame.origin.x += parentPosition.x
+        frame.origin.y += parentPosition.y
+
+        let childClipTo = layer.masksToBounds ? frame.intersection(clipTo) : clipTo
+
+        guard self.layerHasVisibleContent(layer) else { return }
+
+        let aType = ReplayCommonCategorizer.categorizeLayer(layer, frame: frame)
+        guard aType.type != .ignore else { return }
+
+        let clippedFrame = aType.frame.intersection(clipTo)
+        if !clippedFrame.isEmpty, clippedFrame.intersects(clipTo) {
+            rectToBytes(type: aType.type, buffer: &buffer, frame: clippedFrame)
+            for fragment in aType.fragments where fragment.frame.intersects(clipTo) {
+                rectToBytes(type: fragment.type, buffer: &buffer, frame: fragment.frame.intersection(clipTo))
+            }
+        }
+
+        if aType.recurse, let sublayers = layer.sublayers {
+            var nextPosition = frame.origin
+            nextPosition.x -= layer.bounds.minX
+            nextPosition.y -= layer.bounds.minY
+            for sublayer in sublayers {
+                self.traverseLayer(
+                    into: &buffer,
+                    layer: sublayer,
+                    parentPosition: nextPosition,
+                    clipTo: childClipTo
+                )
             }
         }
     }

--- a/platform/swift/source/replay/Replay.swift
+++ b/platform/swift/source/replay/Replay.swift
@@ -89,10 +89,12 @@ package final class Replay {
     {
         // iOS 26+ (liquid glass): orphan CALayers (not backed by a UIView) must be traversed before
         // UIView subviews so that background glass layers are painted beneath the content, not on top.
-        let backedLayerIDs = Set(parent.subviews.map { ObjectIdentifier($0.layer) })
-        if let sublayers = parent.layer.sublayers {
-            for layer in sublayers where !backedLayerIDs.contains(ObjectIdentifier(layer)) {
-                self.traverseLayer(into: &buffer, layer: layer, parentPosition: parentPosition, clipTo: clipTo)
+        if #available(iOS 26, *) {
+            let backedLayerIDs = Set(parent.subviews.map { ObjectIdentifier($0.layer) })
+            if let sublayers = parent.layer.sublayers {
+                for layer in sublayers where !backedLayerIDs.contains(ObjectIdentifier(layer)) {
+                    self.traverseLayer(into: &buffer, layer: layer, parentPosition: parentPosition, clipTo: clipTo)
+                }
             }
         }
 

--- a/platform/swift/source/replay/ReplayCommonCategorizer.swift
+++ b/platform/swift/source/replay/ReplayCommonCategorizer.swift
@@ -75,22 +75,15 @@ struct ReplayCommonCategorizer {
         return nil
     }
 
-    /// Known CALayer class names for iOS 26+ (liquid glass) layer types that are rendered without a
-    /// UIView backing. Extend this as new layer types are discovered.
-    static var knownLayerTypes: [String: AnnotatedView] = [:]
-
-    /// Categorize a pure CALayer (not backed by a UIView) by class name or visual content.
+    /// Categorize a pure CALayer by class name or visual content.
     ///
     /// - parameter layer: The CALayer to analyze.
     /// - parameter frame: Absolute position and size of the layer on screen.
     ///
-    /// - returns: An annotated view describing how to represent this layer.
+    /// - returns: An annotated view which defines the position and traverse behavior, see
+    ///            `AnnotatedViewType` for more information
     static func categorizeLayer(_ layer: CALayer, frame: CGRect) -> AnnotatedView {
         let className = NSStringFromClass(type(of: layer))
-        if var known = knownLayerTypes[className] {
-            known.frame = frame
-            return known
-        }
 
         // CGDrawingLayer is SwiftUI's text/label rendering layer (equivalent to CGDrawingView for UIViews).
         // The class name is Swift-mangled with a module hash prefix, so match by suffix.

--- a/platform/swift/source/replay/ReplayCommonCategorizer.swift
+++ b/platform/swift/source/replay/ReplayCommonCategorizer.swift
@@ -74,4 +74,34 @@ struct ReplayCommonCategorizer {
 
         return nil
     }
+
+    /// Known CALayer class names for iOS 26+ (liquid glass) layer types that are rendered without a
+    /// UIView backing. Extend this as new layer types are discovered.
+    static var knownLayerTypes: [String: AnnotatedView] = [:]
+
+    /// Categorize a pure CALayer (not backed by a UIView) by class name or visual content.
+    ///
+    /// - parameter layer: The CALayer to analyze.
+    /// - parameter frame: Absolute position and size of the layer on screen.
+    ///
+    /// - returns: An annotated view describing how to represent this layer.
+    static func categorizeLayer(_ layer: CALayer, frame: CGRect) -> AnnotatedView {
+        let className = NSStringFromClass(type(of: layer))
+        if var known = knownLayerTypes[className] {
+            known.frame = frame
+            return known
+        }
+
+        // CGDrawingLayer is SwiftUI's text/label rendering layer (equivalent to CGDrawingView for UIViews).
+        // The class name is Swift-mangled with a module hash prefix, so match by suffix.
+        if className.hasSuffix("CGDrawingLayer") {
+            return AnnotatedView(.label, recurse: false, frame: frame)
+        }
+
+        if let contents = layer.contents, CFGetTypeID(contents as CFTypeRef) == CGImage.typeID {
+            return AnnotatedView(.image, frame: frame)
+        }
+
+        return AnnotatedView(.view, frame: frame)
+    }
 }

--- a/platform/swift/source/replay/UIKitCategorizer/UITextView+ReplayUIKitIdentifiable.swift
+++ b/platform/swift/source/replay/UIKitCategorizer/UITextView+ReplayUIKitIdentifiable.swift
@@ -9,6 +9,6 @@ import UIKit
 
 extension UITextView: ReplayUIKitIdentifiable {
     final func identifyUIKit(frame: CGRect) -> AnnotatedView? {
-        return AnnotatedView(.textInput, frame: frame)
+        return AnnotatedView(.textInput, frame: frame, ignoreWhenEmpty: false)
     }
 }

--- a/test/platform/swift/unit_integration/core/BUILD
+++ b/test/platform/swift/unit_integration/core/BUILD
@@ -9,6 +9,7 @@ bitdrift_mobile_swift_test(
     ],
     repository = "@capture",
     tags = ["macos_only"],
+    use_test_host = True,
     visibility = ["//visibility:public"],
     deps = [
         "//platform/swift/source:bitdrift_enhanced_crash_data",

--- a/test/platform/swift/unit_integration/core/ReplayCommonCategorizerTests.swift
+++ b/test/platform/swift/unit_integration/core/ReplayCommonCategorizerTests.swift
@@ -1,0 +1,51 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+@testable import Capture
+import UIKit
+import XCTest
+
+// Subclass whose Swift-mangled name ends with "CGDrawingLayer", matching the suffix used by
+// SwiftUI's internal text rendering layer. Used to unit test the suffix categorization path
+// without depending on private SwiftUI internals.
+private final class CGDrawingLayer: CALayer {}
+
+final class ReplayCommonCategorizerTests: XCTestCase {
+    func testCategorizeLayerDefaultsToView() {
+        let layer = CALayer()
+        layer.backgroundColor = UIColor.red.cgColor
+
+        let result = ReplayCommonCategorizer.categorizeLayer(layer, frame: .zero)
+
+        XCTAssertEqual(result.type, .view)
+    }
+
+    func testCategorizeLayerWithCGImageContentReturnsImage() {
+        let layer = CALayer()
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1)).image { ctx in
+            ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        layer.contents = image.cgImage
+
+        let result = ReplayCommonCategorizer.categorizeLayer(layer, frame: .zero)
+
+        XCTAssertEqual(result.type, .image)
+    }
+
+    func testCategorizeLayerCGDrawingLayerSuffixReturnsLabel() {
+        // CGDrawingLayer (defined above) has a Swift-mangled name that ends with "CGDrawingLayer",
+        // matching the same suffix pattern as SwiftUI's internal text rendering layer.
+        let layer = CGDrawingLayer()
+        let frame = CGRect(x: 0, y: 0, width: 100, height: 20)
+
+        let result = ReplayCommonCategorizer.categorizeLayer(layer, frame: frame)
+
+        XCTAssertEqual(result.type, .label)
+        XCTAssertFalse(result.recurse)
+        XCTAssertEqual(result.frame, frame)
+    }
+}

--- a/test/platform/swift/unit_integration/core/ReplayTests.swift
+++ b/test/platform/swift/unit_integration/core/ReplayTests.swift
@@ -17,7 +17,7 @@ final class ReplayTests: XCTestCase {
 
     override func setUp() {
         self.window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
-        self.window.makeKeyAndVisible()
+        self.window.isHidden = false
     }
 
     override func tearDown() {

--- a/test/platform/swift/unit_integration/core/ReplayTests.swift
+++ b/test/platform/swift/unit_integration/core/ReplayTests.swift
@@ -1,0 +1,353 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+@testable import Capture
+import MapKit
+import SwiftUI
+import UIKit
+import WebKit
+import XCTest
+
+final class ReplayTests: XCTestCase {
+    private var window: UIWindow!
+
+    override func setUp() {
+        self.window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        self.window.makeKeyAndVisible()
+    }
+
+    override func tearDown() {
+        self.window.isHidden = true
+        self.window = nil
+    }
+
+    // MARK: - Orphan CALayer traversal
+
+    func testCaptureIncludesVisibleOrphanLayer() {
+        let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
+        window.addSubview(container)
+        defer { container.removeFromSuperview() }
+
+        let orphan = CALayer()
+        orphan.frame = CGRect(x: 17, y: 23, width: 80, height: 40)
+        orphan.backgroundColor = UIColor.red.cgColor
+        container.layer.addSublayer(orphan)
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        // frame = container origin (0, 500) + orphan origin (17, 23)
+        XCTAssertTrue(entries.contains { $0.type == .view && $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40) })
+    }
+
+    func testCaptureExcludesHiddenOrphanLayer() {
+        let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
+        window.addSubview(container)
+        defer { container.removeFromSuperview() }
+
+        let orphan = CALayer()
+        orphan.frame = CGRect(x: 17, y: 23, width: 80, height: 40)
+        orphan.backgroundColor = UIColor.red.cgColor
+        orphan.isHidden = true
+        container.layer.addSublayer(orphan)
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertFalse(entries.contains { $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40) })
+    }
+
+    func testCaptureExcludesLowOpacityOrphanLayer() {
+        let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
+        window.addSubview(container)
+        defer { container.removeFromSuperview() }
+
+        let orphan = CALayer()
+        orphan.frame = CGRect(x: 17, y: 23, width: 80, height: 40)
+        orphan.backgroundColor = UIColor.red.cgColor
+        orphan.opacity = 0.05
+        container.layer.addSublayer(orphan)
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertFalse(entries.contains { $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40) })
+    }
+
+    func testOrphanLayersArePaintedBeforeUIViewSubviews() {
+        let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
+        window.addSubview(container)
+        defer { container.removeFromSuperview() }
+
+        let child = UIView(frame: CGRect(x: 50, y: 60, width: 70, height: 50))
+        child.backgroundColor = UIColor.blue
+        container.addSubview(child)
+
+        let orphan = CALayer()
+        orphan.frame = CGRect(x: 10, y: 10, width: 100, height: 100)
+        orphan.backgroundColor = UIColor.red.cgColor
+        container.layer.addSublayer(orphan)
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        let orphanIndex = entries.firstIndex { $0.frame == CGRect(x: 10, y: 510, width: 100, height: 100) }
+        let childIndex = entries.firstIndex { $0.frame == CGRect(x: 50, y: 560, width: 70, height: 50) }
+
+        guard let oi = orphanIndex, let ci = childIndex else {
+            XCTFail("Expected both orphan layer and child view in capture output")
+            return
+        }
+
+        XCTAssertLessThan(oi, ci, "Orphan layer should be painted before UIView subview (z-order)")
+    }
+
+    // MARK: - SwiftUI labels
+
+    func testSwiftUITextProducesLabelEntries() {
+        let hosting = UIHostingController(rootView: Text("Hello World"))
+        hosting.view.frame = CGRect(x: 0, y: 400, width: 200, height: 60)
+        hosting.view.backgroundColor = .clear
+        window.addSubview(hosting.view)
+        hosting.view.layoutIfNeeded()
+        defer { hosting.view.removeFromSuperview() }
+
+        // Waiting for SwiftUI to render the Text/label
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        let hostingFrame = CGRect(x: 0, y: 400, width: 200, height: 60)
+        XCTAssertTrue(
+            entries.contains { $0.type == .label && hostingFrame.contains($0.frame) },
+            "SwiftUI Text should produce .label entries within the hosting view's frame"
+        )
+    }
+
+    // MARK: - UITextView
+
+    func testCaptureIncludesTextViewWithClearBackground() {
+        let textView = UITextView(frame: CGRect(x: 20, y: 500, width: 300, height: 150))
+        textView.backgroundColor = UIColor.clear
+        textView.text = "Some sensitive text"
+        window.addSubview(textView)
+        defer { textView.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .textInput && $0.frame == CGRect(x: 20, y: 500, width: 300, height: 150) },
+            "UITextView with clear background should appear as .textInput regardless of layer visibility"
+        )
+    }
+
+    // MARK: - UILabel
+
+    func testUILabelProducesLabelEntry() {
+        let label = UILabel(frame: CGRect(x: 20, y: 400, width: 200, height: 40))
+        label.text = "Hello"
+        window.addSubview(label)
+        defer { label.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        let labelFrame = CGRect(x: 20, y: 400, width: 200, height: 40)
+        XCTAssertTrue(
+            entries.contains { $0.type == .label && labelFrame.contains($0.frame) },
+            "UILabel should produce a .label entry within its bounds"
+        )
+    }
+
+    // MARK: - UIButton
+
+    func testUIButtonProducesButtonEntry() {
+        let button = UIButton(frame: CGRect(x: 20, y: 400, width: 120, height: 44))
+        button.setTitle("Tap", for: .normal)
+        window.addSubview(button)
+        defer { button.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .button && $0.frame == CGRect(x: 20, y: 400, width: 120, height: 44) },
+            "UIButton with title should produce a .button entry"
+        )
+    }
+
+    // MARK: - UITextField
+
+    func testUITextFieldProducesTextInputEntry() {
+        let textField = UITextField(frame: CGRect(x: 20, y: 400, width: 200, height: 44))
+        textField.backgroundColor = .white
+        window.addSubview(textField)
+        defer { textField.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .textInput && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 44) },
+            "UITextField should produce a .textInput entry"
+        )
+    }
+
+    // MARK: - UIImageView
+
+    func testUIImageViewProducesImageEntry() {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 80, height: 80)).image { ctx in
+            UIColor.red.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 80, height: 80))
+        }
+        let imageView = UIImageView(image: image)
+        imageView.frame = CGRect(x: 20, y: 400, width: 80, height: 80)
+        window.addSubview(imageView)
+        defer { imageView.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .image && $0.frame == CGRect(x: 20, y: 400, width: 80, height: 80) },
+            "UIImageView should produce an .image entry"
+        )
+    }
+
+    func testUIImageViewBehindSiblingProducesBackgroundImageEntry() {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 200, height: 100)).image { ctx in
+            UIColor.blue.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+        }
+        let imageView = UIImageView(image: image)
+        imageView.frame = CGRect(x: 20, y: 400, width: 200, height: 100)
+
+        let overlay = UIView(frame: CGRect(x: 40, y: 420, width: 60, height: 40))
+        overlay.backgroundColor = .green
+
+        window.addSubview(imageView)
+        window.addSubview(overlay)
+        defer {
+            imageView.removeFromSuperview()
+            overlay.removeFromSuperview()
+        }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .backgroundImage },
+            "UIImageView with an overlapping sibling should produce a .backgroundImage entry"
+        )
+    }
+
+    // MARK: - UISwitch
+
+    func testUISwitchOnProducesSwitchOnEntry() {
+        let uiSwitch = UISwitch()
+        uiSwitch.isOn = true
+        uiSwitch.frame.origin = CGPoint(x: 20, y: 400)
+        window.addSubview(uiSwitch)
+        defer { uiSwitch.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(entries.contains { $0.type == .switchOn }, "UISwitch with isOn=true should produce .switchOn")
+    }
+
+    func testUISwitchOffProducesSwitchOffEntry() {
+        let uiSwitch = UISwitch()
+        uiSwitch.isOn = false
+        uiSwitch.frame.origin = CGPoint(x: 20, y: 400)
+        window.addSubview(uiSwitch)
+        defer { uiSwitch.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(entries.contains { $0.type == .switchOff }, "UISwitch with isOn=false should produce .switchOff")
+    }
+
+    // MARK: - MKMapView
+
+    func testMKMapViewProducesMapEntry() {
+        let mapView = MKMapView(frame: CGRect(x: 20, y: 400, width: 200, height: 150))
+        window.addSubview(mapView)
+        defer { mapView.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .map && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 150) },
+            "MKMapView should produce a .map entry"
+        )
+    }
+
+    // MARK: - WKWebView
+
+    func testWKWebViewProducesWebviewEntry() {
+        let webView = WKWebView(frame: CGRect(x: 20, y: 400, width: 200, height: 150))
+        window.addSubview(webView)
+        defer { webView.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .webview && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 150) },
+            "WKWebView should produce a .webview entry"
+        )
+    }
+
+    // MARK: - Transparent view
+
+    func testSemiTransparentViewProducesTransparentViewEntry() {
+        let v = UIView(frame: CGRect(x: 20, y: 400, width: 100, height: 100))
+        v.backgroundColor = UIColor.red.withAlphaComponent(0.3)
+        window.addSubview(v)
+        defer { v.removeFromSuperview() }
+
+        let entries = decode(Replay().capture(windows: [self.window]))
+
+        XCTAssertTrue(
+            entries.contains { $0.type == .transparentView && $0.frame == CGRect(x: 20, y: 400, width: 100, height: 100) },
+            "UIView with semi-transparent background should produce a .transparentView entry"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private struct Entry {
+        let type: ViewType
+        let frame: CGRect
+    }
+
+    /// Decodes the binary buffer produced by `Replay.capture()` into readable entries.
+    /// For more information, read the docs of `rectToBytes`
+    private func decode(_ data: Data) -> [Entry] {
+        var entries: [Entry] = []
+        var i = data.startIndex
+
+        while i < data.endIndex {
+            let typeByte = data[i]
+            i = data.index(after: i)
+
+            guard let viewType = ViewType(rawValue: typeByte & 0x0F) else { break }
+
+            var values = [CGFloat](repeating: 0, count: 4)
+            for prop in 0 ..< 4 {
+                if typeByte & (1 << (7 - prop)) != 0 {
+                    guard data.distance(from: i, to: data.endIndex) >= 2 else { return entries }
+                    let high = Int(data[i]) << 8
+                    i = data.index(after: i)
+                    values[prop] = CGFloat(high | Int(data[i]))
+                    i = data.index(after: i)
+                } else {
+                    guard i < data.endIndex else { return entries }
+                    values[prop] = CGFloat(data[i])
+                    i = data.index(after: i)
+                }
+            }
+
+            entries.append(Entry(
+                type: viewType,
+                frame: CGRect(x: values[0], y: values[1], width: values[2], height: values[3])
+            ))
+        }
+
+        return entries
+    }
+}

--- a/test/platform/swift/unit_integration/core/ReplayTests.swift
+++ b/test/platform/swift/unit_integration/core/ReplayTests.swift
@@ -21,32 +21,34 @@ final class ReplayTests: XCTestCase {
     }
 
     override func tearDown() {
-        self.window.isHidden = true
         self.window = nil
     }
 
-    // MARK: - Orphan CALayer traversal
+    // MARK: - traverse CALayer tree
 
     func testCaptureIncludesVisibleOrphanLayer() {
         let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
         window.addSubview(container)
-        defer { container.removeFromSuperview() }
 
         let orphan = CALayer()
         orphan.frame = CGRect(x: 17, y: 23, width: 80, height: 40)
         orphan.backgroundColor = UIColor.red.cgColor
         container.layer.addSublayer(orphan)
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         // frame = container origin (0, 500) + orphan origin (17, 23)
-        XCTAssertTrue(entries.contains { $0.type == .view && $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40) })
+        XCTAssertTrue(
+            entries.contains {
+                $0.type == .view &&
+                    $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40)
+            }
+        )
     }
 
     func testCaptureExcludesHiddenOrphanLayer() {
         let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
         window.addSubview(container)
-        defer { container.removeFromSuperview() }
 
         let orphan = CALayer()
         orphan.frame = CGRect(x: 17, y: 23, width: 80, height: 40)
@@ -54,15 +56,18 @@ final class ReplayTests: XCTestCase {
         orphan.isHidden = true
         container.layer.addSublayer(orphan)
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
-        XCTAssertFalse(entries.contains { $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40) })
+        XCTAssertFalse(
+            entries.contains {
+                $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40)
+            }
+        )
     }
 
     func testCaptureExcludesLowOpacityOrphanLayer() {
         let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
         window.addSubview(container)
-        defer { container.removeFromSuperview() }
 
         let orphan = CALayer()
         orphan.frame = CGRect(x: 17, y: 23, width: 80, height: 40)
@@ -70,15 +75,18 @@ final class ReplayTests: XCTestCase {
         orphan.opacity = 0.05
         container.layer.addSublayer(orphan)
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
-        XCTAssertFalse(entries.contains { $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40) })
+        XCTAssertFalse(
+            entries.contains {
+                $0.frame == CGRect(x: 17, y: 523, width: 80, height: 40)
+            }
+        )
     }
 
     func testOrphanLayersArePaintedBeforeUIViewSubviews() {
         let container = UIView(frame: CGRect(x: 0, y: 500, width: 300, height: 200))
         window.addSubview(container)
-        defer { container.removeFromSuperview() }
 
         let child = UIView(frame: CGRect(x: 50, y: 60, width: 70, height: 50))
         child.backgroundColor = UIColor.blue
@@ -89,17 +97,17 @@ final class ReplayTests: XCTestCase {
         orphan.backgroundColor = UIColor.red.cgColor
         container.layer.addSublayer(orphan)
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         let orphanIndex = entries.firstIndex { $0.frame == CGRect(x: 10, y: 510, width: 100, height: 100) }
         let childIndex = entries.firstIndex { $0.frame == CGRect(x: 50, y: 560, width: 70, height: 50) }
 
-        guard let oi = orphanIndex, let ci = childIndex else {
+        guard let orphanIndex, let childIndex else {
             XCTFail("Expected both orphan layer and child view in capture output")
             return
         }
 
-        XCTAssertLessThan(oi, ci, "Orphan layer should be painted before UIView subview (z-order)")
+        XCTAssertLessThan(orphanIndex, childIndex, "Orphan layer should be painted before UIView subview (z-order)")
     }
 
     // MARK: - SwiftUI labels
@@ -110,18 +118,16 @@ final class ReplayTests: XCTestCase {
         hosting.view.backgroundColor = .clear
         window.addSubview(hosting.view)
         hosting.view.layoutIfNeeded()
-        defer { hosting.view.removeFromSuperview() }
 
         // Waiting for SwiftUI to render the Text/label
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         let hostingFrame = CGRect(x: 0, y: 400, width: 200, height: 60)
         XCTAssertTrue(
             entries.contains { $0.type == .label && hostingFrame.contains($0.frame) },
-            "SwiftUI Text should produce .label entries within the hosting view's frame"
-        )
+            )
     }
 
     // MARK: - UITextView
@@ -129,15 +135,15 @@ final class ReplayTests: XCTestCase {
     func testCaptureIncludesTextViewWithClearBackground() {
         let textView = UITextView(frame: CGRect(x: 20, y: 500, width: 300, height: 150))
         textView.backgroundColor = UIColor.clear
-        textView.text = "Some sensitive text"
+        textView.text = "Some text inside a text view"
         window.addSubview(textView)
-        defer { textView.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .textInput && $0.frame == CGRect(x: 20, y: 500, width: 300, height: 150) },
-            "UITextView with clear background should appear as .textInput regardless of layer visibility"
+            entries.contains {
+                $0.type == .textInput && $0.frame == CGRect(x: 20, y: 500, width: 300, height: 150)
+            }
         )
     }
 
@@ -145,16 +151,16 @@ final class ReplayTests: XCTestCase {
 
     func testUILabelProducesLabelEntry() {
         let label = UILabel(frame: CGRect(x: 20, y: 400, width: 200, height: 40))
-        label.text = "Hello"
+        label.text = "Hello Label"
         window.addSubview(label)
-        defer { label.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         let labelFrame = CGRect(x: 20, y: 400, width: 200, height: 40)
         XCTAssertTrue(
-            entries.contains { $0.type == .label && labelFrame.contains($0.frame) },
-            "UILabel should produce a .label entry within its bounds"
+            entries.contains {
+                $0.type == .label && labelFrame.contains($0.frame)
+            }
         )
     }
 
@@ -164,13 +170,13 @@ final class ReplayTests: XCTestCase {
         let button = UIButton(frame: CGRect(x: 20, y: 400, width: 120, height: 44))
         button.setTitle("Tap", for: .normal)
         window.addSubview(button)
-        defer { button.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .button && $0.frame == CGRect(x: 20, y: 400, width: 120, height: 44) },
-            "UIButton with title should produce a .button entry"
+            entries.contains {
+                $0.type == .button && $0.frame == CGRect(x: 20, y: 400, width: 120, height: 44)
+            }
         )
     }
 
@@ -180,13 +186,13 @@ final class ReplayTests: XCTestCase {
         let textField = UITextField(frame: CGRect(x: 20, y: 400, width: 200, height: 44))
         textField.backgroundColor = .white
         window.addSubview(textField)
-        defer { textField.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .textInput && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 44) },
-            "UITextField should produce a .textInput entry"
+            entries.contains {
+                $0.type == .textInput && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 44)
+            }
         )
     }
 
@@ -200,13 +206,13 @@ final class ReplayTests: XCTestCase {
         let imageView = UIImageView(image: image)
         imageView.frame = CGRect(x: 20, y: 400, width: 80, height: 80)
         window.addSubview(imageView)
-        defer { imageView.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .image && $0.frame == CGRect(x: 20, y: 400, width: 80, height: 80) },
-            "UIImageView should produce an .image entry"
+            entries.contains {
+                $0.type == .image && $0.frame == CGRect(x: 20, y: 400, width: 80, height: 80)
+            }
         )
     }
 
@@ -223,17 +229,12 @@ final class ReplayTests: XCTestCase {
 
         window.addSubview(imageView)
         window.addSubview(overlay)
-        defer {
-            imageView.removeFromSuperview()
-            overlay.removeFromSuperview()
-        }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
             entries.contains { $0.type == .backgroundImage },
-            "UIImageView with an overlapping sibling should produce a .backgroundImage entry"
-        )
+            )
     }
 
     // MARK: - UISwitch
@@ -243,11 +244,10 @@ final class ReplayTests: XCTestCase {
         uiSwitch.isOn = true
         uiSwitch.frame.origin = CGPoint(x: 20, y: 400)
         window.addSubview(uiSwitch)
-        defer { uiSwitch.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
-        XCTAssertTrue(entries.contains { $0.type == .switchOn }, "UISwitch with isOn=true should produce .switchOn")
+        XCTAssertTrue(entries.contains { $0.type == .switchOn })
     }
 
     func testUISwitchOffProducesSwitchOffEntry() {
@@ -255,11 +255,10 @@ final class ReplayTests: XCTestCase {
         uiSwitch.isOn = false
         uiSwitch.frame.origin = CGPoint(x: 20, y: 400)
         window.addSubview(uiSwitch)
-        defer { uiSwitch.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
-        XCTAssertTrue(entries.contains { $0.type == .switchOff }, "UISwitch with isOn=false should produce .switchOff")
+        XCTAssertTrue(entries.contains { $0.type == .switchOff })
     }
 
     // MARK: - MKMapView
@@ -267,13 +266,13 @@ final class ReplayTests: XCTestCase {
     func testMKMapViewProducesMapEntry() {
         let mapView = MKMapView(frame: CGRect(x: 20, y: 400, width: 200, height: 150))
         window.addSubview(mapView)
-        defer { mapView.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .map && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 150) },
-            "MKMapView should produce a .map entry"
+            entries.contains {
+                $0.type == .map && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 150)
+            }
         )
     }
 
@@ -282,13 +281,13 @@ final class ReplayTests: XCTestCase {
     func testWKWebViewProducesWebviewEntry() {
         let webView = WKWebView(frame: CGRect(x: 20, y: 400, width: 200, height: 150))
         window.addSubview(webView)
-        defer { webView.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .webview && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 150) },
-            "WKWebView should produce a .webview entry"
+            entries.contains {
+                $0.type == .webview && $0.frame == CGRect(x: 20, y: 400, width: 200, height: 150)
+            }
         )
     }
 
@@ -298,27 +297,32 @@ final class ReplayTests: XCTestCase {
         let v = UIView(frame: CGRect(x: 20, y: 400, width: 100, height: 100))
         v.backgroundColor = UIColor.red.withAlphaComponent(0.3)
         window.addSubview(v)
-        defer { v.removeFromSuperview() }
 
-        let entries = decode(Replay().capture(windows: [self.window]))
+        let entries = decode(Replay().capture(windows: [window]))
 
         XCTAssertTrue(
-            entries.contains { $0.type == .transparentView && $0.frame == CGRect(x: 20, y: 400, width: 100, height: 100) },
-            "UIView with semi-transparent background should produce a .transparentView entry"
+            entries.contains {
+                $0.type == .transparentView && $0.frame == CGRect(x: 20, y: 400, width: 100, height: 100)
+            }
         )
     }
+}
 
-    // MARK: - Helpers
-
-    private struct Entry {
+// MARK: - Helpers
+extension ReplayTests {
+    struct SessionReplayEntry {
         let type: ViewType
         let frame: CGRect
     }
 
     /// Decodes the binary buffer produced by `Replay.capture()` into readable entries.
     /// For more information, read the docs of `rectToBytes`
-    private func decode(_ data: Data) -> [Entry] {
-        var entries: [Entry] = []
+    ///
+    /// - parameter data: The raw bytes produced by `Replay.capture()`.
+    ///
+    /// - returns: The decoded list of typed, framed entries.
+    func decode(_ data: Data) -> [SessionReplayEntry] {
+        var entries: [SessionReplayEntry] = []
         var i = data.startIndex
 
         while i < data.endIndex {
@@ -342,7 +346,7 @@ final class ReplayTests: XCTestCase {
                 }
             }
 
-            entries.append(Entry(
+            entries.append(SessionReplayEntry(
                 type: viewType,
                 frame: CGRect(x: values[0], y: values[1], width: values[2], height: values[3])
             ))


### PR DESCRIPTION
# Overview
iOS 26 moved several SwiftUI rendering internals from `UIView` subclasses to pure `CALayer` objects. The existing traversal only walked `UIView` subviews, so those elements became invisible in replay captures.