### PR TITLE
[iOS] Reduce report file size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Reduced the size of persisted fatal issue reports.
 
 ### Android
 
@@ -29,7 +29,7 @@
 
 **Fixed**
 
-- Reduced the size of persisted fatal issue reports.
+- Nothing yet!
 
 ### iOS
 

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "aa9e9938ce4018d325fd9ce338b6f49c93deff081f0a270883e66782f32c5fe3",
+  "checksum": "ae5c51cafcfea9875e1b10681bdee2495437bd309c88774b4e5348095bbe9697",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-api"
         }
@@ -1753,7 +1753,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1890,7 +1890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1946,7 +1946,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -2010,7 +2010,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2116,7 +2116,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2192,7 +2192,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2341,7 +2341,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2478,7 +2478,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2615,7 +2615,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2708,7 +2708,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2772,7 +2772,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -2937,7 +2937,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-device"
         }
@@ -3009,7 +3009,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3093,7 +3093,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-events"
         }
@@ -3161,7 +3161,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3392,7 +3392,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3471,7 +3471,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3603,7 +3603,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3663,7 +3663,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3751,7 +3751,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-log"
         }
@@ -3851,7 +3851,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -3939,7 +3939,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4027,7 +4027,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4087,7 +4087,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4180,7 +4180,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4441,7 +4441,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4501,7 +4501,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4549,7 +4549,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4597,7 +4597,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4666,7 +4666,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4726,7 +4726,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4828,7 +4828,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-proto"
         }
@@ -4942,7 +4942,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5074,7 +5074,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5146,7 +5146,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5244,7 +5244,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5372,7 +5372,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5456,7 +5456,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5553,7 +5553,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5649,7 +5649,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-session"
         }
@@ -5758,7 +5758,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5862,7 +5862,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5918,7 +5918,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-state"
         }
@@ -6027,7 +6027,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6100,7 +6100,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6316,7 +6316,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-time"
         }
@@ -6393,7 +6393,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+            "Rev": "6c4f0e341e66a2f16d3da8681eda269030467da2"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -299,7 +299,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.1",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -469,7 +469,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -549,7 +549,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -566,7 +566,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -622,7 +622,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -662,7 +662,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "base64",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -848,7 +848,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -887,7 +887,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -935,7 +935,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1024,7 +1024,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1098,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1180,7 +1180,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=fafadd5ad0e617af802b2f2f1a237e81d04facbb#fafadd5ad0e617af802b2f2f1a237e81d04facbb"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=6c4f0e341e66a2f16d3da8681eda269030467da2#6c4f0e341e66a2f16d3da8681eda269030467da2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,35 +19,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.103"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "fafadd5ad0e617af802b2f2f1a237e81d04facbb" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "6c4f0e341e66a2f16d3da8681eda269030467da2" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "1.0.7"
 env_logger = { version = "0.11.11", default-features = false }

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -275,6 +275,7 @@ public final class Logger {
                 }
 
                 let hangDuration = self.underlyingLogger.runtimeValue(.applicationANRReporterThresholdMs)
+                let optimizeFatalIssueReportSize = self.underlyingLogger.runtimeValue(.optimizeFatalIssueReportSize)
                 let useStackOverlapMatching = self.underlyingLogger.runtimeValue(.crashThreadMatchingByStackOverlap)
                 let memoryPressureLevel = self.underlyingLogger.previousMemoryPressureLevel()
                 let reporter = DiagnosticEventReporter(
@@ -283,6 +284,7 @@ public final class Logger {
                     eventTypes: .crash,
                     minimumHangSeconds: Double(hangDuration) / Double(MSEC_PER_SEC),
                     memoryPressureLevel: memoryPressureLevel,
+                    fileSizeOptimizationEnabled: optimizeFatalIssueReportSize,
                     useStackOverlapMatching: useStackOverlapMatching,
                     crashEnrichmentSummaryHandler: { [weak self] summary in
                         let matcherMode = useStackOverlapMatching ? "base" : "exact"

--- a/platform/swift/source/RuntimeVariable.swift
+++ b/platform/swift/source/RuntimeVariable.swift
@@ -113,6 +113,12 @@ extension RuntimeVariable<Bool> {
         defaultValue: false
     )
 
+    /// Whether iOS fatal issue report size optimizations are enabled.
+    static let optimizeFatalIssueReportSize = RuntimeVariable(
+        name: "client_feature.ios.optimize_fatal_issue_report_size",
+        defaultValue: true
+    )
+
     // When disabled, previousRunInfo falls back to reporting only fatalCrash or unknown,
     // ignoring the revamped resolver signals (cleanExit, appUpdate, osUpdate, etc.).
     static let previousRunInfoRevamped = RuntimeVariable(

--- a/platform/swift/source/reports/DiagnosticEventReporter.h
+++ b/platform/swift/source/reports/DiagnosticEventReporter.h
@@ -39,6 +39,8 @@ typedef void (^CAPCrashEnrichmentSummaryHandler)(
  * @param types      event types to report
  * @param seconds    number of seconds required to report `CAPDiagnosticTypeHang` events
  * @param memoryPressureLevel previous run's memory pressure level (CAPMemoryPressureLevel)
+ * @param fileSizeOptimizationEnabled whether `client_feature.ios.optimize_fatal_issue_report_size`
+ *                                    is enabled for generated fatal issue reports
  * @param useStackOverlapMatching whether to use the overlap-based thread matcher (finds the best
  * contiguous matching region from the stack base) instead of the exact matcher for crash enrichment
  * @param crashEnrichmentSummaryHandler block invoked after crash enrichment with the summary fields
@@ -46,13 +48,14 @@ typedef void (^CAPCrashEnrichmentSummaryHandler)(
  * @param completion block to invoke when report processing is completed
  */
 - (instancetype _Nonnull)initWithOutputDir:(NSURL *_Nonnull)path
-                                sdkVersion:(NSString *_Nonnull)sdkVersion
-                                eventTypes:(CAPDiagnosticType)types
-                        minimumHangSeconds:(NSTimeInterval)seconds
-                     memoryPressureLevel:(CAPMemoryPressureLevel)memoryPressureLevel
-                   useStackOverlapMatching:(BOOL)useStackOverlapMatching
-             crashEnrichmentSummaryHandler:
-                 (CAPCrashEnrichmentSummaryHandler _Nullable)crashEnrichmentSummaryHandler
+                                 sdkVersion:(NSString *_Nonnull)sdkVersion
+                                 eventTypes:(CAPDiagnosticType)types
+                         minimumHangSeconds:(NSTimeInterval)seconds
+                      memoryPressureLevel:(CAPMemoryPressureLevel)memoryPressureLevel
+              fileSizeOptimizationEnabled:(BOOL)fileSizeOptimizationEnabled
+                    useStackOverlapMatching:(BOOL)useStackOverlapMatching
+              crashEnrichmentSummaryHandler:
+                  (CAPCrashEnrichmentSummaryHandler _Nullable)crashEnrichmentSummaryHandler
                          completionHandler:(void (^_Nullable)())completion;
 
 - (void)setMinimumHangSeconds:(NSTimeInterval)seconds;

--- a/platform/swift/source/reports/DiagnosticEventReporter.m
+++ b/platform/swift/source/reports/DiagnosticEventReporter.m
@@ -44,6 +44,7 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle,
                                        NSString *_Nonnull sdk_version,
                                        MXDiagnostic *_Nonnull event,
                                        NSTimeInterval timestamp,
+                                       BOOL fileSizeOptimizationEnabled,
                                        BOOL useStackOverlapMatching,
                                        CAPMemoryPressureLevel memoryPressureLevel,
                                        CAPCrashEnrichmentSummaryHandler _Nullable crashEnrichmentSummaryHandler)
@@ -58,24 +59,27 @@ static const char *name_for_diagnostic_type(ReportType type);
 @property (nullable, strong, nonatomic) void (^completionHandler)();
 @property (nullable, copy, nonatomic) CAPCrashEnrichmentSummaryHandler crashEnrichmentSummaryHandler;
 @property CAPDiagnosticType diagnosticTypes;
+@property BOOL fileSizeOptimizationEnabled;
 @property BOOL useStackOverlapMatching;
 @property CAPMemoryPressureLevel memoryPressureLevel;
 @end
 
 @implementation DiagnosticEventReporter
 - (instancetype _Nonnull)initWithOutputDir:(NSURL *_Nonnull)dir
-                                sdkVersion:(NSString *_Nonnull)sdkVersion
-                                eventTypes:(CAPDiagnosticType)types
-                        minimumHangSeconds:(NSTimeInterval)seconds
-                     memoryPressureLevel:(CAPMemoryPressureLevel)memoryPressureLevel
-                      useStackOverlapMatching:(BOOL)useStackOverlapMatching
-                crashEnrichmentSummaryHandler:(CAPCrashEnrichmentSummaryHandler _Nullable)crashEnrichmentSummaryHandler
+                                 sdkVersion:(NSString *_Nonnull)sdkVersion
+                                 eventTypes:(CAPDiagnosticType)types
+                         minimumHangSeconds:(NSTimeInterval)seconds
+                      memoryPressureLevel:(CAPMemoryPressureLevel)memoryPressureLevel
+              fileSizeOptimizationEnabled:(BOOL)fileSizeOptimizationEnabled
+                    useStackOverlapMatching:(BOOL)useStackOverlapMatching
+              crashEnrichmentSummaryHandler:(CAPCrashEnrichmentSummaryHandler _Nullable)crashEnrichmentSummaryHandler
                          completionHandler:(void (^_Nullable)())completionHandler {
   if (self = [super init]) {
     self.dir = dir;
     self.sdkVersion = sdkVersion;
     self.diagnosticTypes = types;
     self.completionHandler = completionHandler;
+    self.fileSizeOptimizationEnabled = fileSizeOptimizationEnabled;
     self.useStackOverlapMatching = useStackOverlapMatching;
     self.crashEnrichmentSummaryHandler = crashEnrichmentSummaryHandler;
     self.memoryPressureLevel = memoryPressureLevel;
@@ -131,6 +135,7 @@ static const char *name_for_diagnostic_type(ReportType type);
     self.sdkVersion,
     event,
     timestamp,
+    self.fileSizeOptimizationEnabled,
     self.useStackOverlapMatching,
     self.memoryPressureLevel,
     self.crashEnrichmentSummaryHandler
@@ -364,6 +369,7 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle,
                                        NSString *sdk_version,
                                        MXDiagnostic *event,
                                        NSTimeInterval timestamp,
+                                       BOOL fileSizeOptimizationEnabled,
                                        BOOL useStackOverlapMatching,
                                        CAPMemoryPressureLevel memoryPressureLevel,
                                        CAPCrashEnrichmentSummaryHandler _Nullable crashEnrichmentSummaryHandler) {
@@ -372,7 +378,7 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle,
     MXCrashDiagnostic *crash = (MXCrashDiagnostic *)event;
     BOOL is_hang = crash_is_hang_termination(crash);
     report_type = is_hang ? ReportTypeAppNotResponding : ReportTypeNativeCrash;
-    bdrw_create_buffer_handle(handle, report_type, SDK_ID, cstring_from(sdk_version));
+    bdrw_create_buffer_handle(handle, report_type, SDK_ID, cstring_from(sdk_version), fileSizeOptimizationEnabled);
     NSString *name = is_hang ? DEFAULT_HANG_NAME : name_for_crash(crash);
     NSString *reason = reason_for_crash(crash, name);
     NSDictionary<NSString *, NSString *> *summary = nil;
@@ -385,7 +391,7 @@ static ReportType serialize_diagnostic(BDProcessorHandle handle,
     serialize_error_threads(handle, dictReport, name, reason, FrameOrderInnerToOuter);
   } else if ([event isKindOfClass:[MXHangDiagnostic class]]) {
     report_type = ReportTypeAppNotResponding;
-    bdrw_create_buffer_handle(handle, report_type, SDK_ID, cstring_from(sdk_version));
+    bdrw_create_buffer_handle(handle, report_type, SDK_ID, cstring_from(sdk_version), fileSizeOptimizationEnabled);
     MXHangDiagnostic *hang = (MXHangDiagnostic *)event;
     NSMeasurementFormatter *formatter = [NSMeasurementFormatter new];
     NSString *duration = [formatter stringFromMeasurement:hang.hangDuration];

--- a/platform/swift/source/reports/bd-report-writer/ffi.h
+++ b/platform/swift/source/reports/bd-report-writer/ffi.h
@@ -104,7 +104,8 @@ typedef struct BDAppMetrics {
 void bdrw_create_buffer_handle(BDProcessorHandle handle,
                                int8_t report_type,
                                const char *sdk_id,
-                               const char *sdk_version);
+                               const char *sdk_version,
+                               bool is_file_size_optimization_enabled);
 
 /**
  * Finishes Report creation and returns a pointer to the memory buffer

--- a/test/platform/swift/unit_integration/core/DiagnosticEventReporterTests.swift
+++ b/test/platform/swift/unit_integration/core/DiagnosticEventReporterTests.swift
@@ -121,6 +121,7 @@ final class DiagnosticEventReporterTests: XCTestCase {
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -147,6 +148,7 @@ final class DiagnosticEventReporterTests: XCTestCase {
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -173,6 +175,7 @@ final class DiagnosticEventReporterTests: XCTestCase {
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -202,6 +205,7 @@ final class DiagnosticEventReporterTests: XCTestCase {
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -247,6 +251,7 @@ ThermalInfo: (
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -274,6 +279,7 @@ ThermalInfo: (
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -350,6 +356,7 @@ ThermalInfo: (
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -419,6 +426,7 @@ ThermalInfo: (
             eventTypes: [.hang, .crash],
             minimumHangSeconds: 1,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -446,6 +454,7 @@ ThermalInfo: (
             eventTypes: [.hang, .crash],
             minimumHangSeconds: 1,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -531,6 +540,7 @@ ThermalInfo: (
             eventTypes: .crash,
             minimumHangSeconds: 2.5,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )
@@ -568,6 +578,7 @@ ThermalInfo: (
             eventTypes: [.crash],
             minimumHangSeconds: 1,
             memoryPressureLevel: .unknown,
+            fileSizeOptimizationEnabled: true,
             useStackOverlapMatching: true,
             crashEnrichmentSummaryHandler: nil
         )


### PR DESCRIPTION
## Goal

Depends on https://github.com/bitdriftlabs/shared-core/pull/544

Part of BIT-8854

Similar to https://github.com/bitdriftlabs/shared-core/pull/541, https://github.com/bitdriftlabs/shared-core/pull/543 and https://github.com/bitdriftlabs/capture-sdk/pull/1031

Applying memoization for the generated fbs report on iOS. 

This will guarded by `client_feature.ios.optimize_fatal_issue_report_size`. This is a similar killswitch done in [Android](https://github.com/bitdriftlabs/capture-sdk/pull/1031) in this PR . The flag is enabled by default.

## Verification

| client_feature.ios.optimize_fatal_issue_report_size = false | client_feature.ios.optimize_fatal_issue_report_size = true | % reduction
| -----------------------------------------| ----------------------------------------| ---------------|
| [26736 bytes](https://timeline.bitdrift.dev/session/eb55e8a2-ff3d-4afa-bba7-d7b92d26d45b?utilization=0&debug=true&s=raw%7E%7Esearch...contains...CrashReport&sf=true&expanded=4669616941141394489) | [12992 bytes](https://timeline.bitdrift.dev/session/b981fe15-e875-4017-89be-75ea5e3f3c88?utilization=0&debug=true&s=raw~~search...contains...CrashReport&expanded=6423251357677876858&sf=true) |  ~51 % |

## Killswitch flag

`client_feature.ios.optimize_fatal_issue_report_size`, enabled by default


---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.