### PR TITLE
[Android] Harden DeviceStateListenerLogger register/unregister logic

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/device/DeviceStateListenerLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/device/DeviceStateListenerLogger.kt
@@ -76,6 +76,10 @@ internal class DeviceStateListenerLogger(
     }
 
     override fun stop() {
+        if (!runtime.isEnabled(RuntimeFeature.DEVICE_STATE_EVENTS)) {
+            return
+        }
+
         context.unregisterReceiver(this)
         context.unregisterComponentCallbacks(this)
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
@@ -65,7 +65,7 @@ fun StressTestScreen(
 
 @Composable
 private fun ThreadCountCard(onAction: (AppAction) -> Unit) {
-    var threadCountInput by remember { mutableStateOf("500") }
+    var threadCountInput by remember { mutableStateOf("5000") }
     val threadCount = threadCountInput.toIntOrNull()
     val isValid = threadCount != null && threadCount > 0
 

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -180,12 +180,6 @@ class LogBenchmarkTest {
     }
 
     @Test
-    fun logScreenView() =
-        benchmarkCaptureOperation(configuration = Configuration(sessionReplayConfiguration = null)) {
-            Capture.Logger.logScreenView("fake_screen")
-        }
-
-    @Test
     fun logAppLaunchTTI() = benchmarkCaptureOperation{
         Capture.Logger.logAppLaunchTTI(1.toDuration(DurationUnit.SECONDS))
     }


### PR DESCRIPTION
We should only unregister receiver/component callbacks when `RuntimeFeature.DEVICE_STATE_EVENTS` is set to true.

This will prevent a `java.lang.IllegalArgumentException: Receiver not registered: io.bitdrift.capture.events.device.DeviceStateListenerLogger` when the `RuntimeFeature.DEVICE_STATE_EVENTS` is set to false. 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.