### PR TITLE
Prepare for 0.23.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [Unreleased]
-[Unreleased]: https://github.com/bitdriftlabs/capture-sdk/compare/v0.23.4...HEAD
+[Unreleased]: https://github.com/bitdriftlabs/capture-sdk/compare/v0.23.5...HEAD
 
 ### Both
 
@@ -15,7 +15,7 @@
 
 **Fixed**
 
-- Increased reliability of log uploads in the face of failures and SDK restarts.
+- Nothing yet!
 
 ### Android
 
@@ -44,6 +44,13 @@
 **Fixed**
 
 - Nothing yet!
+
+## [0.23.6]
+[0.23.6]: https://github.com/bitdriftlabs/capture-sdk/releases/tag/0.23.6
+
+### Both
+
+- Increased reliability of log uploads in the face of failures and SDK restarts.
 
 ## [0.23.5]
 [0.23.5]: https://github.com/bitdriftlabs/capture-sdk/releases/tag/0.23.5


### PR DESCRIPTION
Mainly for https://github.com/bitdriftlabs/capture-sdk/pull/1018

Pending to update release notes

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.