### PR TITLE
Adding more options for manual releases

### DIFF
--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -18,7 +18,7 @@ on:
         default: all
       capture-suffix:
         type: string
-        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios. Leave empty for standard "capture".'
+        description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios. Leave empty for standard "capture".'
         required: false
         default: ''
     secrets:
@@ -51,7 +51,7 @@ on:
           - capture-only
       capture-suffix:
         type: string
-        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios. Leave empty for standard "capture".'
+        description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios. Leave empty for standard "capture".'
         required: false
         default: ''
 jobs:
@@ -115,10 +115,7 @@ jobs:
         run: sudo apt-get install -y clang
       - name: Build AAR + artifacts
         run: |
-          artifact_name="capture"
-          if [ -n "${{ inputs.capture-suffix }}" ]; then
-            artifact_name="capture-${{ inputs.capture-suffix }}"
-          fi
+          artifact_name="capture${{ inputs.capture-suffix }}"
           ./tools/android_release.sh "$VERSION" "$artifact_name"
         env:
           VERSION: ${{ inputs.version }}
@@ -151,7 +148,6 @@ jobs:
       contents: write
     name: GitHub release
     runs-on: ubuntu-latest
-    if: ${{ always() && !failure() && !cancelled() }}
     needs: [
       "ios-release-build",
       "build-ios-example-apps",
@@ -248,8 +244,8 @@ jobs:
       - name: Create release
         run: |
           tag="v$VERSION"
-          if [ -n "${{ inputs.capture-suffix }}" ]; then
-            tag="v$VERSION-${{ inputs.capture-suffix }}"
+          if [ -n "${{ inputs.capture-suffix }}" ] && [ "${{ inputs.platform }}" = "android" ]; then
+            tag="v$VERSION${{ inputs.capture-suffix }}"
           fi
           gh release create "$tag" \
             --target "$GITHUB_REF_NAME" \

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -63,8 +63,14 @@ jobs:
         run: |
           echo "$VERSION"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$ ]]; then exit 1; fi
+          if [ -n "$CAPTURE_SUFFIX" ] && [ "$PLATFORM" != "android" ]; then
+            echo "capture-suffix can only be used with platform=android" >&2
+            exit 1
+          fi
     env:
       VERSION: ${{ inputs.version }}
+      CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
+      PLATFORM: ${{ inputs.platform }}
 
   # The iOS release build builds the xcframework in release mode and uploads it to the artifact store for later use.
   ios-release-build:
@@ -115,10 +121,11 @@ jobs:
         run: sudo apt-get install -y clang
       - name: Build AAR + artifacts
         run: |
-          artifact_name="capture${{ inputs.capture-suffix }}"
+          artifact_name="capture$CAPTURE_SUFFIX"
           ./tools/android_release.sh "$VERSION" "$artifact_name"
         env:
           VERSION: ${{ inputs.version }}
+          CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
       - uses: actions/upload-artifact@v4
         with:
           name: Capture.android.zip
@@ -148,6 +155,10 @@ jobs:
       contents: write
     name: GitHub release
     runs-on: ubuntu-latest
+    # always() is needed because some dependencies may be conditionally skipped
+    # (e.g. iOS jobs when platform=android, integrations when capture-only).
+    # Without it, a skipped dependency would also skip this job.
+    if: ${{ always() && !failure() && !cancelled() }}
     needs: [
       "ios-release-build",
       "build-ios-example-apps",
@@ -226,26 +237,28 @@ jobs:
         id: assets
         run: |
           assets=""
-          if [ "${{ inputs.platform }}" = "all" ] || [ "${{ inputs.platform }}" = "ios" ]; then
+          if [ "$PLATFORM" = "all" ] || [ "$PLATFORM" = "ios" ]; then
             assets="$assets Capture-$VERSION.ios.zip Capture-$VERSION.doccarchive.ios.zip example-apps.ios.zip"
           fi
-          if [ "${{ inputs.platform }}" = "all" ] || [ "${{ inputs.platform }}" = "android" ]; then
+          if [ "$PLATFORM" = "all" ] || [ "$PLATFORM" = "android" ]; then
             assets="$assets Capture-$VERSION.android.zip example-apps.android.zip"
-            if [ "${{ inputs.android-artifacts }}" = "all" ]; then
+            if [ "$ANDROID_ARTIFACTS" = "all" ]; then
               assets="$assets capture-timber-$VERSION.android.zip capture-apollo-$VERSION.android.zip capture-plugin-$VERSION.android.zip capture-plugin-marker-$VERSION.android.zip"
             fi
           fi
           echo "files=$assets" >> "$GITHUB_OUTPUT"
         env:
           VERSION: ${{ inputs.version }}
+          PLATFORM: ${{ inputs.platform }}
+          ANDROID_ARTIFACTS: ${{ inputs.android-artifacts }}
 
         # Upload artifacts to the newly created release.
         # Prefix release version with "v". If capture-suffix is set, append it to the tag.
       - name: Create release
         run: |
           tag="v$VERSION"
-          if [ -n "${{ inputs.capture-suffix }}" ] && [ "${{ inputs.platform }}" = "android" ]; then
-            tag="v$VERSION${{ inputs.capture-suffix }}"
+          if [ -n "$CAPTURE_SUFFIX" ] && [ "$PLATFORM" = "android" ]; then
+            tag="v$VERSION$CAPTURE_SUFFIX"
           fi
           gh release create "$tag" \
             --target "$GITHUB_REF_NAME" \
@@ -254,3 +267,5 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
+          PLATFORM: ${{ inputs.platform }}

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -6,6 +6,21 @@ on:
         description: 'The new version to tag, ex: 0.9.102'
         required: true
         type: string
+      platform:
+        type: string
+        description: Which platform(s) to release (all, android, ios)
+        required: false
+        default: all
+      android-artifacts:
+        type: string
+        description: Which Android artifacts to publish (all, capture-only)
+        required: false
+        default: all
+      capture-suffix:
+        type: string
+        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios. Leave empty for standard "capture".'
+        required: false
+        default: ''
     secrets:
       OPEN_CAPTURE_SDK_PRS_APP_ID:
         required: true
@@ -17,6 +32,28 @@ on:
         description: 'The new version to tag, ex: 0.9.102'
         required: true
         type: string
+      platform:
+        type: choice
+        description: Which platform(s) to release
+        required: true
+        default: all
+        options:
+          - all
+          - android
+          - ios
+      android-artifacts:
+        type: choice
+        description: Which Android artifacts to publish
+        required: true
+        default: all
+        options:
+          - all
+          - capture-only
+      capture-suffix:
+        type: string
+        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios. Leave empty for standard "capture".'
+        required: false
+        default: ''
 jobs:
   verify-version:
     name: Verify arguments
@@ -28,8 +65,10 @@ jobs:
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+(\.[0-9]+)?)?$ ]]; then exit 1; fi
     env:
       VERSION: ${{ inputs.version }}
+
   # The iOS release build builds the xcframework in release mode and uploads it to the artifact store for later use.
   ios-release-build:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
     name: Capture.xcframework with artifacts
     needs: ["verify-version"]
     runs-on: macos-26
@@ -52,7 +91,9 @@ jobs:
         with:
           name: Capture.doccarchive.ios.zip
           path: ./Capture.doccarchive.ios.zip
+
   build-ios-example-apps:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
     needs: ["verify-version"]
     permissions:
       contents: write
@@ -61,6 +102,7 @@ jobs:
 
   # The Android release build builds capture.aar and accompanying artifacts, like the .pom xml and the symbols corresponding to the .so.
   android-release-build:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'android' }}
     name: Capture.aar with artifacts
     needs: ["verify-version"]
     runs-on: ubuntu-latest
@@ -72,20 +114,29 @@ jobs:
       - name: Install Clang
         run: sudo apt-get install -y clang
       - name: Build AAR + artifacts
-        run: ./tools/android_release.sh "$VERSION"
+        run: |
+          artifact_name="capture"
+          if [ -n "${{ inputs.capture-suffix }}" ]; then
+            artifact_name="capture-${{ inputs.capture-suffix }}"
+          fi
+          ./tools/android_release.sh "$VERSION" "$artifact_name"
         env:
           VERSION: ${{ inputs.version }}
       - uses: actions/upload-artifact@v4
         with:
           name: Capture.android.zip
           path: ./dist/Capture.android.zip
+
   build-android-example-apps:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'android' }}
     needs: ["verify-version"]
     permissions:
       contents: write
     uses: ./.github/workflows/example_apps_android.yaml
     secrets: inherit
+
   build-android-integrations:
+    if: ${{ (inputs.platform == 'all' || inputs.platform == 'android') && inputs.android-artifacts == 'all' }}
     name: Build Android Integrations
     needs: ["verify-version"]
     permissions:
@@ -100,6 +151,7 @@ jobs:
       contents: write
     name: GitHub release
     runs-on: ubuntu-latest
+    if: ${{ always() && !failure() && !cancelled() }}
     needs: [
       "ios-release-build",
       "build-ios-example-apps",
@@ -114,16 +166,21 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+
       - name: Prepare Android artifacts
+        if: ${{ inputs.platform == 'all' || inputs.platform == 'android' }}
         run: ./ci/gh_prepare_android_artifacts.sh "$VERSION"
         env:
           VERSION: ${{ inputs.version }}
+
       - name: Prepare iOS artifacts
+        if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
         run: |
           mv Capture.ios.zip Capture-$VERSION.ios.zip
           mv Capture.doccarchive.ios.zip Capture-$VERSION.doccarchive.ios.zip
         env:
           VERSION: ${{ inputs.version }}
+
       - name: 'Create Github Token'
         if: ${{ github.ref_name == 'main' }}
         id: org-pr-create-token
@@ -168,22 +225,36 @@ jobs:
             echo "Extract release notes step succeeded"
           fi
 
+      # Collect release assets based on platform and android-artifacts selection
+      - name: Collect release assets
+        id: assets
+        run: |
+          assets=""
+          if [ "${{ inputs.platform }}" = "all" ] || [ "${{ inputs.platform }}" = "ios" ]; then
+            assets="$assets Capture-$VERSION.ios.zip Capture-$VERSION.doccarchive.ios.zip example-apps.ios.zip"
+          fi
+          if [ "${{ inputs.platform }}" = "all" ] || [ "${{ inputs.platform }}" = "android" ]; then
+            assets="$assets Capture-$VERSION.android.zip example-apps.android.zip"
+            if [ "${{ inputs.android-artifacts }}" = "all" ]; then
+              assets="$assets capture-timber-$VERSION.android.zip capture-apollo-$VERSION.android.zip capture-plugin-$VERSION.android.zip capture-plugin-marker-$VERSION.android.zip"
+            fi
+          fi
+          echo "files=$assets" >> "$GITHUB_OUTPUT"
+        env:
+          VERSION: ${{ inputs.version }}
+
         # Upload artifacts to the newly created release.
-        # Prefix release version with "v".
+        # Prefix release version with "v". If capture-suffix is set, append it to the tag.
       - name: Create release
         run: |
-          gh release create "v$VERSION" \
+          tag="v$VERSION"
+          if [ -n "${{ inputs.capture-suffix }}" ]; then
+            tag="v$VERSION-${{ inputs.capture-suffix }}"
+          fi
+          gh release create "$tag" \
             --target "$GITHUB_REF_NAME" \
             --notes-file tmp_notes.md \
-            "Capture-$VERSION.ios.zip" \
-            "Capture-$VERSION.doccarchive.ios.zip" \
-            "Capture-$VERSION.android.zip" \
-            "example-apps.ios.zip" \
-            "example-apps.android.zip" \
-            "capture-timber-$VERSION.android.zip" \
-            "capture-apollo-$VERSION.android.zip" \
-            "capture-plugin-$VERSION.android.zip" \
-            "capture-plugin-marker-$VERSION.android.zip"
+            ${{ steps.assets.outputs.files }}
         env:
           VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -127,11 +127,11 @@ jobs:
     - name: Download GH Release Android artifacts
       run: |
         tag="v$VERSION"
-        if [ -n "${{ inputs.capture-suffix }}" ] && [ "${{ inputs.platform }}" = "android" ]; then
-          tag="v$VERSION${{ inputs.capture-suffix }}"
+        if [ -n "$CAPTURE_SUFFIX" ] && [ "$PLATFORM" = "android" ]; then
+          tag="v$VERSION$CAPTURE_SUFFIX"
         fi
         gh release download "$tag" -p 'Capture*.android.zip'
-        if [ "${{ inputs.android-artifacts }}" = "all" ]; then
+        if [ "$ANDROID_ARTIFACTS" = "all" ]; then
           gh release download "$tag" -p 'capture-timber*.android.zip'
           gh release download "$tag" -p 'capture-apollo*.android.zip'
           gh release download "$tag" -p 'capture-plugin*.android.zip'
@@ -139,14 +139,19 @@ jobs:
       env:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
+        PLATFORM: ${{ inputs.platform }}
+        ANDROID_ARTIFACTS: ${{ inputs.android-artifacts }}
     - name: Upload Android Artifacts to aws bucket and prepare Maven Central bundles
       env:
         # GPG signing configuration (existing repo/org secrets)
         GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
+        CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
+        ANDROID_ARTIFACTS: ${{ inputs.android-artifacts }}
       run: |
-        artifact_name="capture${{ inputs.capture-suffix }}"
-        if [ "${{ inputs.android-artifacts }}" = "capture-only" ]; then
+        artifact_name="capture$CAPTURE_SUFFIX"
+        if [ "$ANDROID_ARTIFACTS" = "capture-only" ]; then
           ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "" "" "" "" "$artifact_name"
         else
           ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "capture-timber-${{ inputs.version }}.android.zip" "capture-apollo-${{ inputs.version }}.android.zip" "capture-plugin-${{ inputs.version }}.android.zip" "capture-plugin-marker-${{ inputs.version }}.android.zip" "$artifact_name"

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -10,6 +10,21 @@ on:
         type: boolean
         description: Ignore main branch requirement (SOC2 compliance)
         required: true
+      platform:
+        type: string
+        description: Which platform(s) to release (all, android, ios, react-native)
+        required: false
+        default: all
+      android-artifacts:
+        type: string
+        description: Which Android artifacts to publish (all, capture-only)
+        required: false
+        default: all
+      capture-suffix:
+        type: string
+        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        required: false
+        default: ''
   workflow_dispatch:
     inputs:
       version:
@@ -20,8 +35,32 @@ on:
         type: boolean
         description: Ignore main branch requirement (SOC2 compliance)
         required: true
+      platform:
+        type: choice
+        description: Which platform(s) to release
+        required: true
+        default: all
+        options:
+          - all
+          - android
+          - ios
+          - react-native
+      android-artifacts:
+        type: choice
+        description: Which Android artifacts to publish (ignored if platform is ios or react-native)
+        required: true
+        default: all
+        options:
+          - all
+          - capture-only
+      capture-suffix:
+        type: string
+        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        required: false
+        default: ''
 jobs:
   release-ios:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
     name: Upload iOS artifacts to dl.bitdrift.io
     permissions:
       id-token: write # required to use OIDC authentication
@@ -58,7 +97,8 @@ jobs:
       env:
         VERSION: ${{ inputs.version }}
   release-android:
-    name: Upload Android artifacts to bitdrif maven and maven central
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'android' }}
+    name: Upload Android artifacts to bitdrift maven and maven central
     permissions:
       id-token: write # required to use OIDC authentication (set up aws credentials)
       contents: read
@@ -86,10 +126,16 @@ jobs:
         aws-region: us-east-1
     - name: Download GH Release Android artifacts
       run: |
-        gh release download "v$VERSION" -p 'Capture*.android.zip'
-        gh release download "v$VERSION" -p 'capture-timber*.android.zip'
-        gh release download "v$VERSION" -p 'capture-apollo*.android.zip'
-        gh release download "v$VERSION" -p 'capture-plugin*.android.zip'
+        tag="v$VERSION"
+        if [ -n "${{ inputs.capture-suffix }}" ]; then
+          tag="v$VERSION-${{ inputs.capture-suffix }}"
+        fi
+        gh release download "$tag" -p 'Capture*.android.zip'
+        if [ "${{ inputs.android-artifacts }}" = "all" ]; then
+          gh release download "$tag" -p 'capture-timber*.android.zip'
+          gh release download "$tag" -p 'capture-apollo*.android.zip'
+          gh release download "$tag" -p 'capture-plugin*.android.zip'
+        fi
       env:
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,7 +144,16 @@ jobs:
         # GPG signing configuration (existing repo/org secrets)
         GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
-      run: ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "capture-timber-${{ inputs.version }}.android.zip" "capture-apollo-${{ inputs.version }}.android.zip" "capture-plugin-${{ inputs.version }}.android.zip" "capture-plugin-marker-${{ inputs.version }}.android.zip"
+      run: |
+        artifact_name="capture"
+        if [ -n "${{ inputs.capture-suffix }}" ]; then
+          artifact_name="capture-${{ inputs.capture-suffix }}"
+        fi
+        if [ "${{ inputs.android-artifacts }}" = "capture-only" ]; then
+          ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "" "" "" "" "$artifact_name"
+        else
+          ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "capture-timber-${{ inputs.version }}.android.zip" "capture-apollo-${{ inputs.version }}.android.zip" "capture-plugin-${{ inputs.version }}.android.zip" "capture-plugin-marker-${{ inputs.version }}.android.zip" "$artifact_name"
+        fi
     - name: Upload bundles to Maven Central
       env:
         MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
@@ -182,4 +237,3 @@ jobs:
             exit 1
           fi
         done
-

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -22,7 +22,7 @@ on:
         default: all
       capture-suffix:
         type: string
-        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
         required: false
         default: ''
   workflow_dispatch:
@@ -55,7 +55,7 @@ on:
           - capture-only
       capture-suffix:
         type: string
-        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats"). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
         required: false
         default: ''
 jobs:
@@ -127,8 +127,8 @@ jobs:
     - name: Download GH Release Android artifacts
       run: |
         tag="v$VERSION"
-        if [ -n "${{ inputs.capture-suffix }}" ]; then
-          tag="v$VERSION-${{ inputs.capture-suffix }}"
+        if [ -n "${{ inputs.capture-suffix }}" ] && [ "${{ inputs.platform }}" = "android" ]; then
+          tag="v$VERSION${{ inputs.capture-suffix }}"
         fi
         gh release download "$tag" -p 'Capture*.android.zip'
         if [ "${{ inputs.android-artifacts }}" = "all" ]; then
@@ -145,10 +145,7 @@ jobs:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
       run: |
-        artifact_name="capture"
-        if [ -n "${{ inputs.capture-suffix }}" ]; then
-          artifact_name="capture-${{ inputs.capture-suffix }}"
-        fi
+        artifact_name="capture${{ inputs.capture-suffix }}"
         if [ "${{ inputs.android-artifacts }}" = "capture-only" ]; then
           ./ci/capture_android_release.sh ${{ inputs.version }} "Capture-${{ inputs.version }}.android.zip" "" "" "" "" "$artifact_name"
         else

--- a/.github/workflows/update_sdk_version.yaml
+++ b/.github/workflows/update_sdk_version.yaml
@@ -11,6 +11,29 @@ on:
         type: boolean
         description: Ignore main branch requirement (SOC2 compliance)
         required: true
+      platform:
+        type: choice
+        description: Which platform(s) to release
+        required: true
+        default: all
+        options:
+          - all
+          - android
+          - ios
+          - react-native
+      android-artifacts:
+        type: choice
+        description: Which Android artifacts to publish (ignored if platform is ios or react-native)
+        required: true
+        default: all
+        options:
+          - all
+          - capture-only
+      capture-suffix:
+        type: string
+        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        required: false
+        default: ''
   workflow_call:
     inputs:
       version:
@@ -21,6 +44,21 @@ on:
         type: boolean
         description: Ignore main branch requirement (SOC2 compliance)'
         required: true
+      platform:
+        type: string
+        description: Which platform(s) to release (all, android, ios, react-native)
+        required: false
+        default: all
+      android-artifacts:
+        type: string
+        description: Which Android artifacts to publish (all, capture-only)
+        required: false
+        default: all
+      capture-suffix:
+        type: string
+        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        required: false
+        default: ''
     secrets: 
       OPEN_CAPTURE_SDK_PRS_APP_ID:
         required: true
@@ -34,6 +72,9 @@ jobs:
     uses: ./.github/workflows/release_gh.yaml
     with:
       version: ${{ inputs.version }}
+      platform: ${{ inputs.platform }}
+      android-artifacts: ${{ inputs.android-artifacts }}
+      capture-suffix: ${{ inputs.capture-suffix }}
     secrets: inherit
   public-release:
     permissions:
@@ -43,15 +84,20 @@ jobs:
     with:
       version: ${{ inputs.version }}
       emergency: ${{ inputs.emergency }}
+      platform: ${{ inputs.platform }}
+      android-artifacts: ${{ inputs.android-artifacts }}
+      capture-suffix: ${{ inputs.capture-suffix }}
     secrets: inherit
     needs: gh-release
   capture-ios-release:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
     uses: ./.github/workflows/release_capture_ios.yaml
     with:
       version: ${{ inputs.version }}
     needs: public-release
     secrets: inherit
   capture-react-release:
+    if: ${{ inputs.platform == 'all' || inputs.platform == 'react-native' }}
     uses: ./.github/workflows/release_capture_react.yaml
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/update_sdk_version.yaml
+++ b/.github/workflows/update_sdk_version.yaml
@@ -31,7 +31,7 @@ on:
           - capture-only
       capture-suffix:
         type: string
-        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
         required: false
         default: ''
   workflow_call:
@@ -56,7 +56,7 @@ on:
         default: all
       capture-suffix:
         type: string
-        description: 'Custom Android capture artifact suffix (e.g. "no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
+        description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
         required: false
         default: ''
     secrets: 
@@ -67,6 +67,7 @@ on:
         
 jobs:
   gh-release:
+    if: ${{ inputs.platform != 'react-native' }}
     permissions:
       contents: write
     uses: ./.github/workflows/release_gh.yaml
@@ -77,6 +78,7 @@ jobs:
       capture-suffix: ${{ inputs.capture-suffix }}
     secrets: inherit
   public-release:
+    if: ${{ inputs.platform != 'react-native' }}
     permissions:
       id-token: write # required to use OIDC authentication
       contents: read
@@ -97,7 +99,7 @@ jobs:
     needs: public-release
     secrets: inherit
   capture-react-release:
-    if: ${{ inputs.platform == 'all' || inputs.platform == 'react-native' }}
+    if: ${{ always() && !failure() && !cancelled() && (inputs.platform == 'all' || inputs.platform == 'react-native') }}
     uses: ./.github/workflows/release_capture_react.yaml
     with:
       version: ${{ inputs.version }}

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -8,10 +8,10 @@ readonly remote_location_root_prefix="s3://bitdrift-public-dl/sdk/android-maven/
 
 readonly version="$1"
 readonly capture_archive="$2"
-readonly capture_timber_archive="$3"
-readonly capture_apollo_archive="$4"
-readonly capture_plugin_archive="$5"
-readonly capture_plugin_marker_archive="$6"
+readonly capture_timber_archive="${3:-}"
+readonly capture_apollo_archive="${4:-}"
+readonly capture_plugin_archive="${5:-}"
+readonly capture_plugin_marker_archive="${6:-}"
 # Optional: custom artifact name (e.g. "capture-no-jank-stats"). Defaults to "capture".
 readonly capture_artifact_name="${7:-capture}"
 

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -12,6 +12,8 @@ readonly capture_timber_archive="$3"
 readonly capture_apollo_archive="$4"
 readonly capture_plugin_archive="$5"
 readonly capture_plugin_marker_archive="$6"
+# Optional: custom artifact name (e.g. "capture-no-jank-stats"). Defaults to "capture".
+readonly capture_artifact_name="${7:-capture}"
 
 #############################################
 # Helpers for Maven Central bundle creation #
@@ -211,8 +213,8 @@ function release_capture_sdk() {
 
   echo "+++ Uploading artifacts to s3 bucket"
 
-  local -r remote_location_prefix="$remote_location_root_prefix/capture"
-  local -r name="capture-$version"
+  local -r remote_location_prefix="$remote_location_root_prefix/$capture_artifact_name"
+  local -r name="$capture_artifact_name-$version"
 
   files=(
     "$sdk_repo/ci/LICENSE"
@@ -227,10 +229,10 @@ function release_capture_sdk() {
     upload_file "$remote_location_prefix/$version" "$file"
   done
 
-  generate_maven_file "$remote_location_prefix" "capture"
+  generate_maven_file "$remote_location_prefix" "$capture_artifact_name"
 
-  # Prepare Maven Central bundle (group: io/bitdrift, artifact: capture)
-  package_maven_central_bundle "io/bitdrift" "capture" "$version" \
+  # Prepare Maven Central bundle (group: io/bitdrift, artifact: $capture_artifact_name)
+  package_maven_central_bundle "io/bitdrift" "$capture_artifact_name" "$version" \
     "$name.pom" "$name-javadoc.jar" "$name-sources.jar" "$name.aar"
   popd
 }
@@ -318,7 +320,17 @@ function release_gradle_plugin() {
 import_gpg_key_if_available
 
 release_capture_sdk
-release_gradle_library "capture-timber" "$capture_timber_archive"
-release_gradle_library "capture-apollo" "$capture_apollo_archive"
-release_gradle_library "capture-plugin" "$capture_plugin_archive"
-release_gradle_plugin "capture-plugin" "io.bitdrift.capture-plugin.gradle.plugin" "$capture_plugin_marker_archive"
+
+# Release integration libraries only if their archives are provided
+if [[ -n "$capture_timber_archive" ]]; then
+  release_gradle_library "capture-timber" "$capture_timber_archive"
+fi
+if [[ -n "$capture_apollo_archive" ]]; then
+  release_gradle_library "capture-apollo" "$capture_apollo_archive"
+fi
+if [[ -n "$capture_plugin_archive" ]]; then
+  release_gradle_library "capture-plugin" "$capture_plugin_archive"
+fi
+if [[ -n "$capture_plugin_marker_archive" ]]; then
+  release_gradle_plugin "capture-plugin" "io.bitdrift.capture-plugin.gradle.plugin" "$capture_plugin_marker_archive"
+fi

--- a/ci/capture_android_release.sh
+++ b/ci/capture_android_release.sh
@@ -15,6 +15,11 @@ readonly capture_plugin_marker_archive="${6:-}"
 # Optional: custom artifact name (e.g. "capture-no-jank-stats"). Defaults to "capture".
 readonly capture_artifact_name="${7:-capture}"
 
+if [[ ! "$capture_artifact_name" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "Invalid capture artifact name: '$capture_artifact_name'. Expected regex: [a-z0-9][a-z0-9-]*" >&2
+  exit 1
+fi
+
 #############################################
 # Helpers for Maven Central bundle creation #
 #############################################

--- a/tools/android_release.sh
+++ b/tools/android_release.sh
@@ -11,6 +11,10 @@ if [ $# -eq 0 ]
     readonly version="$1"
 fi
 
+# Optional second argument: custom artifact name (e.g. "capture-no-jank-stats")
+# Defaults to "capture" if not provided.
+readonly artifact_name="${2:-capture}"
+
 ./bazelw build \
   --announce_rc \
   --config=ci \
@@ -22,12 +26,17 @@ mkdir -p dist/
 
 sdk_repo="$(pwd)"
 pushd "$(mktemp -d)"
-  mv "$sdk_repo/bazel-bin/capture.aar" "capture-$version.aar"
-  mv "$sdk_repo/bazel-bin/capture.pom" "capture-$version.pom"
-  mv "$sdk_repo/bazel-bin/capture-sources.jar" "capture-$version-sources.jar"
-  mv "$sdk_repo/bazel-bin/capture-javadoc.jar" "capture-$version-javadoc.jar"
-  mv "$sdk_repo/bazel-bin/symbols.tar" "capture-$version-symbols.tar"
+  mv "$sdk_repo/bazel-bin/capture.aar" "$artifact_name-$version.aar"
+  mv "$sdk_repo/bazel-bin/capture.pom" "$artifact_name-$version.pom"
+  mv "$sdk_repo/bazel-bin/capture-sources.jar" "$artifact_name-$version-sources.jar"
+  mv "$sdk_repo/bazel-bin/capture-javadoc.jar" "$artifact_name-$version-javadoc.jar"
+  mv "$sdk_repo/bazel-bin/symbols.tar" "$artifact_name-$version-symbols.tar"
   cp "$sdk_repo/ci/LICENSE" "LICENSE"
+
+  # If using a custom artifact name, update the artifactId in the POM
+  if [ "$artifact_name" != "capture" ]; then
+    sed -i "s|<artifactId>capture</artifactId>|<artifactId>$artifact_name</artifactId>|" "$artifact_name-$version.pom"
+  fi
 
   zip -j -r "$sdk_repo/dist/Capture.android.zip" ./*
 popd

--- a/tools/android_release.sh
+++ b/tools/android_release.sh
@@ -33,9 +33,12 @@ pushd "$(mktemp -d)"
   mv "$sdk_repo/bazel-bin/symbols.tar" "$artifact_name-$version-symbols.tar"
   cp "$sdk_repo/ci/LICENSE" "LICENSE"
 
-  # If using a custom artifact name, update the artifactId in the POM
+  # If using a custom artifact name, update artifact-specific fields in the POM
   if [ "$artifact_name" != "capture" ]; then
-    sed -i "s|<artifactId>capture</artifactId>|<artifactId>$artifact_name</artifactId>|" "$artifact_name-$version.pom"
+    sed -i \
+      -e "s|<artifactId>capture</artifactId>|<artifactId>$artifact_name</artifactId>|" \
+      -e "s|/capture/|/$artifact_name/|g" \
+      "$artifact_name-$version.pom"
   fi
 
   zip -j -r "$sdk_repo/dist/Capture.android.zip" ./*


### PR DESCRIPTION
## What

Adding more flexibility to have more customization for manual releases. Some of these customizations are:

- Trigger Android only, iOS only, React Native only, or all
- When Android is selected, choose between all artifacts or capture-only (without timber, apollo, plugin)
- Option to add a custom capture-suffix for android release (e.g. that becomes `io.bitdrift:capture-your-suffix:0.23.0`)
- GitHub release tag includes the suffix to avoid conflicts with existing releases

## Verification

Tested with a patch release from local branch [here](https://github.com/bitdriftlabs/capture-sdk/actions/runs/26237507549) by running with these parameters below:

`gh workflow run update_sdk_version.yaml --ref android-release-0.23.0-no-jank-stats -f version=0.23.0 -f emergency=true -f platform=android -f android-artifacts=capture-only -f "capture-suffix=no-jank-stats"`

## Mitigation plan

If any issues with standard release, please revert this PR.
 
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.