### PR TITLE
Add support for DD network tracing format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 **Added**
 
-- Nothing yet!
+- Added Datadog trace propagation support for automatic network tracing.
 
 **Changed**
 

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -114,7 +114,7 @@ cargoNdk {
             extraCargoEnv =
                 mapOf(
                     "RUSTFLAGS" to
-                        "-Zunstable-options -Cpanic=immediate-abort -C link-args=-Wl,-z,max-page-size=16384,--build-id -C codegen-units=1 -C embed-bitcode -C lto=fat -C opt-level=z",
+                            "-Zunstable-options -Cpanic=immediate-abort -C link-args=-Wl,-z,max-page-size=16384,--build-id -C codegen-units=1 -C embed-bitcode -C lto=fat -C opt-level=z",
                     "RUSTC_BOOTSTRAP" to "1", // Required for using unstable features in the Rust compiler
                     "SKIP_PROTO_GEN" to "1",
                 )

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
@@ -34,6 +34,7 @@ internal class CaptureOkHttpEventListener internal constructor(
     private val logger: ILogger?,
     private val clock: IClock,
     private val targetEventListener: EventListener?,
+    private val configuredPropagationMode: TracePropagationMode,
     private val requestExtraFieldsProvider: OkHttpRequestFieldProvider,
     private val responseExtraFieldsProvider: OkHttpResponseFieldProvider,
 ) : EventListener() {
@@ -514,7 +515,7 @@ internal class CaptureOkHttpEventListener internal constructor(
         request: Request,
         baseFields: Map<String, String> = emptyMap(),
     ): Map<String, String> {
-        val traceId = TracePropagation.extractSampledTraceId(request) ?: return baseFields
+        val traceId = TracePropagation.extractSampledTraceId(request, configuredPropagationMode) ?: return baseFields
         val fields = baseFields.toMutableMap()
         fields[TracePropagation.TRACE_ID_FIELD_KEY] = traceId
         return fields

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
@@ -8,9 +8,12 @@
 package io.bitdrift.capture.network.okhttp
 
 import io.bitdrift.capture.Capture
+import io.bitdrift.capture.CaptureRuntimeProvider
 import io.bitdrift.capture.ILogger
+import io.bitdrift.capture.IRuntimeProvider
 import io.bitdrift.capture.common.DefaultClock
 import io.bitdrift.capture.common.IClock
+import io.bitdrift.capture.common.RuntimeStringConfig
 import okhttp3.Call
 import okhttp3.EventListener
 
@@ -32,9 +35,17 @@ class CaptureOkHttpEventListenerFactory internal constructor(
     private val targetEventListenerFactory: EventListener.Factory?,
     private val logger: ILogger?,
     private val clock: IClock,
+    private val runtimeProvider: IRuntimeProvider,
     private val requestFieldProvider: OkHttpRequestFieldProvider,
     private val responseFieldProvider: OkHttpResponseFieldProvider,
 ) : EventListener.Factory {
+    private val configuredPropagationMode by lazy {
+        TracePropagationMode.fromRuntimeValue(
+            runtimeProvider.getRuntimeStringConfigValue(RuntimeStringConfig.TRACE_PROPAGATION_MODE),
+        )
+    }
+    private val requestIgnorePolicy by lazy { RuntimeOkHttpRequestIgnorePolicy(runtimeProvider) }
+
     /**
      * Initializes a new instance of the Capture event listener with an existing event listener factory.
      *
@@ -51,6 +62,7 @@ class CaptureOkHttpEventListenerFactory internal constructor(
         targetEventListenerFactory = targetEventListenerFactory,
         logger = Capture.logger(),
         clock = DefaultClock.getInstance(),
+        runtimeProvider = CaptureRuntimeProvider,
         requestFieldProvider = requestFieldProvider,
         responseFieldProvider = responseFieldProvider,
     )
@@ -58,13 +70,14 @@ class CaptureOkHttpEventListenerFactory internal constructor(
     override fun create(call: Call): EventListener {
         val currentLogger = getLogger()
         val targetEventListener = targetEventListenerFactory?.create(call)
-        if (currentLogger == null) {
+        if (currentLogger == null || requestIgnorePolicy.shouldIgnore(call.request())) {
             return targetEventListener ?: EventListener.NONE
         }
         return CaptureOkHttpEventListener(
             logger = currentLogger,
             clock = clock,
             targetEventListener = targetEventListener,
+            configuredPropagationMode = configuredPropagationMode,
             requestExtraFieldsProvider = requestFieldProvider,
             responseExtraFieldsProvider = responseFieldProvider,
         )

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpRequestIgnorePolicy.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpRequestIgnorePolicy.kt
@@ -1,0 +1,52 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.network.okhttp
+
+import io.bitdrift.capture.CaptureRuntimeProvider
+import io.bitdrift.capture.IRuntimeProvider
+import io.bitdrift.capture.common.RuntimeStringConfig
+import okhttp3.Request
+
+internal interface CaptureOkHttpRequestIgnorePolicy {
+    fun shouldIgnore(request: Request): Boolean
+}
+
+internal class RuntimeOkHttpRequestIgnorePolicy(
+    private val runtimeProvider: IRuntimeProvider = CaptureRuntimeProvider,
+) : CaptureOkHttpRequestIgnorePolicy {
+    private val ignoredPaths by lazy { readRuntimeCsvEntries(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_PATHS_CSV) }
+
+    private val requiredHeaders by lazy {
+        readRuntimeCsvEntries(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_REQUIRED_HEADERS_CSV)
+    }
+
+    override fun shouldIgnore(request: Request): Boolean {
+        val hasIgnoredPaths = ignoredPaths.isNotEmpty()
+        val hasRequiredHeaders = requiredHeaders.isNotEmpty()
+        if (!hasIgnoredPaths && !hasRequiredHeaders) {
+            return false
+        }
+
+        val matchesIgnoredPath = request.url.encodedPath in ignoredPaths
+        val matchesRequiredHeader = requiredHeaders.any { request.header(it) != null }
+
+        return when {
+            hasIgnoredPaths && hasRequiredHeaders -> matchesIgnoredPath && matchesRequiredHeader
+            hasIgnoredPaths -> matchesIgnoredPath
+            else -> matchesRequiredHeader
+        }
+    }
+
+    private fun readRuntimeCsvEntries(config: RuntimeStringConfig): Set<String> =
+        runtimeProvider
+            .getRuntimeStringConfigValue(config)
+            .split(',')
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .toSet()
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
@@ -76,7 +76,6 @@ class CaptureOkHttpTracingInterceptor
 
                 TracePropagationMode.DD -> {
                     requestBuilder.header("x-datadog-trace-id", traceContext.traceIdAsDecimal())
-                    requestBuilder.header("x-datadog-parent-id", traceContext.spanIdAsDecimal())
                     // Using 2 to mean USER_KEEP from https://datadoghq.dev/dd-trace-rb/Datadog/Tracing/Sampling/Ext/Priority.html
                     requestBuilder.header("x-datadog-sampling-priority", "2")
                 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
@@ -38,12 +38,13 @@ class CaptureOkHttpTracingInterceptor
         constructor() : this(CaptureRuntimeProvider)
 
         private val traceContextFactory by lazy { TraceContextFactory() }
+        private val requestIgnorePolicy by lazy { RuntimeOkHttpRequestIgnorePolicy(runtimeProvider) }
 
         override fun intercept(chain: Interceptor.Chain): Response {
             val currentLogger = Capture.logger()
             val request = chain.request()
 
-            if (currentLogger == null || TracePropagation.hasExistingTraceHeaders(request)) {
+            if (currentLogger == null || requestIgnorePolicy.shouldIgnore(request) || TracePropagation.hasExistingTraceHeaders(request)) {
                 return chain.proceed(request)
             }
 
@@ -111,6 +112,7 @@ class CaptureOkHttpTracingInterceptor
                     fieldsOf(
                         "is_tracing_active" to internalLogger.isTracingActive.toString(),
                         "configured_propagation_mode" to this.value,
+                        "dd_support_enabled" to "yes",
                     ),
             ) { "Tracing configuration" }
         }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
@@ -74,6 +74,13 @@ class CaptureOkHttpTracingInterceptor
                     requestBuilder.header("X-B3-Sampled", "1")
                 }
 
+                TracePropagationMode.DD -> {
+                    requestBuilder.header("x-datadog-trace-id", traceContext.traceIdAsDecimal())
+                    requestBuilder.header("x-datadog-parent-id", traceContext.spanIdAsDecimal())
+                    // Using 2 to mean USER_KEEP from https://datadoghq.dev/dd-trace-rb/Datadog/Tracing/Sampling/Ext/Priority.html
+                    requestBuilder.header("x-datadog-sampling-priority", "2")
+                }
+
                 TracePropagationMode.NONE -> return chain.proceed(request)
             }
             return chain.proceed(requestBuilder.build())

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TraceContextFactory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TraceContextFactory.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture.network.okhttp
 
+import java.math.BigInteger
 import java.security.SecureRandom
 
 internal class TraceContextFactory {
@@ -59,6 +60,9 @@ internal enum class TracePropagationMode(
 
     /** Zipkin B3 multiple-headers format via `X-B3-*` headers. */
     B3_MULTI("b3-multi"),
+
+    /** Datadog format via `x-datadog-*` headers. */
+    DD("dd"),
     ;
 
     internal companion object {
@@ -68,6 +72,7 @@ internal enum class TracePropagationMode(
                 W3C.value -> W3C
                 B3_SINGLE.value -> B3_SINGLE
                 B3_MULTI.value -> B3_MULTI
+                DD.value -> DD
                 else -> NONE
             }
     }
@@ -76,4 +81,12 @@ internal enum class TracePropagationMode(
 internal data class TraceContext(
     val traceId: String,
     val spanId: String,
-)
+) {
+    /** Returns the lower 64 bits of the trace ID as a decimal string. */
+    fun traceIdAsDecimal(): String = hexToDecimal(traceId.takeLast(16))
+
+    /** Returns the 64 bits of the span ID as a decimal string. */
+    fun spanIdAsDecimal(): String = hexToDecimal(spanId)
+
+    private fun hexToDecimal(hex: String): String = BigInteger(hex, 16).toString()
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
@@ -50,7 +50,8 @@ internal object TracePropagation {
             // https://datadoghq.dev/dd-trace-rb/Datadog/Tracing/Sampling/Ext/Priority.html
             if (sampled == "1" || sampled == "2") {
                 return try {
-                    ddTraceId.takeIf { BigInteger(it) > BigInteger.ZERO }
+                    val id = BigInteger(ddTraceId)
+                    ddTraceId.takeIf { id.signum() == 1 && id.bitLength() <= 64 }
                 } catch (_: NumberFormatException) {
                     null
                 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
@@ -50,7 +50,7 @@ internal object TracePropagation {
             // https://datadoghq.dev/dd-trace-rb/Datadog/Tracing/Sampling/Ext/Priority.html
             if (sampled == "1" || sampled == "2") {
                 return try {
-                    BigInteger(ddTraceId).toString(16).padStart(16, '0')
+                    ddTraceId.takeIf { BigInteger(it) > BigInteger.ZERO }
                 } catch (_: NumberFormatException) {
                     null
                 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
@@ -43,6 +43,33 @@ internal object TracePropagation {
             return b3TraceId
         }
 
+        return extractSampledDatadogTraceId(request)
+    }
+
+    internal fun extractSampledTraceId(
+        request: Request,
+        configuredPropagationMode: TracePropagationMode,
+    ): String? {
+        if (configuredPropagationMode != TracePropagationMode.DD) {
+            return extractSampledTraceId(request)
+        }
+
+        return extractSampledDatadogTraceId(request)
+            ?: extractSampledW3CTraceIdAsDatadogDecimal(request)
+            ?: extractSampledTraceId(request)
+    }
+
+    private fun extractSampledW3CTraceIdAsDatadogDecimal(request: Request): String? {
+        val traceparent = request.header("traceparent") ?: return null
+        val parts = traceparent.split("-")
+        val flags = parts.getOrNull(3)?.toIntOrNull(16) ?: return null
+        if (flags and 0x01 != 1) return null
+
+        val low64TraceId = parts.getOrNull(1)?.takeLast(16) ?: return null
+        return low64TraceId.toBigIntegerOrNull(16)?.toString()
+    }
+
+    private fun extractSampledDatadogTraceId(request: Request): String? {
         val ddTraceId = request.header("x-datadog-trace-id")
         if (ddTraceId != null) {
             val sampled = request.header("x-datadog-sampling-priority")

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/TracePropagation.kt
@@ -8,6 +8,7 @@
 package io.bitdrift.capture.network.okhttp
 
 import okhttp3.Request
+import java.math.BigInteger
 
 internal object TracePropagation {
     internal const val TRACE_ID_FIELD_KEY = "_trace_id"
@@ -15,7 +16,8 @@ internal object TracePropagation {
     internal fun hasExistingTraceHeaders(request: Request): Boolean =
         request.header("traceparent") != null ||
             request.header("b3") != null ||
-            request.header("X-B3-TraceId") != null
+            request.header("X-B3-TraceId") != null ||
+            request.header("x-datadog-trace-id") != null
 
     internal fun extractSampledTraceId(request: Request): String? {
         val w3c = request.header("traceparent")
@@ -39,6 +41,20 @@ internal object TracePropagation {
             val sampled = request.header("X-B3-Sampled") ?: return null
             if (sampled != "1") return null
             return b3TraceId
+        }
+
+        val ddTraceId = request.header("x-datadog-trace-id")
+        if (ddTraceId != null) {
+            val sampled = request.header("x-datadog-sampling-priority")
+            // Datadog sampling priority values: 1 = AUTO_KEEP, 2 = USER_KEEP
+            // https://datadoghq.dev/dd-trace-rb/Datadog/Tracing/Sampling/Ext/Priority.html
+            if (sampled == "1" || sampled == "2") {
+                return try {
+                    BigInteger(ddTraceId).toString(16).padStart(16, '0')
+                } catch (_: NumberFormatException) {
+                    null
+                }
+            }
         }
 
         return null

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -13,7 +13,9 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.bitdrift.capture.ILogger
+import io.bitdrift.capture.IRuntimeProvider
 import io.bitdrift.capture.common.IClock
+import io.bitdrift.capture.common.RuntimeStringConfig
 import io.bitdrift.capture.network.HttpField
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
@@ -36,6 +38,7 @@ class CaptureOkHttpEventListenerFactoryTest {
     private val endpoint = "https://api.bitdrift.io/my_path/12345?my_query=my_value"
     private val clock: IClock = mock()
     private val logger: ILogger = mock()
+    private val runtimeProvider: IRuntimeProvider = mock()
 
     private val call: Call = mock()
 
@@ -526,6 +529,108 @@ class CaptureOkHttpEventListenerFactoryTest {
     }
 
     @Test
+    fun testDatadogIntakeRequestIsIgnored() {
+        val request =
+            Request
+                .Builder()
+                .url("https://app.datadoghq.com/api/v2/spans")
+                .post("test".toRequestBody())
+                .header("DD-API-KEY", "client-token")
+                .header("DD-EVP-ORIGIN", "android")
+                .header("DD-REQUEST-ID", "request-id")
+                .build()
+
+        val response =
+            Response
+                .Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_2)
+                .code(202)
+                .message("accepted")
+                .build()
+
+        whenever(call.request()).thenReturn(request)
+
+        val factory =
+            createListenerFactory(
+                propagationMode = TracePropagationMode.DD,
+                ignoredRequestPathsCSV = "/api/v2/spans",
+                ignoredRequestRequiredHeadersCSV = "DD-EVP-ORIGIN",
+            )
+        val listener = factory.create(call)
+
+        listener.callStart(call)
+        listener.responseHeadersEnd(call, response)
+        listener.responseBodyEnd(call, 1)
+        listener.callEnd(call)
+
+        verify(logger, org.mockito.Mockito.never()).log(any<HttpRequestInfo>())
+        verify(logger, org.mockito.Mockito.never()).log(any<HttpResponseInfo>())
+    }
+
+    @Test
+    fun testDatadogModeUsesDatadogLinkableTraceIdForExistingW3CHeaders() {
+        val w3cTraceId = "88c131f5a4a41657a4cc039862759571"
+        val expectedDatadogTraceId = "11874870270490940785"
+        val request =
+            Request
+                .Builder()
+                .url(endpoint)
+                .post("test".toRequestBody())
+                .header("traceparent", "00-$w3cTraceId-639ec5ab80cb312d-01")
+                .build()
+
+        val response =
+            Response
+                .Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_2)
+                .code(200)
+                .message("message")
+                .build()
+
+        whenever(call.request()).thenReturn(request)
+
+        val factory =
+            CaptureOkHttpEventListenerFactory(
+                targetEventListenerFactory = null,
+                logger = logger,
+                clock = clock,
+                runtimeProvider =
+                    runtimeProvider.also {
+                        whenever(
+                            it.getRuntimeStringConfigValue(RuntimeStringConfig.TRACE_PROPAGATION_MODE),
+                        ).thenReturn(TracePropagationMode.DD.value)
+                        whenever(
+                            it.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_PATHS_CSV),
+                        ).thenReturn("")
+                        whenever(
+                            it.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_REQUIRED_HEADERS_CSV),
+                        ).thenReturn("")
+                    },
+                requestFieldProvider = OkHttpRequestFieldProvider { emptyMap() },
+                responseFieldProvider = OkHttpResponseFieldProvider { emptyMap() },
+            )
+        val listener = factory.create(call)
+
+        listener.callStart(call)
+        listener.responseHeadersEnd(call, response)
+        listener.responseBodyEnd(call, 1)
+        listener.callEnd(call)
+
+        val requestInfoCapture = argumentCaptor<HttpRequestInfo>()
+        verify(logger).log(requestInfoCapture.capture())
+        val responseInfoCapture = argumentCaptor<HttpResponseInfo>()
+        verify(logger).log(responseInfoCapture.capture())
+
+        val requestInfo = requestInfoCapture.firstValue
+        val responseInfo = responseInfoCapture.firstValue
+
+        assertThat(requestInfo.arrayFields[TracePropagation.TRACE_ID_FIELD_KEY].toString()).isEqualTo(expectedDatadogTraceId)
+        assertThat(responseInfo.arrayFields[TracePropagation.TRACE_ID_FIELD_KEY].toString()).isEqualTo(expectedDatadogTraceId)
+    }
+
+    @Test
     fun testApolloHeadersSendGraphQlSpans() {
         // ARRANGE
         val headerFields =
@@ -636,9 +741,21 @@ class CaptureOkHttpEventListenerFactoryTest {
         // ACT
         val factory =
             CaptureOkHttpEventListenerFactory(
-                null,
-                logger,
-                clock,
+                targetEventListenerFactory = null,
+                logger = logger,
+                clock = clock,
+                runtimeProvider =
+                    runtimeProvider.also {
+                        whenever(
+                            it.getRuntimeStringConfigValue(RuntimeStringConfig.TRACE_PROPAGATION_MODE),
+                        ).thenReturn(TracePropagationMode.W3C.value)
+                        whenever(
+                            it.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_PATHS_CSV),
+                        ).thenReturn("")
+                        whenever(
+                            it.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_REQUIRED_HEADERS_CSV),
+                        ).thenReturn("")
+                    },
                 requestFieldProvider = requestFieldProvider,
                 responseFieldProvider = responseFieldProvider,
             )
@@ -693,6 +810,7 @@ class CaptureOkHttpEventListenerFactoryTest {
 
     @Test
     fun create_withNullLoggerAndNullTargetListener_shouldReturnNoOpListener() {
+        whenever(call.request()).thenReturn(Request.Builder().url(endpoint).build())
         val factory = createListenerFactory(logger = null)
 
         val noOpEventListener = factory.create(call)
@@ -702,6 +820,7 @@ class CaptureOkHttpEventListenerFactoryTest {
 
     @Test
     fun create_withNullLogAndValidTargetListener_returnsTargetListener() {
+        whenever(call.request()).thenReturn(Request.Builder().url(endpoint).build())
         val targetEventListener: EventListener = mock()
         val factory =
             createListenerFactory(
@@ -736,6 +855,9 @@ class CaptureOkHttpEventListenerFactoryTest {
     private fun createListenerFactory(
         targetEventListenerCreator: EventListener.Factory? = null,
         logger: ILogger? = this.logger,
+        propagationMode: TracePropagationMode = TracePropagationMode.W3C,
+        ignoredRequestPathsCSV: String = "",
+        ignoredRequestRequiredHeadersCSV: String = "",
         requestFieldProvider: OkHttpRequestFieldProvider =
             OkHttpRequestFieldProvider {
                 emptyMap()
@@ -749,6 +871,16 @@ class CaptureOkHttpEventListenerFactoryTest {
             targetEventListenerFactory = targetEventListenerCreator,
             logger = logger,
             clock = clock,
+            runtimeProvider =
+                runtimeProvider.also {
+                    whenever(it.getRuntimeStringConfigValue(RuntimeStringConfig.TRACE_PROPAGATION_MODE)).thenReturn(propagationMode.value)
+                    whenever(
+                        it.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_PATHS_CSV),
+                    ).thenReturn(ignoredRequestPathsCSV)
+                    whenever(
+                        it.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_REQUIRED_HEADERS_CSV),
+                    ).thenReturn(ignoredRequestRequiredHeadersCSV)
+                },
             requestFieldProvider = requestFieldProvider,
             responseFieldProvider = responseFieldProvider,
         )

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptorTest.kt
@@ -34,6 +34,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenActiveTracingAndW3c_shouldAddExpectedHeaders() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("w3c")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
 
@@ -50,6 +52,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenActiveTracingAndB3_shouldAddExpectedHeaders() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("b3-single")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
@@ -66,6 +70,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenActiveTracingAndB3Multi_shouldAddExpectedHeaders() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("b3-multi")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
@@ -84,6 +90,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenActiveTracingAndDatadog_shouldAddExpectedHeaders() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("dd")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
@@ -103,6 +111,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenNotActiveTracing_shouldNotAddHeaders() {
         setActiveTracingState(isActiveTracingEnabled = false)
         setPropagationMode("w3c")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
@@ -118,6 +128,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenPropagationModeOff_shouldNotAddHeaders() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("off")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
@@ -133,6 +145,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenStringModeUnknown_shouldDefaultToNone() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("invalid")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
         val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
@@ -148,6 +162,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenExistingTraceparent_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("w3c")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingTraceparent = "00-88c131f5a4a41657a4cc039862759571-639ec5ab80cb312d-01"
         val request =
@@ -170,6 +186,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenExistingB3Single_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("b3-single")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingB3 = "88c131f5a4a41657a4cc039862759571-639ec5ab80cb312d-1"
         val request =
@@ -192,6 +210,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenExistingB3Multi_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("b3-multi")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingTraceId = "88c131f5a4a41657a4cc039862759571"
         val existingSpanId = "639ec5ab80cb312d"
@@ -219,6 +239,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenW3cModeButExistingB3Header_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("w3c")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingB3 = "88c131f5a4a41657a4cc039862759571-639ec5ab80cb312d-1"
         val request =
@@ -242,6 +264,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenB3SingleModeButExistingTraceparent_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("b3-single")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingTraceparent = "00-88c131f5a4a41657a4cc039862759571-639ec5ab80cb312d-01"
         val request =
@@ -265,6 +289,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenB3MultiModeButExistingB3SingleHeader_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("b3-multi")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingB3 = "88c131f5a4a41657a4cc039862759571-639ec5ab80cb312d-1"
         val request =
@@ -289,6 +315,8 @@ class CaptureOkHttpTracingInterceptorTest {
     fun intercept_whenExistingDatadogHeaders_shouldPassThroughUnchanged() {
         setActiveTracingState(isActiveTracingEnabled = true)
         setPropagationMode("dd")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
 
         val existingTraceId = "5498017814432956682"
         val request =
@@ -309,8 +337,84 @@ class CaptureOkHttpTracingInterceptorTest {
         assertThat(captured.headers.size).isEqualTo(request.headers.size)
     }
 
+    @Test
+    fun intercept_whenDatadogIntakeRequest_shouldPassThroughUnchanged() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("dd")
+        setIgnoredRequestPaths("/api/v2/spans")
+        setIgnoredRequestRequiredHeaders("DD-EVP-ORIGIN")
+
+        val request =
+            Request
+                .Builder()
+                .url("https://app.datadoghq.com/api/v2/spans")
+                .header("DD-API-KEY", "client-token")
+                .header("DD-EVP-ORIGIN", "android")
+                .header("DD-REQUEST-ID", "request-id")
+                .build()
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(request)
+
+        interceptor.intercept(chain)
+
+        val captured = chain.capturedRequest
+        assertThat(captured.header("x-datadog-trace-id")).isNull()
+        assertThat(captured.header("x-datadog-sampling-priority")).isNull()
+        assertThat(captured.headers.size).isEqualTo(request.headers.size)
+    }
+
+    @Test
+    fun intercept_whenPlainApiV2SpansRequest_shouldStillInjectHeaders() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("dd")
+        setIgnoredRequestPaths("")
+        setIgnoredRequestRequiredHeaders("")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com/api/v2/spans").build())
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        assertThat(request.header("x-datadog-trace-id")).isNotNull()
+        assertThat(request.header("x-datadog-sampling-priority")).isEqualTo("2")
+    }
+
+    @Test
+    fun intercept_whenIgnoreRequestConfigHasOnlyPath_shouldPassThroughUnchanged() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("dd")
+        setIgnoredRequestPaths("/api/v2/spans")
+        setIgnoredRequestRequiredHeaders("")
+
+        val request =
+            Request
+                .Builder()
+                .url("https://app.datadoghq.com/api/v2/spans")
+                .header("DD-EVP-ORIGIN", "android")
+                .build()
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(request)
+
+        interceptor.intercept(chain)
+
+        val captured = chain.capturedRequest
+        assertThat(captured.header("x-datadog-trace-id")).isNull()
+        assertThat(captured.header("x-datadog-sampling-priority")).isNull()
+    }
+
     private fun setPropagationMode(value: String) {
         whenever(runtimeProvider.getRuntimeStringConfigValue(RuntimeStringConfig.TRACE_PROPAGATION_MODE)).thenReturn(value)
+    }
+
+    private fun setIgnoredRequestPaths(value: String) {
+        whenever(runtimeProvider.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_PATHS_CSV)).thenReturn(value)
+    }
+
+    private fun setIgnoredRequestRequiredHeaders(value: String) {
+        whenever(
+            runtimeProvider.getRuntimeStringConfigValue(RuntimeStringConfig.NETWORK_REQUEST_IGNORE_REQUIRED_HEADERS_CSV),
+        ).thenReturn(value)
     }
 
     private fun setActiveTracingState(isActiveTracingEnabled: Boolean) {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptorTest.kt
@@ -19,6 +19,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Test
 import org.mockito.Mockito.mock
+import java.math.BigInteger
 import java.util.concurrent.atomic.AtomicReference
 
 class CaptureOkHttpTracingInterceptorTest {
@@ -75,6 +76,25 @@ class CaptureOkHttpTracingInterceptorTest {
         assertThat(request.header("X-B3-TraceId")).hasSize(32)
         assertThat(request.header("X-B3-SpanId")).hasSize(16)
         assertThat(request.header("X-B3-Sampled")).isEqualTo("1")
+        assertThat(request.header("traceparent")).isNull()
+        assertThat(request.header("b3")).isNull()
+    }
+
+    @Test
+    fun intercept_whenActiveTracingAndDatadog_shouldAddExpectedHeaders() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("dd")
+
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(Request.Builder().url("https://example.com").build())
+
+        interceptor.intercept(chain)
+
+        val request = chain.capturedRequest
+        val traceId = BigInteger(request.header("x-datadog-trace-id")!!)
+        assertThat(traceId.signum()).isEqualTo(1)
+        assertThat(traceId.bitLength()).isLessThanOrEqualTo(64)
+        assertThat(request.header("x-datadog-sampling-priority")).isEqualTo("2")
         assertThat(request.header("traceparent")).isNull()
         assertThat(request.header("b3")).isNull()
     }
@@ -262,6 +282,30 @@ class CaptureOkHttpTracingInterceptorTest {
         assertThat(captured.header("b3")).isEqualTo(existingB3)
         assertThat(captured.header("X-B3-TraceId")).isNull()
         assertThat(captured.header("X-B3-SpanId")).isNull()
+        assertThat(captured.headers.size).isEqualTo(request.headers.size)
+    }
+
+    @Test
+    fun intercept_whenExistingDatadogHeaders_shouldPassThroughUnchanged() {
+        setActiveTracingState(isActiveTracingEnabled = true)
+        setPropagationMode("dd")
+
+        val existingTraceId = "5498017814432956682"
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", existingTraceId)
+                .header("x-datadog-sampling-priority", "1")
+                .build()
+        val interceptor = CaptureOkHttpTracingInterceptor(runtimeProvider)
+        val chain = FakeOkHttpInterceptorChain(request)
+
+        interceptor.intercept(chain)
+
+        val captured = chain.capturedRequest
+        assertThat(captured.header("x-datadog-trace-id")).isEqualTo(existingTraceId)
+        assertThat(captured.header("x-datadog-sampling-priority")).isEqualTo("1")
         assertThat(captured.headers.size).isEqualTo(request.headers.size)
     }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TraceContextFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TraceContextFactoryTest.kt
@@ -30,6 +30,7 @@ class TraceContextFactoryTest {
         assertThat(TracePropagationMode.fromRuntimeValue("w3c")).isEqualTo(TracePropagationMode.W3C)
         assertThat(TracePropagationMode.fromRuntimeValue("b3-single")).isEqualTo(TracePropagationMode.B3_SINGLE)
         assertThat(TracePropagationMode.fromRuntimeValue("b3-multi")).isEqualTo(TracePropagationMode.B3_MULTI)
+        assertThat(TracePropagationMode.fromRuntimeValue("dd")).isEqualTo(TracePropagationMode.DD)
     }
 
     @Test
@@ -50,5 +51,30 @@ class TraceContextFactoryTest {
     @Test
     fun tracePropagationMode_runtimeConfig_shouldDefaultToW3C() {
         assertThat(RuntimeStringConfig.TRACE_PROPAGATION_MODE.defaultValue).isEqualTo("w3c")
+    }
+
+    @Test
+    fun datadog_conversions_shouldConformToSpec() {
+        // Test with max 64-bit values to ensure unsigned handling (Datadog uses unsigned 64-bit decimals)
+        val traceId = "ffffffffffffffffffffffffffffffff"
+        val spanId = "ffffffffffffffff"
+        val context = TraceContext(traceId = traceId, spanId = spanId)
+
+        // 2^64 - 1
+        val expectedMax64 = "18446744073709551615"
+        assertThat(context.traceIdAsDecimal()).isEqualTo(expectedMax64)
+        assertThat(context.spanIdAsDecimal()).isEqualTo(expectedMax64)
+
+        // Test with a specific known 128-bit trace ID
+        val traceId128 = "88c131f5a4a41657a4cc039862759571"
+        val context128 = TraceContext(traceId = traceId128, spanId = "639ec5ab80cb312d")
+
+        // Lower 64 bits of traceId128: a4cc039862759571
+        // a4cc039862759571 hex to decimal: 11874870270490940785
+        assertThat(context128.traceIdAsDecimal()).isEqualTo("11874870270490940785")
+
+        // spanId: 639ec5ab80cb312d
+        // 639ec5ab80cb312d hex to decimal: 7178392196466028845
+        assertThat(context128.spanIdAsDecimal()).isEqualTo("7178392196466028845")
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TracePropagationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TracePropagationTest.kt
@@ -199,7 +199,6 @@ class TracePropagationTest {
 
     @Test
     fun extractSampledTraceId_datadogSampled_returnsTraceId() {
-        // 12345 in hex is 3039, padded to 16 chars: 0000000000003039
         val request =
             Request
                 .Builder()
@@ -207,6 +206,54 @@ class TracePropagationTest {
                 .header("x-datadog-trace-id", "12345")
                 .header("x-datadog-sampling-priority", "1")
                 .build()
-        assertThat(TracePropagation.extractSampledTraceId(request)).isEqualTo("0000000000003039")
+        assertThat(TracePropagation.extractSampledTraceId(request)).isEqualTo("12345")
+    }
+
+    @Test
+    fun extractSampledTraceId_datadogUserKeep_returnsTraceId() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "5498017814432956682")
+                .header("x-datadog-sampling-priority", "2")
+                .build()
+        assertThat(TracePropagation.extractSampledTraceId(request)).isEqualTo("5498017814432956682")
+    }
+
+    @Test
+    fun extractSampledTraceId_datadogNotSampled_returnsNull() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "12345")
+                .header("x-datadog-sampling-priority", "0")
+                .build()
+        assertThat(TracePropagation.extractSampledTraceId(request)).isNull()
+    }
+
+    @Test
+    fun extractSampledTraceId_datadogInvalidTraceId_returnsNull() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "abc")
+                .header("x-datadog-sampling-priority", "1")
+                .build()
+        assertThat(TracePropagation.extractSampledTraceId(request)).isNull()
+    }
+
+    @Test
+    fun extractSampledTraceId_datadogZeroTraceId_returnsNull() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "0")
+                .header("x-datadog-sampling-priority", "1")
+                .build()
+        assertThat(TracePropagation.extractSampledTraceId(request)).isNull()
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TracePropagationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TracePropagationTest.kt
@@ -185,4 +185,28 @@ class TracePropagationTest {
         val request = Request.Builder().url("https://example.com").build()
         assertThat(TracePropagation.extractSampledTraceId(request)).isNull()
     }
+
+    @Test
+    fun hasExistingTraceHeaders_detectsDatadog() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "12345")
+                .build()
+        assertThat(TracePropagation.hasExistingTraceHeaders(request)).isTrue()
+    }
+
+    @Test
+    fun extractSampledTraceId_datadogSampled_returnsTraceId() {
+        // 12345 in hex is 3039, padded to 16 chars: 0000000000003039
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "12345")
+                .header("x-datadog-sampling-priority", "1")
+                .build()
+        assertThat(TracePropagation.extractSampledTraceId(request)).isEqualTo("0000000000003039")
+    }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TracePropagationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/TracePropagationTest.kt
@@ -181,6 +181,18 @@ class TracePropagationTest {
     }
 
     @Test
+    fun extractSampledTraceId_datadogOverflowTraceId_returnsNull() {
+        val request =
+            Request
+                .Builder()
+                .url("https://example.com")
+                .header("x-datadog-trace-id", "18446744073709551616") // 2^64
+                .header("x-datadog-sampling-priority", "1")
+                .build()
+        assertThat(TracePropagation.extractSampledTraceId(request)).isNull()
+    }
+
+    @Test
     fun extractSampledTraceId_noHeaders_returnsNull() {
         val request = Request.Builder().url("https://example.com").build()
         assertThat(TracePropagation.extractSampledTraceId(request)).isNull()

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -154,6 +154,7 @@ sealed class RuntimeStringConfig(
      * - "w3c": use the W3C `traceparent` header
      * - "b3-single": use the Zipkin B3 `b3` header
      * - "b3-multi": use the Zipkin B3 `X-B3-*` headers
+     * - "dd": use the Datadog `x-datadog-*` headers
      */
     data object TRACE_PROPAGATION_MODE : RuntimeStringConfig("client_config.trace.propagation_mode", "w3c")
 }

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -157,6 +157,26 @@ sealed class RuntimeStringConfig(
      * - "dd": use the Datadog `x-datadog-*` headers
      */
     data object TRACE_PROPAGATION_MODE : RuntimeStringConfig("client_config.trace.propagation_mode", "w3c")
+
+    /**
+     * Comma-separated list (CSV) of request paths used to match requests that should be ignored.
+     *
+     * Example: `/api/v2/spans,/api/v2/logs`
+     */
+    data object NETWORK_REQUEST_IGNORE_PATHS_CSV : RuntimeStringConfig(
+        "client_config.network.request_ignore_match_paths",
+        "",
+    )
+
+    /**
+     * Comma-separated list (CSV) of request paths used to match requests that should be ignored.
+     *
+     * Example: `/api/v2/spans,/api/v2/logs`
+     */
+    data object NETWORK_REQUEST_IGNORE_REQUIRED_HEADERS_CSV : RuntimeStringConfig(
+        "client_config.network.request_ignore_match_headers",
+        "",
+    )
 }
 
 /**

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -4,8 +4,14 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
     id("com.google.firebase.crashlytics") version "3.0.6" apply false
-    id("io.bitdrift.capture-plugin") version "0.23.4" // To verify new changes at capture-plugin use your maven local published version
+    id("io.bitdrift.capture-plugin") version "0.23.10" // To verify new changes at capture-plugin use your maven local published version
 }
+
+val enableAutoCaptureOkHttpInstrumentation =
+    providers.gradleProperty("enableAutoCaptureOkHttpInstrumentation")
+        .map(String::toBoolean)
+        .orElse(true)
+        .get()
 
 val requestedDebugVariant =
     gradle.startParameter.taskNames.any { taskName ->
@@ -106,6 +112,11 @@ android {
         versionCode = 68
         versionName = "3.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField(
+            "boolean",
+            "ENABLE_AUTO_CAPTURE_OKHTTP_INSTRUMENTATION",
+            enableAutoCaptureOkHttpInstrumentation.toString(),
+        )
     }
 
     // This needs to be set to access the strip tools to strip the shared libraries.
@@ -194,7 +205,7 @@ apollo {
 
 bitdrift {
     instrumentation {
-        automaticOkHttpInstrumentation = true
+        automaticOkHttpInstrumentation = enableAutoCaptureOkHttpInstrumentation
         automaticWebViewInstrumentation = true
         // Comment out to change the default type. e.g. okHttpInstrumentationType = OVERWRITE
     }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -76,6 +76,8 @@ sealed class NetworkTestAction : AppAction {
 
     object PerformPreExistingB3MultiRequest : NetworkTestAction()
 
+    object PerformPreExistingDatadogRequest : NetworkTestAction()
+
     object PerformLocalBackendAddToCartRequest : NetworkTestAction()
 
     object PerformLocalBackendGetCartRequest : NetworkTestAction()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -62,9 +62,7 @@ sealed class DiagnosticsAction : AppAction {
 }
 
 sealed class NetworkTestAction : AppAction {
-    object PerformOkHttpRequestManual : NetworkTestAction()
-
-    object PerformOkHttpRequestAutomatic : NetworkTestAction()
+    object PerformOkHttpRequest : NetworkTestAction()
 
     object PerformGraphQlRequest : NetworkTestAction()
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
@@ -75,7 +75,9 @@ class NetworkTestingRepository(context: Context) {
                     addInterceptor(CaptureOkHttpTracingInterceptor())
                     eventListenerFactory(
                         CaptureOkHttpEventListenerFactory(
-                            requestFieldProvider = RetrofitUrlPathProvider(CustomRequestFieldProvider()),
+                            requestFieldProvider = RetrofitUrlPathProvider(
+                                CustomRequestFieldProvider()
+                            ),
                             responseFieldProvider = CustomResponseFieldProvider(),
                         ),
                     )
@@ -295,7 +297,7 @@ class NetworkTestingRepository(context: Context) {
         okHttpClient.newCall(request).enqueue(
             object : Callback {
                 override fun onResponse(call: Call, response: Response) {
-                    val body = response.use { it.body!!.string() }
+                    val body = response.use { it.body.string() }
                     Timber.v("OkHttp request ($label) completed with status code=${response.code} and body=$body")
                 }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
@@ -23,6 +23,7 @@ import io.bitdrift.capture.network.okhttp.CaptureOkHttpTracingInterceptor
 import io.bitdrift.capture.network.okhttp.OkHttpRequestFieldProvider
 import io.bitdrift.capture.network.okhttp.OkHttpResponseFieldProvider
 import io.bitdrift.capture.network.retrofit.RetrofitUrlPathProvider
+import io.bitdrift.gradletestapp.BuildConfig
 import io.bitdrift.gradletestapp.data.service.BinaryJazzRetrofitService
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -63,38 +64,35 @@ class NetworkTestingRepository(context: Context) {
             ).alwaysReadResponseBody(true)
             .build()
 
-    // Manual integration: explicit CaptureOkHttpEventListenerFactory with custom field providers
-    private val okHttpClientManual: OkHttpClient =
+    private val okHttpClient: OkHttpClient =
         OkHttpClient
             .Builder()
             .addInterceptor(chuckerInterceptor)
-            .addInterceptor(CaptureOkHttpTracingInterceptor())
-            .eventListenerFactory(
-                CaptureOkHttpEventListenerFactory(
-                    requestFieldProvider = RetrofitUrlPathProvider(CustomRequestFieldProvider()),
-                    responseFieldProvider = CustomResponseFieldProvider(),
-                ),
-            )
-            .build()
-
-    // Automatic integration: relies on Gradle plugin instrumentation (tests PROXY vs OVERWRITE)
-    private val okHttpClientAutomatic: OkHttpClient =
-        OkHttpClient
-            .Builder()
-            .addInterceptor(chuckerInterceptor)
-            .eventListenerFactory { TimberOkHttpEventListener() }
+            .apply {
+                if (BuildConfig.ENABLE_AUTO_CAPTURE_OKHTTP_INSTRUMENTATION) {
+                    eventListenerFactory { TimberOkHttpEventListener() }
+                } else {
+                    addInterceptor(CaptureOkHttpTracingInterceptor())
+                    eventListenerFactory(
+                        CaptureOkHttpEventListenerFactory(
+                            requestFieldProvider = RetrofitUrlPathProvider(CustomRequestFieldProvider()),
+                            responseFieldProvider = CustomResponseFieldProvider(),
+                        ),
+                    )
+                }
+            }
             .build()
 
     private val apolloClient: ApolloClient =
         ApolloClient
             .Builder()
             .serverUrl("https://apollo-fullstack-tutorial.herokuapp.com/graphql")
-            .okHttpClient(okHttpClientManual)
+            .okHttpClient(okHttpClient)
             .addInterceptor(CaptureApolloInterceptor())
             .build()
     private val retrofitService = Retrofit.Builder()
         .baseUrl("https://binaryjazz.us")
-        .client(okHttpClientManual)
+        .client(okHttpClient)
         .addConverterFactory(GsonConverterFactory.create())
         .build()
         .create(BinaryJazzRetrofitService::class.java)
@@ -141,15 +139,12 @@ class NetworkTestingRepository(context: Context) {
     }
 
     fun performOkHttpRequest() {
-        performOkHttpRequestWithClient(okHttpClientManual, "Manual")
-    }
-
-    fun performOkHttpRequestAutomatic() {
-        performOkHttpRequestWithClient(okHttpClientAutomatic, "Automatic")
-    }
-
-    private fun performOkHttpRequestWithClient(okHttpClient: OkHttpClient, label: String) {
         val requestDef = requestDefinitions.random()
+        val label = if(BuildConfig.ENABLE_AUTO_CAPTURE_OKHTTP_INSTRUMENTATION){
+            "autoOkHttpInstrumentation"
+        }else{
+            "manualOkHttpInstrumentation"
+        }
         Timber.i("Performing OkHttp Network Request ($label): $requestDef")
 
         val url =
@@ -179,7 +174,7 @@ class NetworkTestingRepository(context: Context) {
                 ) {
                     val body =
                         response.use {
-                            it.body!!.string()
+                            it.body.string()
                         }
                     Timber.v("OkHttp request ($label) completed with status code=${response.code} and body=$body")
                 }
@@ -297,7 +292,7 @@ class NetworkTestingRepository(context: Context) {
 
     private fun performRequestWithPreExistingHeaders(request: Request, label: String) {
         Timber.i("Performing OkHttp request ($label): ${request.url}")
-        okHttpClientManual.newCall(request).enqueue(
+        okHttpClient.newCall(request).enqueue(
             object : Callback {
                 override fun onResponse(call: Call, response: Response) {
                     val body = response.use { it.body!!.string() }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
@@ -254,6 +254,18 @@ class NetworkTestingRepository(context: Context) {
         performRequestWithPreExistingHeaders(request, "Pre-existing B3 Multi")
     }
 
+    fun performPreExistingDatadogRequest() {
+        val traceId = generateFakeDatadogTraceId()
+        val spanId = generateFakeDatadogSpanId()
+        val request = Request.Builder()
+            .url("https://httpbin.org/get")
+            .header("x-datadog-trace-id", traceId)
+            .header("x-datadog-parent-id", spanId)
+            .header("x-datadog-sampling-priority", "2")
+            .build()
+        performRequestWithPreExistingHeaders(request, "Pre-existing DD")
+    }
+
     fun performLocalBackendAddToCartRequest() {
         val requestBody = JSONObject()
             .put("product_id", LOCAL_BACKEND_PRODUCT_ID)
@@ -309,6 +321,22 @@ class NetworkTestingRepository(context: Context) {
         val bytes = ByteArray(8)
         Random.nextBytes(bytes)
         return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun generateFakeDatadogTraceId(): String {
+        var value = Random.nextLong().toULong()
+        while (value == 0UL) {
+            value = Random.nextLong().toULong()
+        }
+        return value.toString()
+    }
+
+    private fun generateFakeDatadogSpanId(): String {
+        var value = Random.nextLong().toULong()
+        while (value == 0UL) {
+            value = Random.nextLong().toULong()
+        }
+        return value.toString()
     }
 
     /**

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
@@ -356,6 +356,7 @@ private fun SdkApisTabContent(
                 onPreExistingW3cRequest = { onAction(NetworkTestAction.PerformPreExistingW3cRequest) },
                 onPreExistingB3SingleRequest = { onAction(NetworkTestAction.PerformPreExistingB3SingleRequest) },
                 onPreExistingB3MultiRequest = { onAction(NetworkTestAction.PerformPreExistingB3MultiRequest) },
+                onPreExistingDatadogRequest = { onAction(NetworkTestAction.PerformPreExistingDatadogRequest) },
                 onLocalBackendAddToCartRequest = { onAction(NetworkTestAction.PerformLocalBackendAddToCartRequest) },
                 onLocalBackendGetCartRequest = { onAction(NetworkTestAction.PerformLocalBackendGetCartRequest) },
                 onLocalBackendDeleteCartItemRequest = { onAction(NetworkTestAction.PerformLocalBackendDeleteCartItemRequest) },

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
@@ -349,8 +349,7 @@ private fun SdkApisTabContent(
         }
         item {
             NetworkTestingCard(
-                onOkHttpManualRequest = { onAction(NetworkTestAction.PerformOkHttpRequestManual) },
-                onOkHttpAutoRequest = { onAction(NetworkTestAction.PerformOkHttpRequestAutomatic) },
+                onOkHttpRequest = { onAction(NetworkTestAction.PerformOkHttpRequest) },
                 onGraphQlRequest = { onAction(NetworkTestAction.PerformGraphQlRequest) },
                 onRetrofitRequest = { onAction(NetworkTestAction.PerformRetrofitRequest) },
                 onPreExistingW3cRequest = { onAction(NetworkTestAction.PerformPreExistingW3cRequest) },

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NetworkTestingCard.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NetworkTestingCard.kt
@@ -20,8 +20,7 @@ import io.bitdrift.gradletestapp.ui.theme.BitdriftColors
  */
 @Composable
 fun NetworkTestingCard(
-    onOkHttpManualRequest: () -> Unit,
-    onOkHttpAutoRequest: () -> Unit,
+    onOkHttpRequest: () -> Unit,
     onGraphQlRequest: () -> Unit,
     onRetrofitRequest: () -> Unit,
     onPreExistingW3cRequest: () -> Unit,
@@ -62,25 +61,14 @@ fun NetworkTestingCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 OutlinedButton(
-                    onClick = onOkHttpManualRequest,
+                    onClick = onOkHttpRequest,
                     modifier = Modifier.weight(1f),
                     colors =
                         ButtonDefaults.outlinedButtonColors(
                             contentColor = BitdriftColors.TextPrimary,
                         ),
                 ) {
-                    Text("OkHttp (Manual)", maxLines = 1, softWrap = false)
-                }
-
-                OutlinedButton(
-                    onClick = onOkHttpAutoRequest,
-                    modifier = Modifier.weight(1f),
-                    colors =
-                        ButtonDefaults.outlinedButtonColors(
-                            contentColor = BitdriftColors.TextPrimary,
-                        ),
-                ) {
-                    Text("OkHttp (Auto)", maxLines = 1, softWrap = false)
+                    Text("OkHttp", maxLines = 1, softWrap = false)
                 }
             }
 
@@ -142,7 +130,12 @@ fun NetworkTestingCard(
                 ) {
                     Text("B3 Single", maxLines = 1, softWrap = false)
                 }
+            }
 
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 OutlinedButton(
                     onClick = onPreExistingB3MultiRequest,
                     modifier = Modifier.weight(1f),
@@ -164,6 +157,8 @@ fun NetworkTestingCard(
                 ) {
                     Text("DD", maxLines = 1, softWrap = false)
                 }
+
+                Spacer(modifier = Modifier.weight(1f))
             }
 
             Text(

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NetworkTestingCard.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NetworkTestingCard.kt
@@ -27,6 +27,7 @@ fun NetworkTestingCard(
     onPreExistingW3cRequest: () -> Unit,
     onPreExistingB3SingleRequest: () -> Unit,
     onPreExistingB3MultiRequest: () -> Unit,
+    onPreExistingDatadogRequest: () -> Unit,
     onLocalBackendAddToCartRequest: () -> Unit,
     onLocalBackendGetCartRequest: () -> Unit,
     onLocalBackendDeleteCartItemRequest: () -> Unit,
@@ -151,6 +152,17 @@ fun NetworkTestingCard(
                         ),
                 ) {
                     Text("B3 Multi", maxLines = 1, softWrap = false)
+                }
+
+                OutlinedButton(
+                    onClick = onPreExistingDatadogRequest,
+                    modifier = Modifier.weight(1f),
+                    colors =
+                        ButtonDefaults.outlinedButtonColors(
+                            contentColor = BitdriftColors.TextPrimary,
+                        ),
+                ) {
+                    Text("DD", maxLines = 1, softWrap = false)
                 }
             }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -141,6 +141,9 @@ class MainViewModel(
             is NetworkTestAction.PerformPreExistingB3MultiRequest -> {
                 networkTestingRepository.performPreExistingB3MultiRequest()
             }
+            is NetworkTestAction.PerformPreExistingDatadogRequest -> {
+                networkTestingRepository.performPreExistingDatadogRequest()
+            }
             is NetworkTestAction.PerformLocalBackendAddToCartRequest -> {
                 networkTestingRepository.performLocalBackendAddToCartRequest()
             }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -120,11 +120,8 @@ class MainViewModel(
             is DiagnosticsAction.TriggerRandomAnrCrash -> triggerRandomAnrCrash()
             is DiagnosticsAction.UpdateAppExitReason -> updateAppExitReason(action.reason)
 
-            is NetworkTestAction.PerformOkHttpRequestManual -> {
+            is NetworkTestAction.PerformOkHttpRequest -> {
                 networkTestingRepository.performOkHttpRequest()
-            }
-            is NetworkTestAction.PerformOkHttpRequestAutomatic -> {
-                networkTestingRepository.performOkHttpRequestAutomatic()
             }
             is NetworkTestAction.PerformGraphQlRequest -> {
                 networkTestingRepository.performGraphQlRequest()

--- a/platform/swift/source/RuntimeVariable.swift
+++ b/platform/swift/source/RuntimeVariable.swift
@@ -157,6 +157,7 @@ extension RuntimeVariable<String> {
     /// - "w3c": use the W3C `traceparent` header
     /// - "b3-single": use the Zipkin B3 `b3` header
     /// - "b3-multi": use the Zipkin B3 `X-B3-*` headers
+    /// - "dd": use the Datadog `x-datadog-*` headers
     static let tracePropagationMode = RuntimeVariable(
         name: "client_config.trace.propagation_mode",
         defaultValue: "w3c"

--- a/platform/swift/source/RuntimeVariable.swift
+++ b/platform/swift/source/RuntimeVariable.swift
@@ -162,4 +162,23 @@ extension RuntimeVariable<String> {
         name: "client_config.trace.propagation_mode",
         defaultValue: "w3c"
     )
+
+    /// Comma-separated list (CSV) of request paths used to match requests that should be ignored.
+    ///
+    /// Example: `/api/v2/spans,/api/v2/logs`
+    static let networkRequestIgnorePathsCSV = RuntimeVariable(
+        name: "client_config.network.request_ignore_match_paths",
+        defaultValue: ""
+    )
+
+    /// Comma-separated list (CSV) of request headers used to match requests that should be ignored.
+    ///
+    /// If paths and headers are both configured, both must match.
+    /// If only one is configured, only that matcher is used.
+    ///
+    /// Example: `DD-EVP-ORIGIN,Some-Other-Header`
+    static let networkRequestIgnoreRequiredHeadersCSV = RuntimeVariable(
+        name: "client_config.network.request_ignore_match_headers",
+        defaultValue: ""
+    )
 }

--- a/platform/swift/source/integrations/url_session/TracePropagation.swift
+++ b/platform/swift/source/integrations/url_session/TracePropagation.swift
@@ -12,6 +12,7 @@ enum URLSessionTracePropagationMode {
     case w3c
     case b3Single
     case b3Multi
+    case datadog
     case disabled
 
     init(runtimeValue: String) {
@@ -25,6 +26,8 @@ enum URLSessionTracePropagationMode {
             self = .b3Single
         case "b3-multi":
             self = .b3Multi
+        case "dd":
+            self = .datadog
         case "w3c":
             self = .w3c
         default:
@@ -40,6 +43,9 @@ enum URLSessionTracePropagation {
     static let xB3TraceIDHeader = "X-B3-TraceId"
     static let xB3SpanIDHeader = "X-B3-SpanId"
     static let xB3SampledHeader = "X-B3-Sampled"
+    static let xDatadogTraceIDHeader = "x-datadog-trace-id"
+    static let xDatadogParentIDHeader = "x-datadog-parent-id"
+    static let xDatadogSamplingPriorityHeader = "x-datadog-sampling-priority"
 
     static func traceparentValue(traceContext: URLSessionTraceContext) -> String {
         "00-\(traceContext.traceID)-\(traceContext.spanID)-01"
@@ -60,6 +66,7 @@ enum URLSessionTracePropagation {
         return headers[traceparentHeader] != nil
             || headers[b3Header] != nil
             || headers[xB3TraceIDHeader] != nil
+            || headers[xDatadogTraceIDHeader] != nil
     }
 
     /// Extracts the trace ID from known tracing headers only when the trace is sampled.
@@ -97,6 +104,14 @@ enum URLSessionTracePropagation {
             return traceID
         }
 
+        if let traceID = headers[xDatadogTraceIDHeader] {
+            let sampled = headers[xDatadogSamplingPriorityHeader]
+            // Datadog sampling priority values: 1 = AUTO_KEEP, 2 = USER_KEEP
+            if sampled == "1" || sampled == "2" {
+                return UInt64(traceID).flatMap { $0 > 0 ? traceID : nil }
+            }
+        }
+
         return nil
     }
 }
@@ -104,6 +119,14 @@ enum URLSessionTracePropagation {
 struct URLSessionTraceContext {
     let traceID: String
     let spanID: String
+
+    var datadogTraceID: String? {
+        Self.hexToDecimal(String(self.traceID.suffix(16)))
+    }
+
+    var datadogParentID: String? {
+        Self.hexToDecimal(self.spanID)
+    }
 
     static func make() -> URLSessionTraceContext {
         URLSessionTraceContext(traceID: Self.hexString(byteCount: 16), spanID: Self.hexString(byteCount: 8))
@@ -127,5 +150,9 @@ struct URLSessionTraceContext {
         }
 
         return String(decoding: output, as: UTF8.self)
+    }
+
+    private static func hexToDecimal(_ hex: String) -> String? {
+        UInt64(hex, radix: 16).map(String.init)
     }
 }

--- a/platform/swift/source/integrations/url_session/TracePropagation.swift
+++ b/platform/swift/source/integrations/url_session/TracePropagation.swift
@@ -44,8 +44,21 @@ enum URLSessionTracePropagation {
     static let xB3SpanIDHeader = "X-B3-SpanId"
     static let xB3SampledHeader = "X-B3-Sampled"
     static let xDatadogTraceIDHeader = "x-datadog-trace-id"
-    static let xDatadogParentIDHeader = "x-datadog-parent-id"
     static let xDatadogSamplingPriorityHeader = "x-datadog-sampling-priority"
+
+    static func extractSampledTraceID(
+        from headers: [String: String]?,
+        configuredPropagationMode: URLSessionTracePropagationMode
+    ) -> String?
+    {
+        guard configuredPropagationMode == .datadog else {
+            return extractSampledTraceID(from: headers)
+        }
+
+        return extractSampledDatadogTraceID(from: headers)
+            ?? extractSampledW3CTraceIDAsDatadogDecimal(from: headers)
+            ?? extractSampledTraceID(from: headers)
+    }
 
     static func traceparentValue(traceContext: URLSessionTraceContext) -> String {
         "00-\(traceContext.traceID)-\(traceContext.spanID)-01"
@@ -104,6 +117,27 @@ enum URLSessionTracePropagation {
             return traceID
         }
 
+        return extractSampledDatadogTraceID(from: headers)
+    }
+
+    private static func extractSampledW3CTraceIDAsDatadogDecimal(from headers: [String: String]?) -> String? {
+        guard let headers else { return nil }
+        guard let traceparent = headers[traceparentHeader] else { return nil }
+
+        let parts = traceparent.split(separator: "-")
+        guard parts.count >= 4,
+              let flags = UInt8(parts[3], radix: 16),
+              flags & 0x01 == 1
+        else {
+            return nil
+        }
+
+        let low64TraceID = String(parts[1].suffix(16))
+        return UInt64(low64TraceID, radix: 16).map(String.init)
+    }
+
+    private static func extractSampledDatadogTraceID(from headers: [String: String]?) -> String? {
+        guard let headers else { return nil }
         if let traceID = headers[xDatadogTraceIDHeader] {
             let sampled = headers[xDatadogSamplingPriorityHeader]
             // Datadog sampling priority values: 1 = AUTO_KEEP, 2 = USER_KEEP
@@ -116,16 +150,54 @@ enum URLSessionTracePropagation {
     }
 }
 
+protocol URLSessionRequestIgnorePolicy {
+    func shouldIgnore(_ request: URLRequest?) -> Bool
+}
+
+struct RuntimeURLSessionIgnorePolicy: URLSessionRequestIgnorePolicy {
+    private let ignorePaths: Set<String>
+    private let requiredHeaders: Set<String>
+
+    init(ignorePathsCSV: String, requiredHeadersCSV: String) {
+        self.ignorePaths = Self.readCSV(ignorePathsCSV)
+        self.requiredHeaders = Self.readCSV(requiredHeadersCSV)
+    }
+
+    func shouldIgnore(_ request: URLRequest?) -> Bool {
+        guard let request else { return false }
+
+        let hasIgnoredPaths = !ignorePaths.isEmpty
+        let hasRequiredHeaders = !requiredHeaders.isEmpty
+        if !hasIgnoredPaths && !hasRequiredHeaders {
+            return false
+        }
+
+        let matchesIgnoredPath = request.url.map { ignorePaths.contains($0.path) } ?? false
+        let matchesRequiredHeader = requiredHeaders.contains { request.value(forHTTPHeaderField: $0) != nil }
+
+        switch (hasIgnoredPaths, hasRequiredHeaders) {
+        case (true, true):
+            return matchesIgnoredPath && matchesRequiredHeader
+        case (true, false):
+            return matchesIgnoredPath
+        case (false, true):
+            return matchesRequiredHeader
+        case (false, false):
+            return false
+        }
+    }
+
+    private static func readCSV(_ value: String) -> Set<String> {
+        Set(value.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty })
+    }
+}
+
 struct URLSessionTraceContext {
     let traceID: String
     let spanID: String
 
     var datadogTraceID: String? {
         Self.hexToDecimal(String(self.traceID.suffix(16)))
-    }
-
-    var datadogParentID: String? {
-        Self.hexToDecimal(self.spanID)
     }
 
     static func make() -> URLSessionTraceContext {

--- a/platform/swift/source/integrations/url_session/TracePropagation.swift
+++ b/platform/swift/source/integrations/url_session/TracePropagation.swift
@@ -175,16 +175,13 @@ struct RuntimeURLSessionIgnorePolicy: URLSessionRequestIgnorePolicy {
         let matchesIgnoredPath = request.url.map { ignorePaths.contains($0.path) } ?? false
         let matchesRequiredHeader = requiredHeaders.contains { request.value(forHTTPHeaderField: $0) != nil }
 
-        switch (hasIgnoredPaths, hasRequiredHeaders) {
-        case (true, true):
+        if hasIgnoredPaths && hasRequiredHeaders {
             return matchesIgnoredPath && matchesRequiredHeader
-        case (true, false):
+        } else if hasIgnoredPaths {
             return matchesIgnoredPath
-        case (false, true):
-            return matchesRequiredHeader
-        case (false, false):
-            return false
         }
+
+        return matchesRequiredHeader
     }
 
     private static func readCSV(_ value: String) -> Set<String> {

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -55,6 +55,7 @@ final class URLSessionIntegration {
     private let underlyingRequestFieldProvider = Atomic<URLSessionRequestFieldProvider?>(nil)
     /// The field provider for adding custom fields to response logs
     private let underlyingResponseFieldProvider = Atomic<URLSessionResponseFieldProvider?>(nil)
+    private let underlyingRequestIgnorePolicy = Atomic<URLSessionRequestIgnorePolicy?>(nil)
     fileprivate static var swizzled = Atomic(false)
     static let shared = URLSessionIntegration()
 
@@ -79,20 +80,14 @@ final class URLSessionIntegration {
         return URLSessionTracePropagationMode(runtimeValue: runtimeValue)
     }
 
-    var requestIgnorePathsCSV: String {
-        guard let logger = Logger.getShared() as? Logger else {
-            return RuntimeVariable<String>.networkRequestIgnorePathsCSV.defaultValue
+    var requestIgnorePolicy: URLSessionRequestIgnorePolicy {
+        if let policy = self.underlyingRequestIgnorePolicy.load() {
+            return policy
         }
 
-        return logger.runtimeValue(.networkRequestIgnorePathsCSV)
-    }
-
-    var requestIgnoreRequiredHeadersCSV: String {
-        guard let logger = Logger.getShared() as? Logger else {
-            return RuntimeVariable<String>.networkRequestIgnoreRequiredHeadersCSV.defaultValue
-        }
-
-        return logger.runtimeValue(.networkRequestIgnoreRequiredHeadersCSV)
+        let policy = self.makeRequestIgnorePolicy()
+        self.underlyingRequestIgnorePolicy.update { $0 = policy }
+        return policy
     }
 
     var isTracingActive: Bool {
@@ -108,6 +103,7 @@ final class URLSessionIntegration {
         self.underlyingLogger.update { $0 = logger }
         self.underlyingRequestFieldProvider.update { $0 = requestFieldProvider }
         self.underlyingResponseFieldProvider.update { $0 = responseFieldProvider }
+        self.underlyingRequestIgnorePolicy.update { $0 = self.makeRequestIgnorePolicy() }
         if disableSwizzling || Self.swizzled.load() {
             return
         }
@@ -140,6 +136,20 @@ final class URLSessionIntegration {
         defer { task.cancel() }
 
         return type(of: task)
+    }
+
+    private func makeRequestIgnorePolicy() -> URLSessionRequestIgnorePolicy {
+        guard let logger = Logger.getShared() as? Logger else {
+            return RuntimeURLSessionIgnorePolicy(
+                ignorePathsCSV: RuntimeVariable<String>.networkRequestIgnorePathsCSV.defaultValue,
+                requiredHeadersCSV: RuntimeVariable<String>.networkRequestIgnoreRequiredHeadersCSV.defaultValue,
+                )
+        }
+
+        return RuntimeURLSessionIgnorePolicy(
+            ignorePathsCSV: logger.runtimeValue(.networkRequestIgnorePathsCSV),
+            requiredHeadersCSV: logger.runtimeValue(.networkRequestIgnoreRequiredHeadersCSV),
+            )
     }
 }
 

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -79,6 +79,22 @@ final class URLSessionIntegration {
         return URLSessionTracePropagationMode(runtimeValue: runtimeValue)
     }
 
+    var requestIgnorePathsCSV: String {
+        guard let logger = Logger.getShared() as? Logger else {
+            return RuntimeVariable<String>.networkRequestIgnorePathsCSV.defaultValue
+        }
+
+        return logger.runtimeValue(.networkRequestIgnorePathsCSV)
+    }
+
+    var requestIgnoreRequiredHeadersCSV: String {
+        guard let logger = Logger.getShared() as? Logger else {
+            return RuntimeVariable<String>.networkRequestIgnoreRequiredHeadersCSV.defaultValue
+        }
+
+        return logger.runtimeValue(.networkRequestIgnoreRequiredHeadersCSV)
+    }
+
     var isTracingActive: Bool {
         (Logger.getShared() as? Logger)?.isTracingActive == true
     }

--- a/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionIntegration.swift
@@ -103,7 +103,7 @@ final class URLSessionIntegration {
         self.underlyingLogger.update { $0 = logger }
         self.underlyingRequestFieldProvider.update { $0 = requestFieldProvider }
         self.underlyingResponseFieldProvider.update { $0 = responseFieldProvider }
-        self.underlyingRequestIgnorePolicy.update { $0 = self.makeRequestIgnorePolicy() }
+        self.underlyingRequestIgnorePolicy.update { $0 = nil }
         if disableSwizzling || Self.swizzled.load() {
             return
         }
@@ -160,5 +160,12 @@ extension URLSessionIntegration {
         if Self.swizzled.load() {
             self.toggleURLSessionTaskSwizzling()
         }
+    }
+
+    func resetForTests() {
+        self.underlyingLogger.update { $0 = nil }
+        self.underlyingRequestFieldProvider.update { $0 = nil }
+        self.underlyingResponseFieldProvider.update { $0 = nil }
+        self.underlyingRequestIgnorePolicy.update { $0 = nil }
     }
 }

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -91,6 +91,15 @@ final class URLSessionTaskTracker {
             return
         }
 
+        let integration = URLSessionIntegration.shared
+        let ignorePolicy = RuntimeURLSessionIgnorePolicy(
+            ignorePathsCSV: integration.requestIgnorePathsCSV,
+            requiredHeadersCSV: integration.requestIgnoreRequiredHeadersCSV,
+            )
+        if ignorePolicy.shouldIgnore(task.originalRequest) {
+            return
+        }
+
         self.lock.withLock {
             guard task.cap_requestInfo == nil else {
                 // Defensive check in case we've logged a request for a given task already.
@@ -99,7 +108,7 @@ final class URLSessionTaskTracker {
 
             var extraFields: Fields?
             if let originalRequest = task.originalRequest {
-                extraFields = URLSessionIntegration.shared.requestFieldProvider?.provideExtraFields(for: originalRequest)
+                extraFields = integration.requestFieldProvider?.provideExtraFields(for: originalRequest)
             }
             extraFields = Self.enrichExtraFields(extraFields, with: Self.ensureTraceContext(for: task))
             guard let requestInfo = HTTPRequestInfo(task: task, extraFields: extraFields) else {
@@ -107,7 +116,7 @@ final class URLSessionTaskTracker {
             }
 
             task.cap_requestInfo = requestInfo
-            URLSessionIntegration.shared.logger?.log(requestInfo, file: nil, line: nil, function: nil)
+            integration.logger?.log(requestInfo, file: nil, line: nil, function: nil)
         }
     }
 

--- a/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
+++ b/platform/swift/source/integrations/url_session/URLSessionTaskTracker.swift
@@ -92,10 +92,7 @@ final class URLSessionTaskTracker {
         }
 
         let integration = URLSessionIntegration.shared
-        let ignorePolicy = RuntimeURLSessionIgnorePolicy(
-            ignorePathsCSV: integration.requestIgnorePathsCSV,
-            requiredHeadersCSV: integration.requestIgnoreRequiredHeadersCSV,
-            )
+        let ignorePolicy = integration.requestIgnorePolicy
         if ignorePolicy.shouldIgnore(task.originalRequest) {
             return
         }

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -34,15 +34,24 @@ extension URLSessionTask {
             return
         }
 
+        let ignorePolicy = RuntimeURLSessionIgnorePolicy(
+            ignorePathsCSV: integration.requestIgnorePathsCSV,
+            requiredHeadersCSV: integration.requestIgnoreRequiredHeadersCSV,
+            )
+
         let existingHeaders = self.originalRequest?.allHTTPHeaderFields
 
         guard !URLSessionTracePropagation.isBitdriftInternalRequest(existingHeaders) else {
             return
         }
 
+        guard !ignorePolicy.shouldIgnore(self.originalRequest) else {
+            return
+        }
+
         if URLSessionTracePropagation.hasExistingTraceHeaders(in: existingHeaders) {
             self.cap_hasExistingTraceHeaders = true
-            if let sampledTraceID = URLSessionTracePropagation.extractSampledTraceID(from: existingHeaders) {
+            if let sampledTraceID = URLSessionTracePropagation.extractSampledTraceID(from: existingHeaders, configuredPropagationMode: mode) {
                 self.cap_traceContext = URLSessionTraceContext(traceID: sampledTraceID, spanID: "")
             }
             return
@@ -75,7 +84,6 @@ extension URLSessionTask {
             mutableRequest.setValue("1", forHTTPHeaderField: URLSessionTracePropagation.xB3SampledHeader)
         case .datadog:
             mutableRequest.setValue(traceContext.datadogTraceID, forHTTPHeaderField: URLSessionTracePropagation.xDatadogTraceIDHeader)
-            mutableRequest.setValue(traceContext.datadogParentID, forHTTPHeaderField: URLSessionTracePropagation.xDatadogParentIDHeader)
             mutableRequest.setValue("2", forHTTPHeaderField: URLSessionTracePropagation.xDatadogSamplingPriorityHeader)
         case .disabled:
             break

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -73,6 +73,10 @@ extension URLSessionTask {
             mutableRequest.setValue(traceContext.traceID, forHTTPHeaderField: URLSessionTracePropagation.xB3TraceIDHeader)
             mutableRequest.setValue(traceContext.spanID, forHTTPHeaderField: URLSessionTracePropagation.xB3SpanIDHeader)
             mutableRequest.setValue("1", forHTTPHeaderField: URLSessionTracePropagation.xB3SampledHeader)
+        case .datadog:
+            mutableRequest.setValue(traceContext.datadogTraceID, forHTTPHeaderField: URLSessionTracePropagation.xDatadogTraceIDHeader)
+            mutableRequest.setValue(traceContext.datadogParentID, forHTTPHeaderField: URLSessionTracePropagation.xDatadogParentIDHeader)
+            mutableRequest.setValue("2", forHTTPHeaderField: URLSessionTracePropagation.xDatadogSamplingPriorityHeader)
         case .disabled:
             break
         }

--- a/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
+++ b/platform/swift/source/integrations/url_session/extensions/URLSessionTask+Swizzling.swift
@@ -34,10 +34,7 @@ extension URLSessionTask {
             return
         }
 
-        let ignorePolicy = RuntimeURLSessionIgnorePolicy(
-            ignorePathsCSV: integration.requestIgnorePathsCSV,
-            requiredHeadersCSV: integration.requestIgnoreRequiredHeadersCSV,
-            )
+        let ignorePolicy = integration.requestIgnorePolicy
 
         let existingHeaders = self.originalRequest?.allHTTPHeaderFields
 

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -1141,6 +1141,29 @@ final class URLSessionTracePropagationTests: XCTestCase {
         session.invalidateAndCancel()
     }
 
+    func testCapResume_whenDatadogEnabled_shouldInjectDatadogHeaders() throws {
+        self.loggerBridge.tracingActive = true
+        self.loggerBridge.mockRuntimeVariable(.tracePropagationMode, with: "dd")
+
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: URL(staticString: "https://api-fe.bitdrift.io/fe/ping?q=test"))
+
+        task.resume()
+
+        let traceContext = try XCTUnwrap(task.cap_traceContext)
+        let headers = task.originalRequest?.allHTTPHeaderFields
+        XCTAssertEqual(headers?["x-datadog-trace-id"], traceContext.datadogTraceID)
+        XCTAssertEqual(headers?["x-datadog-parent-id"], traceContext.datadogParentID)
+        XCTAssertEqual(headers?["x-datadog-sampling-priority"], "2")
+
+        XCTAssertNil(headers?["traceparent"])
+        XCTAssertNil(headers?["b3"])
+        XCTAssertNil(headers?["X-B3-TraceId"])
+
+        task.cancel()
+        session.invalidateAndCancel()
+    }
+
     // MARK: - Bitdrift internal request exclusion
 
     func testCapResume_withBitdriftApiKey_shouldNotAttachTraceContext() throws {
@@ -1261,6 +1284,56 @@ final class URLSessionTracePropagationTests: XCTestCase {
         session.invalidateAndCancel()
     }
 
+    func testCapResume_withExistingDatadog_sampled_shouldExtractTraceIDAndSkipInjection() throws {
+        self.loggerBridge.tracingActive = true
+        self.loggerBridge.mockRuntimeVariable(.tracePropagationMode, with: "dd")
+
+        var request = URLRequest(url: URL(staticString: "https://api-fe.bitdrift.io/fe/ping?q=test"))
+        request.setValue("5498017814432956682", forHTTPHeaderField: "x-datadog-trace-id")
+        request.setValue("4063799684456813420", forHTTPHeaderField: "x-datadog-parent-id")
+        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: request)
+
+        task.resume()
+
+        let traceContext = try XCTUnwrap(task.cap_traceContext)
+        XCTAssertEqual(traceContext.traceID, "5498017814432956682")
+        XCTAssertEqual(traceContext.spanID, "")
+
+        let headers = task.originalRequest?.allHTTPHeaderFields
+        XCTAssertEqual(headers?["x-datadog-trace-id"], "5498017814432956682")
+        XCTAssertEqual(headers?["x-datadog-parent-id"], "4063799684456813420")
+        XCTAssertEqual(headers?["x-datadog-sampling-priority"], "1")
+
+        task.cancel()
+        session.invalidateAndCancel()
+    }
+
+    func testCapResume_withExistingDatadog_notSampled_shouldSkipTraceContext() throws {
+        self.loggerBridge.tracingActive = true
+        self.loggerBridge.mockRuntimeVariable(.tracePropagationMode, with: "dd")
+
+        var request = URLRequest(url: URL(staticString: "https://api-fe.bitdrift.io/fe/ping?q=test"))
+        request.setValue("5498017814432956682", forHTTPHeaderField: "x-datadog-trace-id")
+        request.setValue("0", forHTTPHeaderField: "x-datadog-sampling-priority")
+
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: request)
+
+        task.resume()
+
+        XCTAssertNil(task.cap_traceContext)
+        XCTAssertTrue(task.cap_hasExistingTraceHeaders)
+
+        let headers = task.originalRequest?.allHTTPHeaderFields
+        XCTAssertEqual(headers?["x-datadog-trace-id"], "5498017814432956682")
+
+        task.cancel()
+        session.invalidateAndCancel()
+    }
+
     func testCapResume_withExistingTraceparent_notSampled_shouldSkipTraceContext() throws {
         self.loggerBridge.tracingActive = true
         self.loggerBridge.mockRuntimeVariable(.tracePropagationMode, with: "w3c")
@@ -1367,6 +1440,11 @@ final class URLSessionTracePropagationDetectionTests: XCTestCase {
 
     func testHasExistingTraceHeaders_withB3Multi() {
         let headers = ["X-B3-TraceId": "abcdef1234567890abcdef1234567890"]
+        XCTAssertTrue(URLSessionTracePropagation.hasExistingTraceHeaders(in: headers))
+    }
+
+    func testHasExistingTraceHeaders_withDatadog() {
+        let headers = ["x-datadog-trace-id": "5498017814432956682"]
         XCTAssertTrue(URLSessionTracePropagation.hasExistingTraceHeaders(in: headers))
     }
 
@@ -1482,6 +1560,52 @@ final class URLSessionTracePropagationExtractionTests: XCTestCase {
 
     func testExtractSampledTraceID_fromB3Multi_missingSampled() {
         let headers = ["X-B3-TraceId": "abcdef1234567890abcdef1234567890"]
+        XCTAssertNil(URLSessionTracePropagation.extractSampledTraceID(from: headers))
+    }
+
+    func testExtractSampledTraceID_fromDatadog_sampled() {
+        let headers = [
+            "x-datadog-trace-id": "5498017814432956682",
+            "x-datadog-sampling-priority": "1",
+        ]
+        XCTAssertEqual(
+            URLSessionTracePropagation.extractSampledTraceID(from: headers),
+            "5498017814432956682"
+        )
+    }
+
+    func testExtractSampledTraceID_fromDatadog_userKeep() {
+        let headers = [
+            "x-datadog-trace-id": "5498017814432956682",
+            "x-datadog-sampling-priority": "2",
+        ]
+        XCTAssertEqual(
+            URLSessionTracePropagation.extractSampledTraceID(from: headers),
+            "5498017814432956682"
+        )
+    }
+
+    func testExtractSampledTraceID_fromDatadog_notSampled() {
+        let headers = [
+            "x-datadog-trace-id": "5498017814432956682",
+            "x-datadog-sampling-priority": "0",
+        ]
+        XCTAssertNil(URLSessionTracePropagation.extractSampledTraceID(from: headers))
+    }
+
+    func testExtractSampledTraceID_fromDatadog_invalidTraceID() {
+        let headers = [
+            "x-datadog-trace-id": "abc",
+            "x-datadog-sampling-priority": "1",
+        ]
+        XCTAssertNil(URLSessionTracePropagation.extractSampledTraceID(from: headers))
+    }
+
+    func testExtractSampledTraceID_fromDatadog_zeroTraceID() {
+        let headers = [
+            "x-datadog-trace-id": "0",
+            "x-datadog-sampling-priority": "1",
+        ]
         XCTAssertNil(URLSessionTracePropagation.extractSampledTraceID(from: headers))
     }
 

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -1153,12 +1153,57 @@ final class URLSessionTracePropagationTests: XCTestCase {
         let traceContext = try XCTUnwrap(task.cap_traceContext)
         let headers = task.originalRequest?.allHTTPHeaderFields
         XCTAssertEqual(headers?["x-datadog-trace-id"], traceContext.datadogTraceID)
-        XCTAssertEqual(headers?["x-datadog-parent-id"], traceContext.datadogParentID)
+        XCTAssertNil(headers?["x-datadog-parent-id"])
         XCTAssertEqual(headers?["x-datadog-sampling-priority"], "2")
 
         XCTAssertNil(headers?["traceparent"])
         XCTAssertNil(headers?["b3"])
         XCTAssertNil(headers?["X-B3-TraceId"])
+
+        task.cancel()
+        session.invalidateAndCancel()
+    }
+
+    func testCapResume_withExistingTraceparentInDatadogMode_shouldExtractDatadogLinkableTraceID() throws {
+        self.loggerBridge.tracingActive = true
+        self.loggerBridge.mockRuntimeVariable(.tracePropagationMode, with: "dd")
+
+        var request = URLRequest(url: URL(staticString: "https://api-fe.bitdrift.io/fe/ping?q=test"))
+        request.setValue("00-88c131f5a4a41657a4cc039862759571-1234567890abcdef-01", forHTTPHeaderField: "traceparent")
+
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: request)
+
+        task.resume()
+
+        let traceContext = try XCTUnwrap(task.cap_traceContext)
+        XCTAssertEqual(traceContext.traceID, "11874870270490940785")
+        XCTAssertEqual(traceContext.spanID, "")
+
+        task.cancel()
+        session.invalidateAndCancel()
+    }
+
+    func testCapResume_withIgnoredDatadogIntakeRequest_shouldSkipTraceContext() throws {
+        self.loggerBridge.tracingActive = true
+        self.loggerBridge.mockRuntimeVariable(.tracePropagationMode, with: "dd")
+        self.loggerBridge.mockRuntimeVariable(.networkRequestIgnorePathsCSV, with: "/api/v2/spans")
+        self.loggerBridge.mockRuntimeVariable(.networkRequestIgnoreRequiredHeadersCSV, with: "DD-EVP-ORIGIN")
+
+        var request = URLRequest(url: URL(staticString: "https://app.datadoghq.com/api/v2/spans"))
+        request.setValue("android", forHTTPHeaderField: "DD-EVP-ORIGIN")
+
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: request)
+
+        task.resume()
+
+        XCTAssertNil(task.cap_traceContext)
+        XCTAssertFalse(task.cap_hasExistingTraceHeaders)
+
+        let headers = task.originalRequest?.allHTTPHeaderFields
+        XCTAssertNil(headers?["x-datadog-trace-id"])
+        XCTAssertNil(headers?["traceparent"])
 
         task.cancel()
         session.invalidateAndCancel()
@@ -1304,7 +1349,6 @@ final class URLSessionTracePropagationTests: XCTestCase {
 
         let headers = task.originalRequest?.allHTTPHeaderFields
         XCTAssertEqual(headers?["x-datadog-trace-id"], "5498017814432956682")
-        XCTAssertEqual(headers?["x-datadog-parent-id"], "4063799684456813420")
         XCTAssertEqual(headers?["x-datadog-sampling-priority"], "1")
 
         task.cancel()
@@ -1607,6 +1651,14 @@ final class URLSessionTracePropagationExtractionTests: XCTestCase {
             "x-datadog-sampling-priority": "1",
         ]
         XCTAssertNil(URLSessionTracePropagation.extractSampledTraceID(from: headers))
+    }
+
+    func testExtractSampledTraceID_fromW3C_inDatadogMode_returnsDatadogLinkableTraceID() {
+        let headers = ["traceparent": "00-88c131f5a4a41657a4cc039862759571-1234567890abcdef-01"]
+        XCTAssertEqual(
+            URLSessionTracePropagation.extractSampledTraceID(from: headers, configuredPropagationMode: .datadog),
+            "11874870270490940785"
+        )
     }
 
     func testExtractSampledTraceID_prefersW3COverB3() {

--- a/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/integrations/URLSessionIntegrationTests.swift
@@ -975,6 +975,7 @@ final class URLSessionTracePropagationTests: XCTestCase {
         super.setUp()
         self.loggerBridge = MockLoggerBridging()
         URLSessionIntegration.shared.disableURLSessionTaskSwizzling()
+        URLSessionIntegration.shared.resetForTests()
 
         let logger: Logger? = Logger(
             withAPIKey: "123",
@@ -1004,6 +1005,7 @@ final class URLSessionTracePropagationTests: XCTestCase {
 
     override func tearDown() {
         URLSessionIntegration.shared.disableURLSessionTaskSwizzling()
+        URLSessionIntegration.shared.resetForTests()
         Logger.resetShared()
         super.tearDown()
     }


### PR DESCRIPTION
## Goal

Add Datadog trace propagation support.

## Summary

- add Datadog propagation support
- in `dd` mode, keep `_trace_id` Datadog-linkable even when requests already have W3C headers
- add runtime-configurable request ignore rules so Datadog uploader requests can be excluded (`client_config.network.request_ignore_match_paths` and `client_config.network.request_ignore_match_headers`)

## Verification

Use `gradle-test-app`.

<img width="377" height="607" alt="Screenshot 2026-07-10 at 11 38 35" src="https://github.com/user-attachments/assets/164517dc-74b3-4d09-8fea-aa5909b59a43" />

Checks:
- `client_config.trace.propagation_mode=dd`
- requests without existing trace headers log DD decimal `_trace_id`
- requests with existing sampled W3C headers still log DD-linkable `_trace_id`
- existing DD headers pass through unchanged
- ignored uploader requests do not show up as app spans

Example session:
- [session](https://timeline.bitdrift.dev/s/7678d855-4980-4f1e-914f-615ed50ac914?utm_source=sdk)

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
