### PR TITLE
Bump shared-core 61e83af

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Increased reliability of log uploads in the face of failures and SDK restarts.
 
 ### Android
 

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "940eff78b9b42ab4b4dda7895bc8554b0e20f6ba86f2dabc68e7a959b826c763",
+  "checksum": "8611feced4e315a24f3147a80b4d10cb58b47f0d047e39129e799bff48acbf9e",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -323,7 +323,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.63",
+              "id": "cc 1.2.64",
               "target": "cc"
             }
           ],
@@ -1145,7 +1145,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -1295,7 +1295,7 @@
               "target": "futures_core"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-api"
         }
@@ -1679,6 +1679,10 @@
               "target": "bd_shutdown"
             },
             {
+              "id": "bd-state 1.0.0",
+              "target": "bd_state"
+            },
+            {
               "id": "bd-stats-common 1.0.0",
               "target": "bd_stats_common"
             },
@@ -1707,7 +1711,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -1719,7 +1723,7 @@
               "target": "tracing"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -1749,7 +1753,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1848,7 +1852,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -1856,7 +1860,7 @@
               "target": "tokio"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -1886,7 +1890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1921,7 +1925,7 @@
               "target": "rand"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -1942,7 +1946,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -2006,7 +2010,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2087,7 +2091,7 @@
         "deps": {
           "common": [
             {
-              "id": "cbindgen 0.29.3",
+              "id": "cbindgen 0.29.4",
               "target": "cbindgen"
             }
           ],
@@ -2112,7 +2116,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2188,7 +2192,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2275,7 +2279,7 @@
               "target": "futures"
             },
             {
-              "id": "intrusive-collections 0.10.1",
+              "id": "intrusive-collections 0.10.2",
               "target": "intrusive_collections"
             },
             {
@@ -2299,7 +2303,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -2337,7 +2341,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2432,7 +2436,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -2474,7 +2478,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2577,7 +2581,7 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -2611,7 +2615,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2704,7 +2708,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2768,7 +2772,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2887,7 +2891,7 @@
               "target": "notify"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
@@ -2895,7 +2899,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -2903,7 +2907,7 @@
               "target": "tokio"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -2933,7 +2937,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-device"
         }
@@ -2980,11 +2984,11 @@
               "target": "parking_lot"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -3005,7 +3009,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3068,7 +3072,7 @@
               "target": "tokio"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -3089,7 +3093,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-events"
         }
@@ -3157,7 +3161,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3256,7 +3260,7 @@
               "target": "futures"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -3308,7 +3312,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -3324,7 +3328,7 @@
               "target": "tower"
             },
             {
-              "id": "tower-http 0.6.11",
+              "id": "tower-http 0.7.0",
               "target": "tower_http"
             },
             {
@@ -3388,7 +3392,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3467,7 +3471,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3529,7 +3533,7 @@
               "target": "bytes"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -3599,7 +3603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3659,7 +3663,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3722,7 +3726,7 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -3747,7 +3751,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-log"
         }
@@ -3782,7 +3786,7 @@
               "target": "bd_workspace_hack"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -3806,7 +3810,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -3847,7 +3851,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3910,11 +3914,11 @@
               "target": "log"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -3935,7 +3939,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -3998,7 +4002,7 @@
               "target": "rand"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
@@ -4023,7 +4027,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4062,7 +4066,7 @@
               "target": "bd_workspace_hack"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -4083,7 +4087,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4146,7 +4150,7 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -4176,7 +4180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4383,7 +4387,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -4403,7 +4407,7 @@
               "target": "unwrap_infallible"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -4415,6 +4419,10 @@
             {
               "id": "async-trait 0.1.89",
               "target": "async_trait"
+            },
+            {
+              "id": "bd-macros 1.0.0",
+              "target": "bd_macros"
             }
           ],
           "selects": {}
@@ -4433,7 +4441,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4493,7 +4501,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4541,7 +4549,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4589,7 +4597,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4658,7 +4666,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4718,7 +4726,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4820,7 +4828,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4930,7 +4938,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5021,7 +5029,7 @@
               "target": "sha2"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -5043,7 +5051,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.63",
+              "id": "cc 1.2.64",
               "target": "cc"
             }
           ],
@@ -5062,7 +5070,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5134,7 +5142,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5207,7 +5215,7 @@
         "deps": {
           "common": [
             {
-              "id": "cbindgen 0.29.3",
+              "id": "cbindgen 0.29.4",
               "target": "cbindgen"
             }
           ],
@@ -5232,7 +5240,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5360,7 +5368,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5419,7 +5427,7 @@
               "target": "log"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -5444,7 +5452,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5507,7 +5515,7 @@
               "target": "tempfile"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -5541,7 +5549,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5604,7 +5612,7 @@
               "target": "prometheus"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
@@ -5612,7 +5620,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -5637,7 +5645,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-session"
         }
@@ -5708,7 +5716,7 @@
               "target": "thread_local"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -5716,7 +5724,7 @@
               "target": "tokio"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -5746,7 +5754,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5825,7 +5833,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -5850,7 +5858,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5906,7 +5914,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-state"
         }
@@ -5981,7 +5989,7 @@
               "target": "tempfile"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -6015,7 +6023,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6088,7 +6096,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6254,7 +6262,7 @@
               "target": "tempfile"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -6304,7 +6312,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-time"
         }
@@ -6347,7 +6355,7 @@
               "target": "rand"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -6381,7 +6389,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fb711aec4989bf181efd901ec38df6313ea6219b"
+            "Rev": "61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
           },
           "strip_prefix": "bd-workflows"
         }
@@ -6492,11 +6500,15 @@
               "target": "log"
             },
             {
+              "id": "parking_lot 0.12.5",
+              "target": "parking_lot"
+            },
+            {
               "id": "protobuf 4.0.0-alpha.0",
               "target": "protobuf"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
@@ -6512,7 +6524,7 @@
               "target": "thiserror"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -6520,7 +6532,7 @@
               "target": "tokio"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -7086,7 +7098,7 @@
               "target": "tempfile"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -7094,7 +7106,7 @@
               "target": "tracing_subscriber"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -7155,14 +7167,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "cbindgen 0.29.3": {
+    "cbindgen 0.29.4": {
       "name": "cbindgen",
-      "version": "0.29.3",
+      "version": "0.29.4",
       "package_url": "https://github.com/mozilla/cbindgen",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cbindgen/0.29.3/download",
-          "sha256": "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
+          "url": "https://static.crates.io/crates/cbindgen/0.29.4/download",
+          "sha256": "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
         }
       },
       "targets": [
@@ -7206,7 +7218,7 @@
         "deps": {
           "common": [
             {
-              "id": "cbindgen 0.29.3",
+              "id": "cbindgen 0.29.4",
               "target": "build_script_build"
             },
             {
@@ -7257,7 +7269,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.29.3"
+        "version": "0.29.4"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -7276,14 +7288,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "cc 1.2.63": {
+    "cc 1.2.64": {
       "name": "cc",
-      "version": "1.2.63",
+      "version": "1.2.64",
       "package_url": "https://github.com/rust-lang/cc-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/cc/1.2.63/download",
-          "sha256": "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+          "url": "https://static.crates.io/crates/cc/1.2.64/download",
+          "sha256": "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
         }
       },
       "targets": [
@@ -7319,7 +7331,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.2.63"
+        "version": "1.2.64"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -8505,7 +8517,7 @@
               "target": "rayon"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
@@ -9071,17 +9083,12 @@
         "crate_features": {
           "common": [
             "default",
-            "powerfmt",
             "serde"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
-            {
-              "id": "powerfmt 0.2.0",
-              "target": "powerfmt"
-            },
             {
               "id": "serde_core 1.0.228",
               "target": "serde_core"
@@ -11119,7 +11126,7 @@
               "target": "futures_sink"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -11440,14 +11447,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "http 1.4.1": {
+    "http 1.4.2": {
       "name": "http",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "package_url": "https://github.com/hyperium/http",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/http/1.4.1/download",
-          "sha256": "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+          "url": "https://static.crates.io/crates/http/1.4.2/download",
+          "sha256": "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
         }
       },
       "targets": [
@@ -11490,7 +11497,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.4.1"
+        "version": "1.4.2"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11535,7 +11542,7 @@
               "target": "bytes"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             }
           ],
@@ -11596,7 +11603,7 @@
               "target": "futures_core"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -11846,7 +11853,7 @@
               "target": "h2"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -11936,7 +11943,7 @@
         "deps": {
           "common": [
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -12107,7 +12114,7 @@
               "target": "futures_util"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -13021,14 +13028,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "intrusive-collections 0.10.1": {
+    "intrusive-collections 0.10.2": {
       "name": "intrusive-collections",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "package_url": "https://github.com/Amanieu/intrusive-rs",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/intrusive-collections/0.10.1/download",
-          "sha256": "80e165935eba36cb526af8389effd2005a741adcbb6ed32106cc68e3f7b92960"
+          "url": "https://static.crates.io/crates/intrusive-collections/0.10.2/download",
+          "sha256": "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
         }
       },
       "targets": [
@@ -13067,9 +13074,9 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.1"
+        "version": "0.10.2"
       },
-      "license": "Apache-2.0/MIT",
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -13965,7 +13972,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.63",
+              "id": "cc 1.2.64",
               "target": "cc"
             },
             {
@@ -14387,7 +14394,7 @@
               "target": "tempfile"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -16079,7 +16086,7 @@
               "target": "bytes"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -16160,7 +16167,7 @@
         "deps": {
           "common": [
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -16997,11 +17004,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -17101,7 +17108,7 @@
               "target": "bd_test_helpers"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -18449,7 +18456,7 @@
               "target": "protobuf_parse"
             },
             {
-              "id": "regex 1.12.3",
+              "id": "regex 1.12.4",
               "target": "regex"
             },
             {
@@ -19415,14 +19422,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "regex 1.12.3": {
+    "regex 1.12.4": {
       "name": "regex",
-      "version": "1.12.3",
+      "version": "1.12.4",
       "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex/1.12.3/download",
-          "sha256": "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+          "url": "https://static.crates.io/crates/regex/1.12.4/download",
+          "sha256": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
         }
       },
       "targets": [
@@ -19481,14 +19488,14 @@
               "target": "regex_automata"
             },
             {
-              "id": "regex-syntax 0.8.10",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.12.3"
+        "version": "1.12.4"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19566,7 +19573,7 @@
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.8.10",
+              "id": "regex-syntax 0.8.11",
               "target": "regex_syntax"
             }
           ],
@@ -19582,14 +19589,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "regex-syntax 0.8.10": {
+    "regex-syntax 0.8.11": {
       "name": "regex-syntax",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "package_url": "https://github.com/rust-lang/regex",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/regex-syntax/0.8.10/download",
-          "sha256": "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+          "url": "https://static.crates.io/crates/regex-syntax/0.8.11/download",
+          "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
         }
       },
       "targets": [
@@ -19627,7 +19634,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.8.10"
+        "version": "0.8.11"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -19680,7 +19687,7 @@
               "target": "futures_core"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -19874,7 +19881,7 @@
         "deps": {
           "common": [
             {
-              "id": "cc 1.2.63",
+              "id": "cc 1.2.64",
               "target": "cc"
             }
           ],
@@ -22509,7 +22516,7 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             },
             {
@@ -22521,7 +22528,7 @@
               "target": "tracing_subscriber"
             },
             {
-              "id": "uuid 1.23.2",
+              "id": "uuid 1.23.3",
               "target": "uuid"
             }
           ],
@@ -22966,7 +22973,7 @@
               "target": "jni"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -23054,7 +23061,7 @@
               "target": "protobuf"
             },
             {
-              "id": "time 0.3.47",
+              "id": "time 0.3.49",
               "target": "time"
             }
           ],
@@ -23394,14 +23401,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "time 0.3.47": {
+    "time 0.3.49": {
       "name": "time",
-      "version": "0.3.47",
+      "version": "0.3.49",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time/0.3.47/download",
-          "sha256": "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+          "url": "https://static.crates.io/crates/time/0.3.49/download",
+          "sha256": "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
         }
       },
       "targets": [
@@ -23443,10 +23450,6 @@
               "target": "deranged"
             },
             {
-              "id": "itoa 1.0.18",
-              "target": "itoa"
-            },
-            {
               "id": "num-conv 0.2.2",
               "target": "num_conv"
             },
@@ -23459,7 +23462,7 @@
               "target": "serde_core"
             },
             {
-              "id": "time-core 0.1.8",
+              "id": "time-core 0.1.9",
               "target": "time_core"
             }
           ],
@@ -23469,13 +23472,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "time-macros 0.2.27",
+              "id": "time-macros 0.2.29",
               "target": "time_macros"
             }
           ],
           "selects": {}
         },
-        "version": "0.3.47"
+        "version": "0.3.49"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -23484,14 +23487,14 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "time-core 0.1.8": {
+    "time-core 0.1.9": {
       "name": "time-core",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time-core/0.1.8/download",
-          "sha256": "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+          "url": "https://static.crates.io/crates/time-core/0.1.9/download",
+          "sha256": "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
         }
       },
       "targets": [
@@ -23514,7 +23517,7 @@
           "**"
         ],
         "edition": "2024",
-        "version": "0.1.8"
+        "version": "0.1.9"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -23523,14 +23526,14 @@
       ],
       "license_file": "LICENSE-Apache"
     },
-    "time-macros 0.2.27": {
+    "time-macros 0.2.29": {
       "name": "time-macros",
-      "version": "0.2.27",
+      "version": "0.2.29",
       "package_url": "https://github.com/time-rs/time",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/time-macros/0.2.27/download",
-          "sha256": "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+          "url": "https://static.crates.io/crates/time-macros/0.2.29/download",
+          "sha256": "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
         }
       },
       "targets": [
@@ -23567,14 +23570,14 @@
               "target": "num_conv"
             },
             {
-              "id": "time-core 0.1.8",
+              "id": "time-core 0.1.9",
               "target": "time_core"
             }
           ],
           "selects": {}
         },
         "edition": "2024",
-        "version": "0.2.27"
+        "version": "0.2.29"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -24319,7 +24322,7 @@
               "target": "bytes"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -24653,22 +24656,14 @@
         ],
         "crate_features": {
           "common": [
-            "compression-deflate",
-            "default",
             "follow-redirect",
-            "futures-core",
             "futures-util",
-            "tokio-util",
             "tower"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
-            {
-              "id": "async-compression 0.4.42",
-              "target": "async_compression"
-            },
             {
               "id": "bitflags 2.12.1",
               "target": "bitflags"
@@ -24678,15 +24673,11 @@
               "target": "bytes"
             },
             {
-              "id": "futures-core 0.3.32",
-              "target": "futures_core"
-            },
-            {
               "id": "futures-util 0.3.32",
               "target": "futures_util"
             },
             {
-              "id": "http 1.4.1",
+              "id": "http 1.4.2",
               "target": "http"
             },
             {
@@ -24696,14 +24687,6 @@
             {
               "id": "pin-project-lite 0.2.17",
               "target": "pin_project_lite"
-            },
-            {
-              "id": "tokio 1.52.3",
-              "target": "tokio"
-            },
-            {
-              "id": "tokio-util 0.7.18",
-              "target": "tokio_util"
             },
             {
               "id": "tower 0.5.3",
@@ -24726,6 +24709,106 @@
         },
         "edition": "2018",
         "version": "0.6.11"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "tower-http 0.7.0": {
+      "name": "tower-http",
+      "version": "0.7.0",
+      "package_url": "https://github.com/tower-rs/tower-http",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/tower-http/0.7.0/download",
+          "sha256": "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "tower_http",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "tower_http",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "compression-deflate",
+            "default",
+            "futures-core",
+            "tokio-util"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "async-compression 0.4.42",
+              "target": "async_compression"
+            },
+            {
+              "id": "bitflags 2.12.1",
+              "target": "bitflags"
+            },
+            {
+              "id": "bytes 1.11.1",
+              "target": "bytes"
+            },
+            {
+              "id": "futures-core 0.3.32",
+              "target": "futures_core"
+            },
+            {
+              "id": "http 1.4.2",
+              "target": "http"
+            },
+            {
+              "id": "http-body 1.0.1",
+              "target": "http_body"
+            },
+            {
+              "id": "percent-encoding 2.3.2",
+              "target": "percent_encoding"
+            },
+            {
+              "id": "pin-project-lite 0.2.17",
+              "target": "pin_project_lite"
+            },
+            {
+              "id": "tokio 1.52.3",
+              "target": "tokio"
+            },
+            {
+              "id": "tokio-util 0.7.18",
+              "target": "tokio_util"
+            },
+            {
+              "id": "tower-layer 0.3.3",
+              "target": "tower_layer"
+            },
+            {
+              "id": "tower-service 0.3.3",
+              "target": "tower_service"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.7.0"
       },
       "license": "MIT",
       "license_ids": [
@@ -25721,14 +25804,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "uuid 1.23.2": {
+    "uuid 1.23.3": {
       "name": "uuid",
-      "version": "1.23.2",
+      "version": "1.23.3",
       "package_url": "https://github.com/uuid-rs/uuid",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/uuid/1.23.2/download",
-          "sha256": "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+          "url": "https://static.crates.io/crates/uuid/1.23.3/download",
+          "sha256": "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
         }
       },
       "targets": [
@@ -25769,7 +25852,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.23.2"
+        "version": "1.23.3"
       },
       "license": "Apache-2.0 OR MIT",
       "license_ids": [
@@ -31208,15 +31291,15 @@
     "objc-foundation 0.1.1",
     "parking_lot 0.12.5",
     "protobuf 4.0.0-alpha.0",
-    "regex 1.12.3",
+    "regex 1.12.4",
     "serde 1.0.228",
     "serde_json 1.0.150",
     "simple-xml 0.1.10",
     "tempfile 3.27.0",
-    "time 0.3.47",
+    "time 0.3.49",
     "tokio 1.52.3",
     "tracing-subscriber 0.3.23",
-    "uuid 1.23.2"
+    "uuid 1.23.3"
   ],
   "direct_dev_deps": [
     "pretty_assertions 1.4.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -282,6 +282,7 @@ dependencies = [
  "bd-runtime",
  "bd-session",
  "bd-shutdown",
+ "bd-state",
  "bd-stats-common",
  "bd-time",
  "bd-workspace-hack",
@@ -298,7 +299,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -327,7 +328,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -337,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -350,7 +351,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -363,7 +364,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -378,7 +379,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -410,7 +411,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -439,7 +440,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -468,7 +469,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -486,7 +487,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -498,7 +499,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -534,7 +535,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -548,7 +549,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -565,7 +566,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -578,7 +579,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -613,7 +614,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower",
- "tower-http",
+ "tower-http 0.7.0",
  "unwrap-infallible",
  "urlencoding",
 ]
@@ -621,7 +622,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -635,7 +636,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -661,7 +662,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -672,7 +673,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "base64",
@@ -690,7 +691,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -711,7 +712,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -729,7 +730,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "anyhow",
@@ -747,7 +748,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -758,7 +759,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "anyhow",
@@ -776,7 +777,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -801,6 +802,7 @@ dependencies = [
  "bd-log-matcher",
  "bd-log-metadata",
  "bd-log-primitives",
+ "bd-macros",
  "bd-network-quality",
  "bd-proto",
  "bd-proto-util",
@@ -835,7 +837,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -846,7 +848,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -854,7 +856,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -862,7 +864,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -874,7 +876,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -885,7 +887,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -897,7 +899,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -911,7 +913,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "anyhow",
@@ -932,7 +934,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -946,7 +948,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -957,7 +959,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "anyhow",
@@ -985,7 +987,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1002,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1021,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1041,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1063,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1085,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1095,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1117,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1130,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1177,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1191,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fb711aec4989bf181efd901ec38df6313ea6219b#fb711aec4989bf181efd901ec38df6313ea6219b"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=61e83af61f5fb7b0cd6021e5a3b16580d363fc51#61e83af61f5fb7b0cd6021e5a3b16580d363fc51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1216,6 +1218,7 @@ dependencies = [
  "bincode",
  "itertools 0.14.0",
  "log",
+ "parking_lot",
  "protobuf 4.0.0-alpha.0",
  "regex",
  "serde",
@@ -1333,9 +1336,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
-version = "0.29.3"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "clap",
  "heck",
@@ -1352,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1630,7 +1633,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1989,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2258,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e165935eba36cb526af8389effd2005a741adcbb6ed32106cc68e3f7b92960"
+checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
 dependencies = [
  "memoffset",
 ]
@@ -3267,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3290,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3315,7 +3317,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3883,12 +3885,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3898,15 +3899,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4106,20 +4107,36 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "async-compression",
  "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -4286,9 +4303,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fb711aec4989bf181efd901ec38df6313ea6219b" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "61e83af61f5fb7b0cd6021e5a3b16580d363fc51" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "1.0.7"
 env_logger = { version = "0.11.10", default-features = false }
@@ -70,7 +70,7 @@ protobuf-codegen = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", 
 protobuf-json-mapping = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch = "patch-stack" }
 rand = "0.10.1"
 rand_distr = "0.6.0"
-regex = "1.12.3"
+regex = "1.12.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.150"
 tempfile = "3.27.0"

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ format: lint-shell ktlint rustfmt buildifier fix-swift lint-yaml
 # Use repin when you get Error: Digests do not match
 .PHONY: repin
 repin:
-    # This technically fails because there are no tests to find, but the repin still happens and it's fast.
-	CARGO_BAZEL_REPIN=true ./bazelw test --build_tests_only //platform/shared:platform-shared  >/dev/null 2>&1 || true
+	# crate_universe repins during Bazel analysis, so --nobuild keeps this faster while still surfacing real errors.
+	CARGO_BAZEL_REPIN=true ./bazelw build --nobuild //platform/shared:platform-shared
 
 .PHONY: push-additional-images
 push-additional-images:

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -162,27 +162,7 @@ class LogBenchmarkTest {
             handler.log(message)
         }
     }
-
-    @Test
-    fun webViewBridgeWebVitalCLS() {
-        val handler = WebViewBridgeMessageHandler(getInternalLogger())
-        val message = """{"v":1,"type":"webVital","timestamp":1234567890,"metric":{"name":"CLS","value":0.15,"rating":"needs-improvement","delta":0.05,"id":"v3-1234567890","navigationType":"navigate","entries":[{"value":0.1,"startTime":1000.0},{"value":0.05,"startTime":2000.0}]}}"""
-
-        benchmarkRule.measureRepeated {
-            handler.log(message)
-        }
-    }
-
-    @Test
-    fun webViewBridgeCustomLog() {
-        val handler = WebViewBridgeMessageHandler(getInternalLogger())
-        val message = """{"v":1,"type":"customLog","timestamp":1234567890,"level":"info","message":"User logged in","fields":{"userId":"12345","userName":"john.doe","sessionId":"abc-123"}}"""
-
-        benchmarkRule.measureRepeated {
-            handler.log(message)
-        }
-    }
-
+    
     private fun getInternalLogger(): IInternalLogger {
         startLogger()
         return Capture.logger() as IInternalLogger


### PR DESCRIPTION
## Changes

- Bump shared-core mainly for verifying https://github.com/bitdriftlabs/shared-core/pull/520 https://github.com/bitdriftlabs/shared-core/commit/61e83af61f5fb7b0cd6021e5a3b16580d363fc51

- Update makefile to report error if failed to run
 
## Verification

Session https://timeline.bitdrift.dev/session/90893902-d638-4f3b-84df-bf4cabbc96fe?utm_source=sdk&utilization=0&expanded=-1142919372604859408


---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.