### PR TITLE
[Android] Fix ConcurrentModification at ReplayDecorations.addDecorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Session replay: fix a rare `ConcurrentModificationException` on API < 29 when windows change while screen capture is in progress.
 
 ### iOS
 

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/WindowManager.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/WindowManager.kt
@@ -55,7 +55,10 @@ class WindowManager(
         }
         try {
             @Suppress("UNCHECKED_CAST")
-            return getWindowViews.get(windowManagerGlobal) as List<View>
+            // Match WindowInspector.getGlobalWindowViews(), which returns a defensive copy.
+            // This reflection fallback reads WindowManagerGlobal.mViews directly, so returning it
+            // can cause ConcurrentModificationException for consumers if windows change later.
+            return ArrayList(getWindowViews.get(windowManagerGlobal) as List<View>)
         } catch (e: Throwable) {
             errorHandler.handleError("Failed to retrieve windows", e)
             return emptyList()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -111,6 +111,8 @@ sealed class StressTestAction : AppAction {
     data class TriggerJankyFrames(val type: JankType) : StressTestAction()
 
     data class TriggerStrictModeViolation(val type: StrictModeViolationType) : StressTestAction()
+
+    data class TriggerScreenReplayCapture(val activity: android.app.Activity) : StressTestAction()
 }
 
 enum class StrictModeViolationType(val displayName: String) {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
@@ -7,10 +7,22 @@
 
 package io.bitdrift.gradletestapp.data.repository
 
+import android.app.Activity
+import android.app.Dialog
 import android.content.Context
+import android.graphics.PixelFormat
 import android.os.Handler
+import android.os.IBinder
 import android.os.Looper
 import android.os.StrictMode
+import android.view.Gravity
+import android.view.View
+import android.view.Window
+import android.view.WindowInsets
+import android.view.WindowManager
+import android.widget.PopupWindow
+import android.widget.TextView
+import android.widget.Toast
 import io.bitdrift.capture.Capture
 import io.bitdrift.gradletestapp.data.model.StrictModeViolationType
 import timber.log.Timber
@@ -19,6 +31,8 @@ import java.io.FileInputStream
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.URL
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class StressTestRepository(
     private val context: Context,
@@ -127,6 +141,182 @@ class StressTestRepository(
         } catch (e: Exception) {
             Timber.d("Expected exception during StrictMode test: ${e.message}")
         }
+    }
+
+    /**
+     * Before fix for BIT-8521, it reproduces the ConcurrentModificationException in ReplayDecorations.addDecorations on
+     * API < 29 by racing screen replay captures against rapid main-thread mutations of
+     * WindowManagerGlobal.mViews (dialogs, popups, toasts, and an injected trigger view).
+     */
+    fun triggerScreenReplayCapture(activity: Activity) {
+        val deadline = System.currentTimeMillis() + REPLAY_RACE_DURATION_MS
+        val mainHandler = Handler(Looper.getMainLooper())
+        val activityToken = activity.window.decorView.windowToken
+        val triggerView = RootMutationTriggerView(activity, mainHandler, activityToken)
+
+        triggerView.attachTo(activity.windowManager)
+        repeat(CONCURRENT_CHURN_RUNNERS) {
+            mainHandler.post(WindowChurnRunnable(activity, mainHandler, deadline, triggerView))
+        }
+        startReplayCaptureDriver(deadline)
+    }
+
+    private fun startReplayCaptureDriver(deadline: Long) {
+        Thread({
+            while (System.currentTimeMillis() < deadline) {
+                Capture.Logger.logScreenView("Stress ${System.nanoTime()}")
+                Thread.sleep(REPLAY_CAPTURE_INTERVAL_MS)
+            }
+        }, "replay-race-driver").start()
+    }
+
+    /**
+     * Repeatedly creates and dismisses dialogs/popups/toasts on the main thread, growing the
+     * set of attached windows seen by WindowManagerGlobal until the deadline is reached.
+     */
+    private class WindowChurnRunnable(
+        private val activity: Activity,
+        private val mainHandler: Handler,
+        private val deadline: Long,
+        private val triggerView: RootMutationTriggerView,
+    ) : Runnable {
+        private val dialogs = ArrayDeque<Dialog>()
+        private val popups = ArrayDeque<PopupWindow>()
+        private var counter = 0
+
+        override fun run() {
+            repeat(CHURN_STEPS_PER_TICK) {
+                dialogs.removeFirstOrNull()?.dismiss()
+                popups.removeFirstOrNull()?.dismiss()
+
+                val size = MIN_WINDOW_SIZE_PX + (counter % WINDOW_SIZE_RANGE_PX)
+                dialogs.addLast(createStressDialog(activity, counter, size))
+                popups.addLast(createStressPopup(activity, counter, size))
+                counter++
+            }
+
+            Toast.makeText(activity, "stress $counter", Toast.LENGTH_SHORT).show()
+
+            if (System.currentTimeMillis() < deadline) {
+                mainHandler.postDelayed(this, CHURN_INTERVAL_MS)
+            } else {
+                dialogs.forEach { it.dismiss() }
+                popups.forEach { it.dismiss() }
+                triggerView.detach()
+            }
+        }
+    }
+
+    /**
+     * A no-op overlay View whose getRootWindowInsets() forces a synchronous main-thread
+     * addView/removeView when called off the main thread, mutating WindowManagerGlobal.mViews
+     * exactly while ReplayDecorations is iterating it on the background executor.
+     */
+    private class RootMutationTriggerView(
+        context: Context,
+        private val mainHandler: Handler,
+        private val activityToken: IBinder,
+    ) : View(context) {
+        private var windowManager: WindowManager? = null
+
+        fun attachTo(windowManager: WindowManager) {
+            runCatching {
+                windowManager.addView(this, overlayLayoutParams(activityToken))
+                this.windowManager = windowManager
+            }
+        }
+
+        fun detach() {
+            val wm = windowManager ?: return
+            windowManager = null
+            removeViewIfAttached(wm, this)
+        }
+
+        override fun getRootWindowInsets(): WindowInsets? {
+            val wm = windowManager
+            if (wm == null || Looper.myLooper() == Looper.getMainLooper()) {
+                return super.getRootWindowInsets()
+            }
+            mutateWindowsOnMainThread(wm)
+            return super.getRootWindowInsets()
+        }
+
+        private fun mutateWindowsOnMainThread(wm: WindowManager) {
+            val latch = CountDownLatch(1)
+            mainHandler.post {
+                runCatching {
+                    val transient = View(context)
+                    wm.addView(transient, overlayLayoutParams(activityToken))
+                    removeViewIfAttached(wm, transient)
+                }
+                latch.countDown()
+            }
+            latch.await(MAIN_THREAD_MUTATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    companion object {
+        private const val REPLAY_RACE_DURATION_MS = 10_000L
+        private const val REPLAY_CAPTURE_INTERVAL_MS = 20L
+        private const val CHURN_INTERVAL_MS = 16L
+        private const val CHURN_STEPS_PER_TICK = 2
+        private const val CONCURRENT_CHURN_RUNNERS = 12
+        private const val MAIN_THREAD_MUTATION_TIMEOUT_MS = 200L
+        private const val MIN_WINDOW_SIZE_PX = 80
+        private const val WINDOW_SIZE_RANGE_PX = 160
+
+        private fun overlayLayoutParams(token: IBinder): WindowManager.LayoutParams =
+            WindowManager.LayoutParams(
+                1,
+                1,
+                WindowManager.LayoutParams.TYPE_APPLICATION_PANEL,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                    WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+                PixelFormat.TRANSLUCENT,
+            ).apply { this.token = token }
+
+        private fun removeViewIfAttached(windowManager: WindowManager, view: View) {
+            runCatching {
+                if (view.isAttachedToWindow) {
+                    windowManager.removeViewImmediate(view)
+                }
+            }
+        }
+
+        private fun createStressDialog(activity: Activity, counter: Int, size: Int): Dialog =
+            Dialog(activity).apply {
+                requestWindowFeature(Window.FEATURE_NO_TITLE)
+                setContentView(
+                    TextView(activity).apply {
+                        text = "Dialog $counter"
+                        minimumWidth = size
+                        minimumHeight = size
+                    },
+                )
+                window?.setDimAmount(0f)
+                show()
+                window?.setLayout(size, size)
+            }
+
+        private fun createStressPopup(activity: Activity, counter: Int, size: Int): PopupWindow =
+            PopupWindow(
+                TextView(activity).apply {
+                    text = "Popup $counter"
+                    minimumWidth = size
+                    minimumHeight = size
+                },
+                size,
+                size,
+                false,
+            ).apply {
+                isClippingEnabled = false
+                showAtLocation(
+                    activity.window.decorView,
+                    Gravity.TOP or Gravity.START,
+                    counter % 200,
+                    counter % 300,
+                )
+            }
     }
 
     private fun triggerNetworkViolation() {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
@@ -15,9 +15,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import android.app.Activity
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.bitdrift.gradletestapp.R
 import io.bitdrift.gradletestapp.data.model.AppAction
@@ -48,6 +51,9 @@ fun StressTestScreen(
         }
         item {
             StrictModeCard(onAction = onAction)
+        }
+        item {
+            ScreenReplayCard(onAction = onAction)
         }
     }
 }
@@ -254,6 +260,34 @@ private fun StrictModeCard(onAction: (AppAction) -> Unit) {
     }
 }
 
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ScreenReplayCard(onAction: (AppAction) -> Unit) {
+    @Suppress("ContextCastToActivity")
+    val activity = LocalContext.current as Activity
+    StressTestCard(title = stringResource(id = R.string.screen_capture)) {
+        Text(
+            text = "Stress replay with window mutations",
+            style = MaterialTheme.typography.bodySmall,
+            color = BitdriftColors.TextSecondary,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedButton(
+                onClick = { onAction(StressTestAction.TriggerScreenReplayCapture(activity)) },
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = BitdriftColors.TextPrimary),
+            ) {
+                Text("Trigger", maxLines = 1)
+            }
+        }
+    }
+}
+
 @Composable
 private fun StressTestCard(
     title: String,
@@ -285,4 +319,10 @@ private fun StressTestCard(
             content()
         }
     }
+}
+
+@Preview
+@Composable
+fun StressTestScreenPreview(){
+    StressTestScreen({},{})
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -183,7 +183,7 @@ class MainViewModel(
             is StressTestAction.TriggerMemoryPressureAnr -> stressTestRepository.triggerMemoryPressureAnr()
             is StressTestAction.TriggerJankyFrames -> stressTestRepository.triggerJankyFrames(action.type.durationMs)
             is StressTestAction.TriggerStrictModeViolation -> stressTestRepository.triggerStrictModeViolation(action.type)
-
+            is StressTestAction.TriggerScreenReplayCapture -> stressTestRepository.triggerScreenReplayCapture(action.activity)
             is ClearError -> clearError()
 
             // For now, navigation actions are handled at the Fragment level

--- a/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="memory_leak" translatable="false">Memory Leak</string>
     <string name="janky_frames" translatable="false">Janky Frames</string>
     <string name="strict_mode" translatable="false">StrictMode Violations</string>
+    <string name="screen_capture" translatable="false">Screen Capture</string>
     <string name="device_code_valid">Device code: Valid</string>
     <string name="device_code_invalid">Device code: Invalid</string>
     <string name="restart_warning_title">Restart the App to apply changes</string>


### PR DESCRIPTION
## What

Resolves BIT-8521

Fixes a rare ConcurrentModificationException on API < 29 when windows change (toasts, dialogs, popups) while session replay is capturing the screen on a background thread.

```
Fatal Exception: java.util.ConcurrentModificationException
   at java.util.ArrayList$Itr.next(ArrayList.java:860)
   at io.bitdrift.capture.replay.internal.ReplayDecorations.addDecorations(ReplayDecorations.kt:54)
   at io.bitdrift.capture.replay.internal.ReplayCaptureEngine$captureScreen$2.run(ReplayCaptureEngine.kt:61)

```

- On API < 29 `WindowManager.getAllRootViews()` uses reflection to read `WindowManagerGlobal.mViews` directly and returning a live reference to the internal list. If the main thread adds or removes a window while the background thread iterates, the iterator can throw the ConcurrentModificationException.

- On API >=29 is unaffected because `WindowInspector.getGlobalWindowViews()` already returns a copy internally. So the fix for the fallback api is to also do a defensive copy.

## Verification

- For the gradle-test-app, created a new entry on StressTab to reproduce the original issue.
- Run on API <29

<img width="449" height="845" alt="Screenshot 2026-06-03 at 14 16 21" src="https://github.com/user-attachments/assets/b198f4f6-6957-4b1a-836f-0541ec41c4d5" />

- Without defensive copy fix the crash is reproduced each time. [See report here](https://explorations.bitdrift.dev/issues/18226480752552072537/0e9627c3-5e04-4e51-83c0-a2985ee61e7c?index=0&range=7d)
- When the fix is apply, the session replay capture continues without crashing.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.