### PR TITLE
[Android] Fix auto instrumentation for webviews subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 **Fixed**
 
 - Ensure the Gradle plugin adds the OkHttp tracing interceptor last during automatic instrumentation.
+- Match Android `WebView` subclass `loadUrl(...)` callsites during automatic WebView instrumentation.
 
 ### iOS
 

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/instrumentation/webview/WebViewInstrumentable.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/instrumentation/webview/WebViewInstrumentable.kt
@@ -32,7 +32,7 @@ class WebViewLoadUrlInstrumentable : ClassInstrumentable {
         WebViewClassVisitor(
             apiVersion = apiVersion,
             classVisitor = originalVisitor,
-            className = instrumentableContext.currentClassData.className,
+            classContext = instrumentableContext,
         )
 }
 
@@ -42,7 +42,7 @@ class WebViewLoadUrlInstrumentable : ClassInstrumentable {
 class WebViewClassVisitor(
     apiVersion: Int,
     classVisitor: ClassVisitor,
-    private val className: String,
+    private val classContext: ClassContext,
 ) : ClassVisitor(apiVersion, classVisitor) {
 
     override fun visitMethod(
@@ -53,6 +53,6 @@ class WebViewClassVisitor(
         exceptions: Array<out String>?,
     ): MethodVisitor {
         val methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions)
-        return WebViewMethodVisitor(api, methodVisitor)
+        return WebViewMethodVisitor(api, methodVisitor, classContext)
     }
 }

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/instrumentation/webview/WebViewMethodVisitor.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/instrumentation/webview/WebViewMethodVisitor.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture.instrumentation.webview
 
+import com.android.build.api.instrumentation.ClassContext
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
@@ -31,10 +32,12 @@ import org.objectweb.asm.Opcodes
 class WebViewMethodVisitor(
     apiVersion: Int,
     methodVisitor: MethodVisitor,
+    private val classContext: ClassContext,
 ) : MethodVisitor(apiVersion, methodVisitor) {
 
     companion object {
-        private const val WEBVIEW_CLASS = "android/webkit/WebView"
+        private const val WEBVIEW_CLASS_INTERNAL_NAME = "android/webkit/WebView"
+        private const val WEBVIEW_CLASS = "android.webkit.WebView"
         private const val LOAD_URL_METHOD = "loadUrl"
         private const val LOAD_URL_DESCRIPTOR = "(Ljava/lang/String;)V"
         private const val LOAD_URL_WITH_HEADERS_DESCRIPTOR = "(Ljava/lang/String;Ljava/util/Map;)V"
@@ -52,7 +55,7 @@ class WebViewMethodVisitor(
         isInterface: Boolean,
     ) {
         val isWebViewLoadUrl = opcode == Opcodes.INVOKEVIRTUAL &&
-            owner == WEBVIEW_CLASS &&
+            owner.isWebViewClassOwner(classContext) &&
             name == LOAD_URL_METHOD &&
             (descriptor == LOAD_URL_DESCRIPTOR || descriptor == LOAD_URL_WITH_HEADERS_DESCRIPTOR)
 
@@ -106,5 +109,22 @@ class WebViewMethodVisitor(
             }
         }
         super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+    }
+
+    private fun String?.isWebViewClassOwner(classContext: ClassContext): Boolean {
+        if (this == null) {
+            return false
+        }
+
+        if (this == WEBVIEW_CLASS_INTERNAL_NAME) {
+            return true
+        }
+
+        val ownerFullyQualifyClassName = replace('/', '.')
+        val classData = runCatching {
+            classContext.loadClassData(ownerFullyQualifyClassName)
+        }.getOrNull() ?: return false
+
+        return WEBVIEW_CLASS in classData.superClasses
     }
 }

--- a/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/instrumentation/webview/WebViewMethodVisitorTest.kt
+++ b/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/instrumentation/webview/WebViewMethodVisitorTest.kt
@@ -1,0 +1,154 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.instrumentation.webview
+
+import io.bitdrift.capture.instrumentation.fakes.TestClassContext
+import io.bitdrift.capture.instrumentation.fakes.TestClassData
+import org.junit.Test
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import kotlin.test.assertEquals
+
+class WebViewMethodVisitorTest {
+    @Test
+    fun `instruments base webview owner`() {
+        val recorder = RecordingMethodVisitor()
+        val sut = WebViewMethodVisitor(Opcodes.ASM7, recorder, TestClassContext("com.example.Caller"))
+
+        sut.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            "android/webkit/WebView",
+            "loadUrl",
+            "(Ljava/lang/String;)V",
+            false,
+        )
+
+        assertEquals(
+            listOf(
+                "INSN:DUP_X1",
+                "INSN:POP",
+                "INSN:DUP_X1",
+                "METHOD:INVOKESTATIC:io/bitdrift/capture/webview/WebViewCapture.instrument(Landroid/webkit/WebView;)V",
+                "METHOD:INVOKEVIRTUAL:android/webkit/WebView.loadUrl(Ljava/lang/String;)V",
+            ),
+            recorder.events,
+        )
+    }
+
+    @Test
+    fun `instruments webview subclass loadUrl owner`() {
+        val recorder = RecordingMethodVisitor()
+        val sut =
+            WebViewMethodVisitor(
+                Opcodes.ASM7,
+                recorder,
+                TestClassContext("com/example/Caller") { className ->
+                    when (className) {
+                        "com.reactnativecommunity.webview.RNCWebView" ->
+                            TestClassData(
+                                className = className,
+                                superClasses = listOf(
+                                    "android.webkit.WebView",
+                                    "android.view.View",
+                                ),
+                            )
+
+                        else -> null
+                    }
+                },
+            )
+
+        sut.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            "com/reactnativecommunity/webview/RNCWebView",
+            "loadUrl",
+            "(Ljava/lang/String;)V",
+            false,
+        )
+
+        assertEquals(
+            listOf(
+                "INSN:DUP_X1",
+                "INSN:POP",
+                "INSN:DUP_X1",
+                "METHOD:INVOKESTATIC:io/bitdrift/capture/webview/WebViewCapture.instrument(Landroid/webkit/WebView;)V",
+                "METHOD:INVOKEVIRTUAL:com/reactnativecommunity/webview/RNCWebView.loadUrl(Ljava/lang/String;)V",
+            ),
+            recorder.events,
+        )
+    }
+
+    @Test
+    fun `skips unrelated loadUrl owner`() {
+        val recorder = RecordingMethodVisitor()
+        val sut = WebViewMethodVisitor(Opcodes.ASM7, recorder, TestClassContext("com/example/Caller"))
+
+        sut.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            "com/example/CustomView",
+            "loadUrl",
+            "(Ljava/lang/String;)V",
+            false,
+        )
+
+        assertEquals(
+            listOf(
+                "METHOD:INVOKEVIRTUAL:com/example/CustomView.loadUrl(Ljava/lang/String;)V",
+            ),
+            recorder.events,
+        )
+    }
+
+    @Test
+    fun `skips owner when class lookup fails`() {
+        val recorder = RecordingMethodVisitor()
+        val sut = WebViewMethodVisitor(Opcodes.ASM7, recorder, TestClassContext("com.example.Caller"))
+
+        sut.visitMethodInsn(
+            Opcodes.INVOKEVIRTUAL,
+            "com/reactnativecommunity/webview/RNCWebView",
+            "loadUrl",
+            "(Ljava/lang/String;)V",
+            false,
+        )
+
+        assertEquals(
+            listOf(
+                "METHOD:INVOKEVIRTUAL:com/reactnativecommunity/webview/RNCWebView.loadUrl(Ljava/lang/String;)V",
+            ),
+            recorder.events,
+        )
+    }
+}
+
+private class RecordingMethodVisitor : MethodVisitor(Opcodes.ASM7) {
+    val events = mutableListOf<String>()
+
+    override fun visitInsn(opcode: Int) {
+        events += "INSN:${opcodeName(opcode)}"
+    }
+
+    override fun visitMethodInsn(
+        opcode: Int,
+        owner: String?,
+        name: String?,
+        descriptor: String?,
+        isInterface: Boolean,
+    ) {
+        events += "METHOD:${opcodeName(opcode)}:$owner.$name$descriptor"
+    }
+
+    private fun opcodeName(opcode: Int): String =
+        when (opcode) {
+            Opcodes.DUP_X1 -> "DUP_X1"
+            Opcodes.POP -> "POP"
+            Opcodes.INVOKESTATIC -> "INVOKESTATIC"
+            Opcodes.INVOKEVIRTUAL -> "INVOKEVIRTUAL"
+            else -> opcode.toString()
+        }
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/WebViewFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/WebViewFragment.kt
@@ -12,10 +12,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
 import io.bitdrift.gradletestapp.R
+import io.bitdrift.gradletestapp.ui.webview.CustomWebView
 
 /**
  * A basic WebView that can be used to test multi process.
@@ -30,7 +30,7 @@ class WebViewFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         val view = inflater.inflate(R.layout.fragment_web_view, container, false)
-        val webView = view.findViewById<WebView>(R.id.webView)
+        val webView = view.findViewById<CustomWebView>(R.id.webView)
         webView.webViewClient = WebViewClient()
         webView.settings.javaScriptEnabled = true
         val url = arguments?.getString(ARG_URL) ?: WEBVIEW_URLS.first().second

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/webview/CustomWebView.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/webview/CustomWebView.kt
@@ -1,0 +1,20 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.gradletestapp.ui.webview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.webkit.WebView
+
+class CustomWebView
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : WebView(context, attrs, defStyleAttr)

--- a/platform/jvm/gradle-test-app/src/main/res/layout/fragment_web_view.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/layout/fragment_web_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<WebView android:id="@+id/webView"
+<io.bitdrift.gradletestapp.ui.webview.CustomWebView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/webView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android" />
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## Problem

Part of BIT-8545

For customers using WebViews subclasses the bytecode manipulation won't work as we are checking for exact WebView match. The fix is to check if the class is a child of `android.webkit.WebView` so we can inject the instrument call at loadUrl

This is now a problem for RN integration subclass `com.reactnativecommunity.webview.RNCWebView`

This will be used in https://github.com/bitdriftlabs/capture-es/pull/261

## Verification

- JUnit tests
- Manually verified with gradle-test-app, CustomWebView and local maven plugin publish. See [demo session here](https://timeline.bitdrift.dev/session/2db28b66-d25c-4c18-8d22-ef6a0e4d45ad?utm_source=sdk&utilization=0&expanded=-3163060467042078438). 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.