### PR TITLE
[PreviousRunInfo] limit constructor visibility

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolver.kt
@@ -103,7 +103,7 @@ internal class PreviousRunInfoResolver(
  * @property hasFatallyTerminated Whether the previous run ended in a fatal termination.
  * @property terminationReason Platform exit reason when available.
  */
-data class PreviousRunInfo(
+class PreviousRunInfo internal constructor(
     val hasFatallyTerminated: Boolean,
     val terminationReason: ExitReason? = null,
 )

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -18,10 +18,10 @@ import io.bitdrift.capture.network.HttpResponseInfo
 import io.bitdrift.capture.network.HttpUrlPath
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.exitinfo.ExitReason
-import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfoResolver
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.utils.DebugCustomerCallbackException
+import io.bitdrift.capture.utils.assertPreviousRunInfo
 import io.bitdrift.capture.utils.setIsDebuggable
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -161,9 +161,7 @@ class CaptureTest {
 
         val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
-        assertThat(previousRunInfo).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
-        )
+        assertPreviousRunInfo(previousRunInfo, hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash)
     }
 
     @Test
@@ -173,9 +171,7 @@ class CaptureTest {
 
         val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
-        assertThat(previousRunInfo).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = false, terminationReason = ExitReason.ExitSelf),
-        )
+        assertPreviousRunInfo(previousRunInfo, hasFatallyTerminated = false, terminationReason = ExitReason.ExitSelf)
     }
 
     @Test
@@ -185,7 +181,7 @@ class CaptureTest {
 
         val previousRunInfo = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler).get()
 
-        assertThat(previousRunInfo).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false, terminationReason = null))
+        assertPreviousRunInfo(previousRunInfo, hasFatallyTerminated = false, terminationReason = null)
     }
 
     @Test

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/exitinfo/PreviousRunInfoResolverTest.kt
@@ -15,6 +15,7 @@ import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.utils.BuildVersionChecker
+import io.bitdrift.capture.utils.assertPreviousRunInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -51,9 +52,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
-        )
+        assertPreviousRunInfo(result, hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash)
     }
 
     @Test
@@ -68,9 +67,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.NativeCrash),
-        )
+        assertPreviousRunInfo(result, hasFatallyTerminated = true, terminationReason = ExitReason.NativeCrash)
     }
 
     @Test
@@ -85,9 +82,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.AppNotResponding),
-        )
+        assertPreviousRunInfo(result, hasFatallyTerminated = true, terminationReason = ExitReason.AppNotResponding)
     }
 
     @Test
@@ -102,9 +97,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = false, terminationReason = ExitReason.UserRequested),
-        )
+        assertPreviousRunInfo(result, hasFatallyTerminated = false, terminationReason = ExitReason.UserRequested)
     }
 
     @Test
@@ -119,7 +112,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false))
+        assertPreviousRunInfo(result, hasFatallyTerminated = false)
     }
 
     @Test
@@ -165,7 +158,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(PreviousRunInfo(hasFatallyTerminated = false))
+        assertPreviousRunInfo(result, hasFatallyTerminated = false)
     }
 
     @Test
@@ -182,9 +175,7 @@ class PreviousRunInfoResolverTest {
                 buildVersionChecker,
             ).get()
 
-        assertThat(result).isEqualTo(
-            PreviousRunInfo(hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash),
-        )
+        assertPreviousRunInfo(result, hasFatallyTerminated = true, terminationReason = ExitReason.JvmCrash)
     }
 
     @Test
@@ -217,5 +208,15 @@ class PreviousRunInfoResolverTest {
         val resolver = PreviousRunInfoResolver(latestAppExitInfoProvider, preferences, captureUncaughtExceptionHandler, buildVersionChecker)
 
         verify(captureUncaughtExceptionHandler, never()).install(resolver)
+    }
+
+    private fun assertPreviousRunInfo(
+        actual: PreviousRunInfo?,
+        hasFatallyTerminated: Boolean,
+        terminationReason: ExitReason? = null,
+    ) {
+        assertThat(actual).isNotNull
+        assertThat(actual?.hasFatallyTerminated).isEqualTo(hasFatallyTerminated)
+        assertThat(actual?.terminationReason).isEqualTo(terminationReason)
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/PreviousRunInfoTestUtils.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/utils/PreviousRunInfoTestUtils.kt
@@ -1,0 +1,23 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.utils
+
+import io.bitdrift.capture.reports.exitinfo.ExitReason
+import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+fun assertPreviousRunInfo(
+    actual: PreviousRunInfo?,
+    hasFatallyTerminated: Boolean,
+    terminationReason: ExitReason? = null,
+) {
+    assertNotNull(actual)
+    assertEquals(hasFatallyTerminated, actual?.hasFatallyTerminated)
+    assertEquals(terminationReason, actual?.terminationReason)
+}

--- a/platform/swift/source/reports/previousRunInfo/PreviousRunInfo.swift
+++ b/platform/swift/source/reports/previousRunInfo/PreviousRunInfo.swift
@@ -25,7 +25,7 @@ public struct PreviousRunInfo: Equatable {
         self.terminationReason == .cleanExit
     }
 
-    public init(
+    init(
         terminationReason: ExitReason
     ) {
         self.terminationReason = terminationReason


### PR DESCRIPTION
This was an oversight on https://github.com/bitdriftlabs/capture-sdk/pull/922