### PR TITLE
Preventing breaking change

### DIFF
--- a/platform/swift/source/reports/previousRunInfo/PreviousRunInfo.swift
+++ b/platform/swift/source/reports/previousRunInfo/PreviousRunInfo.swift
@@ -25,10 +25,13 @@ public struct PreviousRunInfo: Equatable {
         self.terminationReason == .cleanExit
     }
 
-    public init(
-        terminationReason: ExitReason
-    ) {
+    public init(terminationReason: ExitReason) {
         self.terminationReason = terminationReason
+    }
+
+    @available(*, deprecated, renamed: "init(terminationReason:)")
+    public init(hasFatallyTerminated: Bool) {
+        self.init(terminationReason: hasFatallyTerminated ? .fatalCrash : .unknown)
     }
 
     static let unknown = PreviousRunInfo(terminationReason: .unknown)


### PR DESCRIPTION
# Overview
[This PR](https://github.com/bitdriftlabs/capture-sdk/pull/1044/changes) introduces a breaking change. Even though the API is marked as experimental, avoiding the breaking change requires very little effort.

It's unlikely that any production code relies on the `PreviousRunInfo` constructor directly (perhaps only tests mocking those states), so this PR preserves backwards compatibility at virtually no cost.

Just in case, marked the API as deprecated:
<img width="1262" height="218" alt="image" src="https://github.com/user-attachments/assets/47b1480f-2df9-4df2-92cc-464eb87dfee3" />
