### PR TITLE
Xcode 27 / iOS 27 SDK compatibility

### DIFF
--- a/bazel/third_party/SwiftArgumentParser.BUILD
+++ b/bazel/third_party/SwiftArgumentParser.BUILD
@@ -8,6 +8,7 @@ swift_library(
     features = [
         "swift.enable_library_evolution",
     ],
+    copts = ["-language-mode", "5"],
     visibility = ["//visibility:public"],
     deps = [":swift_argument_parser_tool_info"],
 )
@@ -18,4 +19,5 @@ swift_library(
     tags = ["manual"],
     library_evolution = True,
     module_name = "ArgumentParserToolInfo",
+    copts = ["-language-mode", "5"],
 )

--- a/examples/swift/hello_world/AppDelegate.swift
+++ b/examples/swift/hello_world/AppDelegate.swift
@@ -11,30 +11,19 @@ import UIKit
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
     func application(
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         Theme.applyNavigationAppearance()
-        let window = UIWindow(frame: UIScreen.main.bounds)
-        window.rootViewController = UIHostingController(rootView: createContentView())
-        window.makeKeyAndVisible()
-        self.window = window
-
         return true
     }
 
-    private func createContentView() -> some View {
-        let startupCrashStorage = StartupCrashStorage()
-        let crashRegistry = CrashRegistry(startupStorage: startupCrashStorage)
-        let loggerCustomer = LoggerCustomer()
-        let crashPanelViewModel = CrashPanelViewModel(crashRegistry: crashRegistry)
-        crashPanelViewModel.refreshEnvironment()
-        return ContentView(
-            loggerCustomer: loggerCustomer,
-            crashPanelViewModel: crashPanelViewModel
-        )
+    func application(
+        _: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options _: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 }

--- a/examples/swift/hello_world/CrashPanel/CrashCatalog.swift
+++ b/examples/swift/hello_world/CrashPanel/CrashCatalog.swift
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 import Foundation
-import HelloWorldCrashSupport
+internal import HelloWorldCrashSupport
 
 enum CrashCategory: String, CaseIterable {
     case swiftRuntime = "Swift Runtime"

--- a/examples/swift/hello_world/CrashPanel/CrashCatalog.swift
+++ b/examples/swift/hello_world/CrashPanel/CrashCatalog.swift
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 import Foundation
-@_implementationOnly import HelloWorldCrashSupport
+import HelloWorldCrashSupport
 
 enum CrashCategory: String, CaseIterable {
     case swiftRuntime = "Swift Runtime"

--- a/examples/swift/hello_world/CrashPanel/CrashEnvironmentSnapshot.swift
+++ b/examples/swift/hello_world/CrashPanel/CrashEnvironmentSnapshot.swift
@@ -7,7 +7,7 @@
 
 import Darwin
 import Foundation
-import HelloWorldCrashSupport
+internal import HelloWorldCrashSupport
 import SwiftUI
 
 struct CrashEnvironmentSnapshot {

--- a/examples/swift/hello_world/CrashPanel/CrashEnvironmentSnapshot.swift
+++ b/examples/swift/hello_world/CrashPanel/CrashEnvironmentSnapshot.swift
@@ -7,7 +7,7 @@
 
 import Darwin
 import Foundation
-@_implementationOnly import HelloWorldCrashSupport
+import HelloWorldCrashSupport
 import SwiftUI
 
 struct CrashEnvironmentSnapshot {

--- a/examples/swift/hello_world/CrashPanel/CrashPanelViewModel.swift
+++ b/examples/swift/hello_world/CrashPanel/CrashPanelViewModel.swift
@@ -7,7 +7,7 @@
 
 import Capture
 import Foundation
-@_implementationOnly import HelloWorldCrashSupport
+import HelloWorldCrashSupport
 import MetricKit
 import SwiftUI
 

--- a/examples/swift/hello_world/CrashPanel/CrashPanelViewModel.swift
+++ b/examples/swift/hello_world/CrashPanel/CrashPanelViewModel.swift
@@ -7,7 +7,7 @@
 
 import Capture
 import Foundation
-import HelloWorldCrashSupport
+internal import HelloWorldCrashSupport
 import MetricKit
 import SwiftUI
 

--- a/examples/swift/hello_world/Info.plist
+++ b/examples/swift/hello_world/Info.plist
@@ -52,5 +52,22 @@
         <key>UIImageName</key>
         <string></string>
     </dict>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string>SceneDelegate</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/examples/swift/hello_world/SceneDelegate.swift
+++ b/examples/swift/hello_world/SceneDelegate.swift
@@ -1,0 +1,38 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import SwiftUI
+import UIKit
+
+@objc(SceneDelegate)
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo _: UISceneSession,
+        options _: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = UIHostingController(rootView: createContentView())
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+
+    private func createContentView() -> some View {
+        let startupCrashStorage = StartupCrashStorage()
+        let crashRegistry = CrashRegistry(startupStorage: startupCrashStorage)
+        let loggerCustomer = LoggerCustomer()
+        let crashPanelViewModel = CrashPanelViewModel(crashRegistry: crashRegistry)
+        crashPanelViewModel.refreshEnvironment()
+        return ContentView(
+            loggerCustomer: loggerCustomer,
+            crashPanelViewModel: crashPanelViewModel
+        )
+    }
+}

--- a/platform/swift/source/replay/Replay.swift
+++ b/platform/swift/source/replay/Replay.swift
@@ -71,7 +71,7 @@ package final class Replay {
         guard layerIsVisible else { return false }
 
         // iOS 27: CGDrawingLayer renders text/content via display callback without setting layer.contents.
-        if NSStringFromClass(type(of: layer)).hasSuffix("CGDrawingLayer") {
+        if #available(iOS 27, *), NSStringFromClass(type(of: layer)).hasSuffix("CGDrawingLayer") {
             return true
         }
 

--- a/platform/swift/source/replay/Replay.swift
+++ b/platform/swift/source/replay/Replay.swift
@@ -68,7 +68,14 @@ package final class Replay {
 
     private func layerHasVisibleContent(_ layer: CALayer) -> Bool {
         let layerIsVisible = !layer.isHidden && layer.opacity > 0.1
-        return layerIsVisible && (
+        guard layerIsVisible else { return false }
+
+        // iOS 27: CGDrawingLayer renders text/content via display callback without setting layer.contents.
+        if NSStringFromClass(type(of: layer)).hasSuffix("CGDrawingLayer") {
+            return true
+        }
+
+        return (
             // Layer contents might hold to bitmaps so lets just assume is visible
             layer.contents != nil ||
 

--- a/test/platform/swift/test_host/Info.plist
+++ b/test/platform/swift/test_host/Info.plist
@@ -32,5 +32,22 @@
 	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDefault</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>TestHostSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/test/platform/swift/test_host/sources/AppDelegate.swift
+++ b/test/platform/swift/test_host/sources/AppDelegate.swift
@@ -9,30 +9,18 @@ import UIKit
 
 @UIApplicationMain
 private final class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
     func application(
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.window?.rootViewController = HostViewController()
-        self.window?.makeKeyAndVisible()
-        return true
+        true
     }
 
-    private final class HostViewController: UIViewController {
-        override func viewDidLoad() {
-            super.viewDidLoad()
-
-            self.view.backgroundColor = .white
-
-            let label = UILabel()
-            self.view.addSubview(label)
-            label.text = "Test Host"
-            label.font = .boldSystemFont(ofSize: 50)
-            label.sizeToFit()
-            label.center = self.view.center
-        }
+    func application(
+        _: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options _: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 }

--- a/test/platform/swift/test_host/sources/SceneDelegate.swift
+++ b/test/platform/swift/test_host/sources/SceneDelegate.swift
@@ -1,0 +1,40 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+import UIKit
+
+@objc(TestHostSceneDelegate)
+final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(
+        _ scene: UIScene,
+        willConnectTo _: UISceneSession,
+        options _: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = HostViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+}
+
+private final class HostViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.view.backgroundColor = .white
+
+        let label = UILabel()
+        self.view.addSubview(label)
+        label.text = "Test Host"
+        label.font = .boldSystemFont(ofSize: 50)
+        label.sizeToFit()
+        label.center = self.view.center
+    }
+}

--- a/test/platform/swift/unit_integration/core/ReplayTests.swift
+++ b/test/platform/swift/unit_integration/core/ReplayTests.swift
@@ -16,7 +16,13 @@ final class ReplayTests: XCTestCase {
     private var window: UIWindow!
 
     override func setUp() {
-        self.window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            self.window = UIWindow(windowScene: windowScene)
+            self.window.frame = frame
+        } else {
+            self.window = UIWindow(frame: frame)
+        }
         self.window.isHidden = false
     }
 
@@ -127,7 +133,7 @@ final class ReplayTests: XCTestCase {
         let hostingFrame = CGRect(x: 0, y: 400, width: 200, height: 60)
         XCTAssertTrue(
             entries.contains { $0.type == .label && hostingFrame.contains($0.frame) },
-            )
+        )
     }
 
     // MARK: - UITextView

--- a/test/platform/swift/unit_integration/core/ReplayTests.swift
+++ b/test/platform/swift/unit_integration/core/ReplayTests.swift
@@ -133,7 +133,7 @@ final class ReplayTests: XCTestCase {
         let hostingFrame = CGRect(x: 0, y: 400, width: 200, height: 60)
         XCTAssertTrue(
             entries.contains { $0.type == .label && hostingFrame.contains($0.frame) },
-        )
+            )
     }
 
     // MARK: - UITextView

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -671,9 +671,12 @@ final class URLSessionIntegrationTests: XCTestCase {
             expectations.append(completionExpectation)
         }
 
-        XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 3, enforceOrder: false))
+        XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 5, enforceOrder: false))
 
         XCTAssertEqual(2, self.logger.logs.count)
+        guard self.logger.logs.count >= 2 else {
+            return
+        }
 
         let requestInfo = try XCTUnwrap(self.logger.logs[0].request())
         var requestInfoFields = try XCTUnwrap(requestInfo.toFields() as? [String: String])


### PR DESCRIPTION
# Overview
Three issues blocked building and running on Xcode 27 / iOS 27 SDK:
1. `SwiftArgumentParser` fails to build: Swift 6 requires `-language-mode` to be explicitly set when emitting module interface files (library evolution). Added `-language-mode 5` copts to both `swift_argument_parser` and `swift_argument_parser_tool_info` targets in `SwiftArgumentParser.BUILD`.
3. `UIScene` lifecycle now required: in iOS 26 this was a warning, now you're unable to launch. So, both the hello world sample app and the unit test host app were migrated from the window-based `AppDelegate` pattern to a `SceneDelegate`-based setup, with the corresponding `UIApplicationSceneManifest` entries in their `Info.plist` files.
4. Fix on Session replay for `SwiftUI.Text` not detected as label: `SwiftUI.Text` renders through an orphan `CGDrawingLayer` (no `UIView` backing) that draws content via a display callback rather than setting `layer.contents`.