### PR TITLE
[Android] [gradle-test-app] Add thread count to stress test tab

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -108,6 +108,8 @@ sealed class StressTestAction : AppAction {
 
     object TriggerMemoryPressureAnr : StressTestAction()
 
+    data class CreateThreads(val count: Int) : StressTestAction()
+
     data class TriggerJankyFrames(val type: JankType) : StressTestAction()
 
     data class TriggerStrictModeViolation(val type: StrictModeViolationType) : StressTestAction()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
@@ -24,6 +24,7 @@ import android.widget.PopupWindow
 import android.widget.TextView
 import android.widget.Toast
 import io.bitdrift.capture.Capture
+import io.bitdrift.gradletestapp.diagnostics.fatalissues.FatalIssueGenerator
 import io.bitdrift.gradletestapp.data.model.StrictModeViolationType
 import timber.log.Timber
 import java.io.File
@@ -98,6 +99,14 @@ class StressTestRepository(
                 Capture.Logger.logError { "ANR test completed after ${System.currentTimeMillis() - startTime}ms" }
             }
         }.start()
+    }
+
+    fun createThreads(count: Int) {
+        require(count > 0) { "Thread count must be positive" }
+        Capture.Logger.logWarning(mapOf("thread_count" to count.toString())) {
+            "Started creating $count sleeping threads"
+        }
+        FatalIssueGenerator.forceThreadCount(count)
     }
 
     private fun stopAllThreads() {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/fatalissues/FatalIssueGenerator.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/fatalissues/FatalIssueGenerator.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
+import java.util.concurrent.Executors
 
 
 /**
@@ -160,19 +161,27 @@ internal object FatalIssueGenerator {
     }
 
     fun forceTooManyThreadsOutOfMemory() {
-        var threadIndex = 0
-        while (true) {
-            val thread = Thread(
-                {
-                    runCatching {
-                        Thread.sleep(Long.MAX_VALUE)
-                    }
-                },
-                "oom-thread-$threadIndex",
-            )
-            thread.start()
-            threadsListForOom.add(thread)
-            threadIndex++
+        forceThreadCount(7000)
+    }
+
+    fun forceThreadCount(count: Int) {
+        val executor = Executors.newFixedThreadPool(1)
+        executor.submit {
+
+            var threadIndex = 0
+            while (threadIndex < count) {
+                val thread = Thread(
+                    {
+                        runCatching {
+                            Thread.sleep(Long.MAX_VALUE)
+                        }
+                    },
+                    "oom-thread-$threadIndex",
+                )
+                thread.start()
+                threadsListForOom.add(thread)
+                threadIndex++
+            }
         }
     }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/CaptureSdkInitializer.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/CaptureSdkInitializer.kt
@@ -100,7 +100,8 @@ object CaptureSdkInitializer {
             when (startResult) {
                 is CaptureResult.Success -> {
                     val logger = startResult.value
-                    Log.d("bitdrift","SDK started successfully. sessionId=${logger.sessionId}, sessionUrl=${logger.sessionUrl}")
+                    Log.d("bitdrift","SDK started successfully. sessionId=${logger.sessionId}, sessionUrl=${logger.sessionUrl}, userUuid=${userUuid}")
+                    Capture.Logger.setEntityId(userUuid)
                     addSessionUrlToThirdPartySdks(context, logger.sessionUrl)
                 }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -20,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.bitdrift.gradletestapp.R
@@ -47,6 +49,9 @@ fun StressTestScreen(
             MemoryPressureCard(onAction = onAction)
         }
         item {
+            ThreadCountCard(onAction = onAction)
+        }
+        item {
             JankyFramesCard(onAction = onAction)
         }
         item {
@@ -54,6 +59,68 @@ fun StressTestScreen(
         }
         item {
             ScreenReplayCard(onAction = onAction)
+        }
+    }
+}
+
+@Composable
+private fun ThreadCountCard(onAction: (AppAction) -> Unit) {
+    var threadCountInput by remember { mutableStateOf("500") }
+    val threadCount = threadCountInput.toIntOrNull()
+    val isValid = threadCount != null && threadCount > 0
+
+    StressTestCard(title = "Threads") {
+        Text(
+            text = "Create an exact number of sleeping background threads.",
+            style = MaterialTheme.typography.bodySmall,
+            color = BitdriftColors.TextSecondary,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = threadCountInput,
+            onValueChange = { value ->
+                if (value.all(Char::isDigit)) {
+                    threadCountInput = value
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Thread count", color = BitdriftColors.TextSecondary) },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            singleLine = true,
+            isError = threadCountInput.isNotEmpty() && !isValid,
+            colors =
+                OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = BitdriftColors.TextBright,
+                    unfocusedTextColor = BitdriftColors.TextBright,
+                    focusedBorderColor = BitdriftColors.Primary,
+                    unfocusedBorderColor = BitdriftColors.Border,
+                    focusedLabelColor = BitdriftColors.Primary,
+                    unfocusedLabelColor = BitdriftColors.TextSecondary,
+                    cursorColor = BitdriftColors.TextBright,
+                    selectionColors =
+                        TextSelectionColors(
+                            handleColor = BitdriftColors.TextBright,
+                            backgroundColor = BitdriftColors.Primary.copy(alpha = 0.3f),
+                        ),
+                ),
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Button(
+            onClick = { threadCount?.let { onAction(StressTestAction.CreateThreads(it)) } },
+            enabled = isValid,
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = BitdriftColors.Primary,
+                    contentColor = Color.White,
+                    disabledContainerColor = BitdriftColors.Border,
+                ),
+        ) {
+            Text("Create Threads")
         }
     }
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -181,6 +181,7 @@ class MainViewModel(
 
             is StressTestAction.IncreaseMemoryPressure -> stressTestRepository.increaseMemoryPressure(action.targetPercent)
             is StressTestAction.TriggerMemoryPressureAnr -> stressTestRepository.triggerMemoryPressureAnr()
+            is StressTestAction.CreateThreads -> stressTestRepository.createThreads(action.count)
             is StressTestAction.TriggerJankyFrames -> stressTestRepository.triggerJankyFrames(action.type.durationMs)
             is StressTestAction.TriggerStrictModeViolation -> stressTestRepository.triggerStrictModeViolation(action.type)
             is StressTestAction.TriggerScreenReplayCapture -> stressTestRepository.triggerScreenReplayCapture(action.activity)


### PR DESCRIPTION
Just to ease testing generating different type of reports with many threads

<img width="496" height="881" alt="Screenshot 2026-06-22 at 16 10 47" src="https://github.com/user-attachments/assets/235c6127-a604-47d5-a691-58e72e3485a2" />
