### PR TITLE
[Android] Harden startResultCallback + rethrow on debug builds for customer callback errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Prevent SDK from entering failed state when customer throws in `startResult` callback.
 
 ### iOS
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -28,6 +28,8 @@ import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
 import io.bitdrift.capture.utils.BuildTypeChecker
+import io.bitdrift.capture.utils.DebugCustomerCallbackException
+import io.bitdrift.capture.utils.invokeCatchingOrThrowOnDebug
 import okhttp3.HttpUrl
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
@@ -184,7 +186,7 @@ object Capture {
             if (hasInvalidContext(context)) {
                 val errorMessage = "Attempted to initialize Capture with a null context"
                 Log.w(LOG_TAG, errorMessage)
-                startResult?.invoke(CaptureResult.Failure(SdkStartFailure(errorMessage)))
+                startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Failure(SdkStartFailure(errorMessage)))
                 return
             }
 
@@ -727,12 +729,15 @@ object Capture {
                 captureStartThread = Thread.currentThread().name,
             )
 
-            startResult?.invoke(CaptureResult.Success(loggerImpl))
+            startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Success(loggerImpl))
         } catch (throwable: Throwable) {
+            if (throwable.shouldReThrowOnDebugBuild()) throw throwable
             val errorDetails = "Failed to start Capture: ${throwable.message}"
             Log.w(LOG_TAG, errorDetails, throwable)
             default.set(LoggerState.StartFailure)
-            startResult?.invoke(CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)))
+            startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)))
         }
     }
+
+    private fun Throwable.shouldReThrowOnDebugBuild(): Boolean = this is DebugCustomerCallbackException
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/SessionStrategyConfiguration.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/session/SessionStrategyConfiguration.kt
@@ -8,6 +8,7 @@
 package io.bitdrift.capture.providers.session
 
 import io.bitdrift.capture.common.MainThreadHandler
+import io.bitdrift.capture.utils.invokeCatchingOrThrowOnDebug
 
 internal sealed class SessionStrategyConfiguration {
     data class Fixed(
@@ -24,7 +25,7 @@ internal sealed class SessionStrategyConfiguration {
 
         fun sessionIdChanged(sessionId: String) {
             mainThreadHandler.run {
-                runCatching { sessionStrategy.onSessionIdChanged?.invoke(sessionId) }
+                sessionStrategy.onSessionIdChanged.invokeCatchingOrThrowOnDebug(sessionId)
             }
         }
     }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebug.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebug.kt
@@ -1,0 +1,47 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.utils
+
+import android.util.Log
+import io.bitdrift.capture.Capture.LOG_TAG
+import io.bitdrift.capture.ContextHolder
+
+/**
+ * Safely invokes a customer facing callback with the given [arg]. On failure:
+ * - Always logs a warning to logcat.
+ * - In debug builds, throws [DebugCustomerCallbackException] so the customer is aware during development.
+ * - In release builds, the exception is swallowed to avoid crashing the app.
+ */
+internal fun <T> ((T) -> Unit)?.invokeCatchingOrThrowOnDebug(arg: T) {
+    runCatching {
+        this?.invoke(arg)
+    }.onFailure { throwable ->
+        DebugCustomerCallbackException.createIfDebug(throwable)?.let { throw it }
+    }
+}
+
+/**
+ * Exception thrown only in debug builds when a customer-provided callback throws an unhandled exception.
+ * This exception cannot be instantiated in release builds due to the private constructor
+ * and the [createIfDebug] factory method which gates on [BuildTypeChecker.isDebuggable].
+ */
+internal class DebugCustomerCallbackException private constructor(
+    message: String,
+    cause: Throwable,
+) : RuntimeException(message, cause) {
+    companion object {
+        fun createIfDebug(throwable: Throwable): DebugCustomerCallbackException? =
+            if (ContextHolder.isInitialized && BuildTypeChecker.isDebuggable(ContextHolder.APP_CONTEXT)) {
+                val message = "Unhandled exception in customer callback"
+                Log.w(LOG_TAG, message, throwable)
+                DebugCustomerCallbackException(message, throwable)
+            } else {
+                null
+            }
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -21,7 +21,10 @@ import io.bitdrift.capture.reports.exitinfo.ExitReason
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfoResolver
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
+import io.bitdrift.capture.utils.DebugCustomerCallbackException
+import io.bitdrift.capture.utils.setIsDebuggable
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Test
@@ -202,5 +205,44 @@ class CaptureTest {
         assertThat(status.initializationState).isEqualTo(InitializationState.NOT_STARTED)
         assertThat(status.lastHandshakeTimeMs).isNull()
         assertThat(status.lastConfigDeliveryTimeMs).isNull()
+    }
+
+    @Test
+    fun startResultCallback_throwingException_onDebugBuild_throwsDebugCustomerCallbackException() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+        setIsDebuggable(debuggable = true)
+
+        assertThatThrownBy {
+            Logger.start(
+                apiKey = "test1",
+                sessionStrategy = SessionStrategy.Fixed(),
+                dateProvider = null,
+            ) { _ ->
+                throw IllegalStateException("customer callback error")
+            }
+        }.isInstanceOf(DebugCustomerCallbackException::class.java)
+            .hasCauseInstanceOf(IllegalStateException::class.java)
+
+        assertThat(Capture.logger()).isNotNull()
+    }
+
+    @Test
+    fun startResultCallback_throwingException_onReleaseBuild_swallowsAndSdkRemainsStarted() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+        setIsDebuggable(debuggable = false)
+
+        Logger.start(
+            apiKey = "test1",
+            sessionStrategy = SessionStrategy.Fixed(),
+            dateProvider = null,
+        ) { _ ->
+            throw IllegalStateException("customer callback error")
+        }
+
+        assertThat(Capture.logger()).isNotNull()
+        val status = Logger.getSdkStatus()
+        assertThat(status.initializationState).isNotEqualTo(InitializationState.NOT_STARTED)
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/DebuggableTestHelper.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/DebuggableTestHelper.kt
@@ -10,7 +10,10 @@ package io.bitdrift.capture.utils
 import android.content.pm.ApplicationInfo
 import androidx.test.core.app.ApplicationProvider
 
-internal fun setIsDebuggable(debuggable: Boolean) {
+/**
+ * Sets if the app is debuggable or not
+ */
+fun setIsDebuggable(debuggable: Boolean) {
     val appInfo = ApplicationProvider.getApplicationContext<android.app.Application>().applicationInfo
     if (debuggable) {
         appInfo.flags = appInfo.flags or ApplicationInfo.FLAG_DEBUGGABLE

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/DebuggableTestHelper.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/DebuggableTestHelper.kt
@@ -1,0 +1,20 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.utils
+
+import android.content.pm.ApplicationInfo
+import androidx.test.core.app.ApplicationProvider
+
+internal fun setIsDebuggable(debuggable: Boolean) {
+    val appInfo = ApplicationProvider.getApplicationContext<android.app.Application>().applicationInfo
+    if (debuggable) {
+        appInfo.flags = appInfo.flags or ApplicationInfo.FLAG_DEBUGGABLE
+    } else {
+        appInfo.flags = appInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE.inv()
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebugTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebugTest.kt
@@ -1,0 +1,85 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.utils
+
+import androidx.test.core.app.ApplicationProvider
+import io.bitdrift.capture.ContextHolder
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class InvokeCatchingOrThrowOnDebugTest {
+    @Before
+    fun setUp() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun illegalStateExceptionAtCallback_whenDebugBuild_shouldThrowDebugCustomerCallbackException() {
+        setIsDebuggable(true)
+
+        val callback: (String) -> Unit = { throw IllegalStateException("customer error") }
+
+        assertThatThrownBy {
+            callback.invokeCatchingOrThrowOnDebug("arg")
+        }.isInstanceOf(DebugCustomerCallbackException::class.java)
+            .hasCauseInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun illegalStateExceptionAtCallback_whenDebugBuild_shouldNotThrowDebugCustomerCallbackException() {
+        setIsDebuggable(false)
+
+        val callback: (String) -> Unit = { throw IllegalStateException("customer error") }
+
+        callback.invokeCatchingOrThrowOnDebug("arg")
+    }
+
+    @Test
+    fun callbackSuccess_whenDebugBuild_shouldNotThrowDebugCustomerCallbackException() {
+        setIsDebuggable(true)
+
+        var called = false
+        val callback: (String) -> Unit = { called = true }
+
+        callback.invokeCatchingOrThrowOnDebug("arg")
+
+        assertThat(called).isTrue()
+    }
+
+    @Test
+    fun debugCustomerCallbackException_whenReleaseBuild_shouldBeNull() {
+        setIsDebuggable(false)
+
+        val result =
+            DebugCustomerCallbackException.createIfDebug(
+                IllegalStateException("error"),
+            )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun debugCustomerCallbackException_whenDebugBuild_shouldNotBeNull() {
+        setIsDebuggable(true)
+
+        val result =
+            DebugCustomerCallbackException.createIfDebug(
+                IllegalStateException("error"),
+            )
+
+        assertThat(result).isNotNull()
+    }
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/BitdriftInit.kt
@@ -118,6 +118,9 @@ object BitdriftInit {
                         }
                         is CaptureResult.Failure -> {
                             Log.e("GradleTestApp", "SDK failed to start: ${result.error.message}")
+                            // Re-throwing on debug builds so we can get immediate signal of
+                            // any issues at Capture.Logger.start internals during the development phase.
+                            throw IllegalStateException(result.error.message)
                         }
                     }
                 }


### PR DESCRIPTION
## What

Follow up to https://github.com/bitdriftlabs/capture-sdk/issues/969.

If a customer throws an exception in their `startResult` callback implementation, the SDK could incorrectly transitions to StartFailure state (even though the SDK started successfully). This happens because the callback invocation lives inside the same try-catch that handles actual SDK initialization failures.

This PR introduces `invokeCatchingOrThrowOnDebug` that safely wraps customer-facing callback invocations:
- Debug builds: Customer callback exceptions are re-thrown as `DebugCustomerCallbackException` so developers catch broken callback implementations during development phase.
- Release builds: Behavior remains unchanged and not throwing if errors occurs in existing implementations like `onSessionIdChanged`.

Existing iOS implementation should be safe given this is prevented at compile time by the callback signature

## Verification

On the gradle-test-app and debug build created a fake crash in `startResultCallback` implementation. This should be recorded by the SDK. See [reports here](https://explorations.bitdrift.dev/issues/4220259928824558187/52126775-6e3a-407b-85df-4b39ab2e98ae?utm_source=sdk).

Same artificial callback crash for release build shouldn't crash the app. See [session here](https://timeline.bitdrift.dev/session/840b4756-fdee-4316-9496-1679e28b9d74?find=_crash_artifact_id...is...52126775-6e3a-407b-85df-4b39ab2e98ae&utilization=0&expanded=-4698491898917172903).

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.