### PR TITLE
[Android] Optimize Capture.Logger.start call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- Improving performance of Capture.Logger.start call
 
 ### iOS
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/DeviceCodeService.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/DeviceCodeService.kt
@@ -9,10 +9,10 @@ package io.bitdrift.capture
 
 import com.google.gson.annotations.SerializedName
 import io.bitdrift.capture.network.okhttp.HttpApiEndpoint
-import io.bitdrift.capture.network.okhttp.OkHttpApiClient
+import io.bitdrift.capture.network.okhttp.OkHttpCaptureApiClient
 
 internal class DeviceCodeService(
-    private val apiClient: OkHttpApiClient,
+    private val apiClient: Lazy<OkHttpCaptureApiClient>,
 ) {
     fun createTemporaryDeviceCode(
         deviceId: String,
@@ -20,7 +20,7 @@ internal class DeviceCodeService(
     ) {
         val typedRequest = DeviceCodeRequest(deviceId)
 
-        apiClient.perform<DeviceCodeRequest, DeviceCodeResponse>(
+        apiClient.value.perform<DeviceCodeRequest, DeviceCodeResponse>(
             HttpApiEndpoint.GetTemporaryDeviceCode,
             typedRequest,
         ) { result ->

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -39,8 +39,8 @@ import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
-import io.bitdrift.capture.network.okhttp.OkHttpApiClient
-import io.bitdrift.capture.network.okhttp.OkHttpNetwork
+import io.bitdrift.capture.network.okhttp.OkHttpCaptureApiClient
+import io.bitdrift.capture.network.okhttp.OkHttpCaptureStream
 import io.bitdrift.capture.network.okhttp.buildSharedOkHttpClient
 import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.DateProvider
@@ -94,7 +94,12 @@ internal class LoggerImpl(
         ),
     preferences: IPreferences = Preferences(context),
     sharedOkHttpClient: OkHttpClient = buildSharedOkHttpClient(),
-    private val apiClient: OkHttpApiClient = OkHttpApiClient(apiUrl, apiKey, client = sharedOkHttpClient),
+    // This client is only used for temporary device code creation and internal
+    // SDK error reporting, so defer constructing it until one of those paths runs.
+    private val apiClient: Lazy<OkHttpCaptureApiClient> =
+        lazy {
+            OkHttpCaptureApiClient(apiUrl, apiKey, client = sharedOkHttpClient)
+        },
     private var deviceCodeService: DeviceCodeService = DeviceCodeService(apiClient),
     activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager,
     bridge: IBridge = CaptureJniLibrary,
@@ -116,9 +121,17 @@ internal class LoggerImpl(
     private val runtime: JniRuntime
     private var jankStatsMonitor: JankStatsMonitor? = null
 
-    // we can assume a properly formatted api url is being used, so we can follow the same pattern
-    // making sure we only replace the first occurrence
-    private val sessionUrlBase: HttpUrl
+    // Session URLs are only needed when queried externally, so derive the
+    // timeline base URL on first access. We replace only the first "api."
+    // prefix when converting the Capture API host to the timeline host.
+    private val sessionUrlBase: HttpUrl by lazy {
+        HttpUrl
+            .Builder()
+            .scheme("https")
+            .host(apiUrl.host.replaceFirst("api.", "timeline."))
+            .addQueryParameter("utm_source", "sdk")
+            .build()
+    }
 
     private val resourceUtilizationTarget: ResourceUtilizationTarget
     private val eventsListenerTarget = EventsListenerTarget()
@@ -148,14 +161,6 @@ internal class LoggerImpl(
     internal val loggerId: LoggerId
 
     init {
-        this.sessionUrlBase =
-            HttpUrl
-                .Builder()
-                .scheme("https")
-                .host(apiUrl.host.replaceFirst("api.", "timeline."))
-                .addQueryParameter("utm_source", "sdk")
-                .build()
-
         val networkAttributes = NetworkAttributes(context)
 
         metadataProvider =
@@ -173,7 +178,7 @@ internal class LoggerImpl(
             )
 
         val network =
-            OkHttpNetwork(
+            OkHttpCaptureStream(
                 apiBaseUrl = apiUrl,
                 okHttpClient = sharedOkHttpClient,
             )

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/error/ErrorReporterService.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/error/ErrorReporterService.kt
@@ -12,12 +12,12 @@ import com.google.gson.annotations.SerializedName
 import io.bitdrift.capture.ApiError
 import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.network.okhttp.HttpApiEndpoint
-import io.bitdrift.capture.network.okhttp.OkHttpApiClient
+import io.bitdrift.capture.network.okhttp.OkHttpCaptureApiClient
 import io.bitdrift.capture.providers.FieldProvider
 
 internal class ErrorReporterService(
     private val fieldProviders: List<FieldProvider>,
-    private val apiClient: OkHttpApiClient,
+    private val apiClient: Lazy<OkHttpCaptureApiClient>,
 ) : IErrorReporter {
     private fun headers(): Map<String, String> {
         val map = mutableMapOf<String, String>()
@@ -45,7 +45,7 @@ internal class ErrorReporterService(
                 putAll(fields)
             }
 
-        apiClient.perform<ErrorReportRequest, Unit>(
+        apiClient.value.perform<ErrorReportRequest, Unit>(
             HttpApiEndpoint.ReportSdkError,
             typedRequest,
             allFields,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -17,6 +17,7 @@ import io.bitdrift.capture.IInternalLogger
 import io.bitdrift.capture.LogAttributesOverrides
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.LogType
+import io.bitdrift.capture.common.IBackgroundThreadHandler
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
@@ -29,6 +30,7 @@ import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitReasonResult
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.IJvmCrashListener
+import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.BuildVersionChecker
 
 internal class AppExitLogger(
@@ -38,7 +40,8 @@ internal class AppExitLogger(
     private val memoryMetricsProvider: IMemoryMetricsProvider,
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider,
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler,
-    private val issueReporter: IIssueReporter?,
+    issueReporter: IIssueReporter?,
+    private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
 ) : IJvmCrashListener {
     companion object {
         private const val APP_EXIT_EVENT_NAME = "AppExit"
@@ -56,17 +59,26 @@ internal class AppExitLogger(
         private const val FOREGROUND_KEY = "foreground"
     }
 
+    private val isFatalIssueReportingInitialized = IssueReporterState.Initialized == issueReporter?.initializationState()
+
     @SuppressLint("NewApi")
     fun installAppExitLogger() {
         if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS)) {
             return
         }
-        captureUncaughtExceptionHandler.install(this)
-        logPreviousExitReasonIfAny()
+        if (!isFatalIssueReportingInitialized) {
+            captureUncaughtExceptionHandler.install(this)
+        }
+        backgroundThreadHandler.runAsync {
+            // Ordering is handled at shared-core layer
+            logPreviousExitReasonIfAny()
+        }
     }
 
     fun uninstallAppExitLogger() {
-        captureUncaughtExceptionHandler.uninstall()
+        if (!isFatalIssueReportingInitialized) {
+            captureUncaughtExceptionHandler.uninstall()
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
@@ -101,9 +113,7 @@ internal class AppExitLogger(
         throwable: Throwable,
     ) {
         // When IssueReporterState is Initialized will rely on shared-core to emit the related JVM crash log
-        if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS) ||
-            IssueReporterState.Initialized == issueReporter?.initializationState()
-        ) {
+        if (!runtime.isEnabled(RuntimeFeature.APP_EXIT_EVENTS) || isFatalIssueReportingInitialized) {
             return
         }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLogger.kt
@@ -17,7 +17,6 @@ import io.bitdrift.capture.IInternalLogger
 import io.bitdrift.capture.LogAttributesOverrides
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.LogType
-import io.bitdrift.capture.common.IBackgroundThreadHandler
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
@@ -30,7 +29,6 @@ import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
 import io.bitdrift.capture.reports.exitinfo.LatestAppExitReasonResult
 import io.bitdrift.capture.reports.jvmcrash.ICaptureUncaughtExceptionHandler
 import io.bitdrift.capture.reports.jvmcrash.IJvmCrashListener
-import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.BuildVersionChecker
 
 internal class AppExitLogger(
@@ -41,7 +39,6 @@ internal class AppExitLogger(
     private val latestAppExitInfoProvider: ILatestAppExitInfoProvider,
     private val captureUncaughtExceptionHandler: ICaptureUncaughtExceptionHandler,
     issueReporter: IIssueReporter?,
-    private val backgroundThreadHandler: IBackgroundThreadHandler = CaptureDispatchers.CommonBackground,
 ) : IJvmCrashListener {
     companion object {
         private const val APP_EXIT_EVENT_NAME = "AppExit"
@@ -69,10 +66,7 @@ internal class AppExitLogger(
         if (!isFatalIssueReportingInitialized) {
             captureUncaughtExceptionHandler.install(this)
         }
-        backgroundThreadHandler.runAsync {
-            // Ordering is handled at shared-core layer
-            logPreviousExitReasonIfAny()
-        }
+        logPreviousExitReasonIfAny()
     }
 
     fun uninstallAppExitLogger() {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpCaptureApiClient.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpCaptureApiClient.kt
@@ -31,7 +31,13 @@ internal sealed class HttpApiEndpoint(
     object ReportSdkError : HttpApiEndpoint("v1/sdk-errors")
 }
 
-internal class OkHttpApiClient(
+/**
+ * Small JSON-over-HTTP client for Capture's non-streaming backend APIs.
+ *
+ * This is used for secondary request/response endpoints such as temporary
+ * device code creation and SDK error reporting.
+ */
+internal class OkHttpCaptureApiClient(
     private val apiBaseUrl: HttpUrl,
     private val apiKey: String,
     private val gson: Gson = Gson(),

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpCaptureStream.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/OkHttpCaptureStream.kt
@@ -73,7 +73,11 @@ internal fun newDuplexRequestBody(contentType: MediaType): PipeDuplexRequestBody
         pipeMaxBufferSize = REQUEST_BODY_BUFFER_SIZE.toLong(),
     )
 
-internal class OkHttpNetwork(
+/**
+ * Concrete implementation of [ICaptureNetwork] used for the logger's
+ * long-lived backend stream.
+ */
+internal class OkHttpCaptureStream(
     apiBaseUrl: HttpUrl,
     timeoutSeconds: Long = 2L * 60,
     private val okHttpClient: OkHttpClient,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
@@ -9,7 +9,7 @@ package io.bitdrift.capture
 
 import com.google.common.util.concurrent.MoreExecutors
 import com.nhaarman.mockitokotlin2.mock
-import io.bitdrift.capture.network.okhttp.OkHttpNetwork
+import io.bitdrift.capture.network.okhttp.OkHttpCaptureStream
 import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
@@ -70,7 +70,7 @@ class CaptureLoggerNetworkTest {
         testServerPort = CaptureTestJniLibrary.startTestApiServer(pingIdleTimeout)
 
         val network =
-            OkHttpNetwork(
+            OkHttpCaptureStream(
                 apiBaseUrl = testServerUrl(testServerPort!!),
                 timeoutSeconds = streamTimeoutSeconds,
                 okHttpClient = okHttpClient,
@@ -155,7 +155,7 @@ class CaptureLoggerNetworkTest {
         // We start the logger without starting the test server, so any attempt at connecting
         // to it should immediately fail (connection refused).
         val network =
-            OkHttpNetwork(
+            OkHttpCaptureStream(
                 apiBaseUrl = testServerUrl(50051),
                 timeoutSeconds = 1,
                 okHttpClient = okHttpClient,
@@ -193,7 +193,7 @@ class CaptureLoggerNetworkTest {
     fun large_upload() {
         val port = CaptureTestJniLibrary.startTestApiServer(500)
         val network =
-            OkHttpNetwork(
+            OkHttpCaptureStream(
                 apiBaseUrl = testServerUrl(port),
                 timeoutSeconds = 1,
                 okHttpClient = okHttpClient,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ErrorReporterTest.kt
@@ -12,7 +12,7 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.bitdrift.capture.error.ErrorReportRequest
 import io.bitdrift.capture.error.ErrorReporterService
-import io.bitdrift.capture.network.okhttp.OkHttpApiClient
+import io.bitdrift.capture.network.okhttp.OkHttpCaptureApiClient
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
@@ -44,12 +44,12 @@ class ErrorReporterTest {
         server = MockWebServer()
         server.start()
 
-        val apiClient = OkHttpApiClient(server.url(""), "api-key", client = OkHttpClient())
+        val apiClient = OkHttpCaptureApiClient(server.url(""), "api-key", client = OkHttpClient())
 
         reporter =
             ErrorReporterService(
                 listOf(FieldProvider { mapOf("foo" to "bar") }),
-                apiClient,
+                lazyOf(apiClient),
             )
 
         val initializer = ContextHolder()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -25,7 +25,6 @@ import io.bitdrift.capture.LogType
 import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
-import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
 import io.bitdrift.capture.fakes.FakeIssueReporter
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.FAKE_EXCEPTION
@@ -395,7 +394,6 @@ class AppExitLoggerTest {
             lastExitInfo,
             captureUncaughtExceptionHandler,
             FakeIssueReporter(fatalReporterInitState),
-            backgroundThreadHandler = FakeBackgroundThreadHandler(),
         )
 
     private fun fieldsMatchExpectedAnr(arrayFields: ArrayFields): Boolean {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppExitLoggerTest.kt
@@ -25,6 +25,7 @@ import io.bitdrift.capture.LogType
 import io.bitdrift.capture.MockPreferences
 import io.bitdrift.capture.common.Runtime
 import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.fakes.FakeBackgroundThreadHandler
 import io.bitdrift.capture.fakes.FakeIssueReporter
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider
 import io.bitdrift.capture.fakes.FakeLatestAppExitInfoProvider.Companion.FAKE_EXCEPTION
@@ -394,6 +395,7 @@ class AppExitLoggerTest {
             lastExitInfo,
             captureUncaughtExceptionHandler,
             FakeIssueReporter(fatalReporterInitState),
+            backgroundThreadHandler = FakeBackgroundThreadHandler(),
         )
 
     private fun fieldsMatchExpectedAnr(arrayFields: ArrayFields): Boolean {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/OkHttpCaptureApiClientTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/OkHttpCaptureApiClientTest.kt
@@ -23,15 +23,15 @@ import java.nio.charset.Charset
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-class OkHttpApiClientTest {
+class OkHttpCaptureApiClientTest {
     private lateinit var server: MockWebServer
-    private lateinit var apiClient: OkHttpApiClient
+    private lateinit var apiClient: OkHttpCaptureApiClient
 
     @Before
     fun setup() {
         server = MockWebServer()
         server.start()
-        apiClient = OkHttpApiClient(server.url(""), "api-key", client = OkHttpClient())
+        apiClient = OkHttpCaptureApiClient(server.url(""), "api-key", client = OkHttpClient())
     }
 
     @After

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionStrategyTest.kt
@@ -11,6 +11,7 @@ import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockitokotlin2.mock
 import io.bitdrift.capture.Capture
+import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.Configuration
 import io.bitdrift.capture.ContextHolder
 import io.bitdrift.capture.LoggerImpl
@@ -31,6 +32,7 @@ class SessionStrategyTest {
     fun setUp() {
         val initializer = ContextHolder()
         initializer.create(ApplicationProvider.getApplicationContext())
+        CaptureJniLibrary.load()
     }
 
     @Test

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -3,8 +3,20 @@ plugins {
     alias(libs.plugins.apollo.graphql)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
-    id("com.google.firebase.crashlytics") version "3.0.6"
+    id("com.google.firebase.crashlytics") version "3.0.6" apply false
     id("io.bitdrift.capture-plugin") version "0.23.4" // To verify new changes at capture-plugin use your maven local published version
+}
+
+val requestedDebugVariant =
+    gradle.startParameter.taskNames.any { taskName ->
+        taskName.contains("Debug", ignoreCase = true)
+    }
+
+if (requestedDebugVariant) {
+    logger.lifecycle("Debug crashlytics plugin enabled")
+    pluginManager.apply("com.google.firebase.crashlytics")
+} else {
+    logger.lifecycle("Release crashlytics plugin disabled")
 }
 
 dependencies {
@@ -99,24 +111,6 @@ android {
     // This needs to be set to access the strip tools to strip the shared libraries.
     ndkVersion = "27.2.12479018"
 
-    buildTypes {
-        debug {
-            ndk {
-                debugSymbolLevel = "SYMBOL_TABLE" // Using this to reduce output .so size
-            }
-        }
-        release {
-            ndk {
-                debugSymbolLevel = "FULL"
-            }
-            packaging {
-                jniLibs {
-                    keepDebugSymbols += "**/*.so"
-                }
-            }
-        }
-    }
-
     // Run lint checks on every build
     applicationVariants.configureEach {
         val lintTask = tasks.named("lint${name.replaceFirstChar(Char::titlecase)}")
@@ -144,6 +138,9 @@ android {
     buildTypes {
         debug {
             // This can be enable to test proguard rules while debugging
+            ndk {
+                debugSymbolLevel = "SYMBOL_TABLE" // Using this to reduce output .so size
+            }
             isMinifyEnabled = false
             isShrinkResources = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
@@ -156,6 +153,20 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             testProguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "test-proguard-rules.pro")
         }
+        create("profileable") {
+            initWith(getByName("release"))
+            matchingFallbacks += listOf("release")
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
+            packaging {
+                jniLibs {
+                    keepDebugSymbols += "**/*.so"
+                }
+            }
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles("profileable-rules.pro")
+        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -164,6 +175,12 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+}
+
+afterEvaluate {
+    dependencies {
+        add("profileableImplementation", "com.github.chuckerteam.chucker:library-no-op:4.2.0")
     }
 }
 

--- a/platform/jvm/gradle-test-app/profileable-rules.pro
+++ b/platform/jvm/gradle-test-app/profileable-rules.pro
@@ -1,0 +1,1 @@
+-dontobfuscate

--- a/platform/jvm/gradle-test-app/src/profileable/AndroidManifest.xml
+++ b/platform/jvm/gradle-test-app/src/profileable/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <profileable android:shell="true" />
+    </application>
+
+</manifest>

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -16,23 +16,38 @@ import androidx.test.platform.app.InstrumentationRegistry
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.Configuration
+import io.bitdrift.capture.IBridge
+import io.bitdrift.capture.IEventsListenerTarget
 import io.bitdrift.capture.IInternalLogger
+import io.bitdrift.capture.IMetadataProvider
+import io.bitdrift.capture.IPreferences
+import io.bitdrift.capture.IResourceUtilizationTarget
+import io.bitdrift.capture.ISessionReplayTarget
 import io.bitdrift.capture.LogLevel
+import io.bitdrift.capture.LoggerImpl
+import io.bitdrift.capture.common.RuntimeConfig
+import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.common.RuntimeStringConfig
+import io.bitdrift.capture.error.IErrorReporter
 import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponse
 import io.bitdrift.capture.network.HttpResponse.HttpResult
 import io.bitdrift.capture.network.HttpResponseInfo
 import io.bitdrift.capture.network.HttpUrlPath
+import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.providers.FieldProvider
+import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.reports.IssueCallbackConfiguration
 import io.bitdrift.capture.webview.WebViewBridgeMessageHandler
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.time.Duration
 import kotlin.time.DurationUnit
+import kotlin.time.measureTime
 import kotlin.time.toDuration
 
 private const val LOG_MESSAGE = "50 characters long test message - 0123456789012345"
@@ -48,7 +63,10 @@ class LogBenchmarkTest {
     @get:Rule
     val benchmarkRule = BenchmarkRule()
 
-    private fun startLogger(fieldProviders: List<FieldProvider> = listOf(), configuration: Configuration = Configuration()) {
+    private fun startLogger(
+        fieldProviders: List<FieldProvider> = listOf(),
+        configuration: Configuration = Configuration()
+    ) {
         CaptureJniLibrary.load()
 
         Capture.Logger.start(
@@ -57,17 +75,14 @@ class LogBenchmarkTest {
             context = InstrumentationRegistry.getInstrumentation().targetContext,
             sessionStrategy = SessionStrategy.Fixed(),
             fieldProviders = fieldProviders,
-            configuration =  configuration,
+            configuration = configuration,
         )
     }
 
-    private fun createFieldProviders(providers: Int = 5, fields: Int = 10): List<FieldProvider> {
-        return (1..providers).map { providerIndex ->
-            val fields = (1..fields).associate { fieldIndex ->
-                "provider${providerIndex}_key$fieldIndex" to "provider${providerIndex}_val$fieldIndex"
-            }
-            FieldProvider { fields }
-        }
+    @After
+    fun tearDown() {
+        destroyCurrentLogger()
+        Capture.Logger.resetShared()
     }
 
     @Test
@@ -162,39 +177,65 @@ class LogBenchmarkTest {
     @Test
     fun webViewBridgeBridgeReady() {
         val handler = WebViewBridgeMessageHandler(getInternalLogger())
-        val message = """{"v":1,"type":"bridgeReady","url":"https://example.com","instrumentationConfig":{"capturePageViews":true,"captureErrors":false}}"""
+        val message =
+            """{"v":1,"type":"bridgeReady","url":"https://example.com","instrumentationConfig":{"capturePageViews":true,"captureErrors":false}}"""
 
         benchmarkRule.measureRepeated {
             handler.log(message)
         }
     }
-    
+
     @Test
-    fun startNewSession() = benchmarkCaptureOperation{
+    fun startNewSession() = benchmarkCaptureOperation {
         Capture.Logger.startNewSession()
     }
 
     @Test
-    fun getSdkStatus() = benchmarkCaptureOperation{
+    fun getSdkStatus() = benchmarkCaptureOperation {
         Capture.Logger.getSdkStatus()
     }
 
     @Test
-    fun logAppLaunchTTI() = benchmarkCaptureOperation{
+    fun logAppLaunchTTI() = benchmarkCaptureOperation {
         Capture.Logger.logAppLaunchTTI(1.toDuration(DurationUnit.SECONDS))
     }
 
     @Test
-    fun setEntityId() = benchmarkCaptureOperation{
+    fun setEntityId() = benchmarkCaptureOperation {
         Capture.Logger.setEntityId("fake_id")
     }
 
     @Test
-    fun clearEntityId() = benchmarkCaptureOperation{
+    fun clearEntityId() = benchmarkCaptureOperation {
         Capture.Logger.clearEntityId()
     }
 
-    private fun benchmarkCaptureOperation(configuration: Configuration = Configuration(), captureSdkOperation: () -> Unit ) {
+    @Test
+    fun loggerImplCreation() {
+        benchmarkRule.measureRepeated {
+            runWithTimingDisabled {
+                CaptureJniLibrary.load()
+            }
+            val logger = LoggerImpl(
+                apiKey = "[test_api_key]",
+                apiUrl = "https://api-test.bitdrift.dev".toHttpUrl(),
+                context = InstrumentationRegistry.getInstrumentation().targetContext,
+                fieldProviders = emptyList(),
+                dateProvider = SystemDateProvider(),
+                configuration = Configuration(),
+                sessionStrategy = SessionStrategy.Fixed(),
+            )
+            runWithTimingDisabled {
+                CaptureJniLibrary.shutdown(logger.loggerId)
+                CaptureJniLibrary.destroyLogger(logger.loggerId)
+            }
+        }
+    }
+
+    private fun benchmarkCaptureOperation(
+        configuration: Configuration = Configuration(),
+        captureSdkOperation: () -> Unit
+    ) {
         startLogger(fieldProviders = createFieldProviders(), configuration = configuration)
 
         benchmarkRule.measureRepeated { captureSdkOperation() }
@@ -203,6 +244,21 @@ class LogBenchmarkTest {
     private fun getInternalLogger(): IInternalLogger {
         startLogger()
         return Capture.logger() as IInternalLogger
+    }
+
+    private fun destroyCurrentLogger() {
+        (Capture.logger() as? IInternalLogger)?.let {
+            CaptureJniLibrary.shutdown((it as io.bitdrift.capture.LoggerImpl).loggerId)
+            CaptureJniLibrary.destroyLogger(it.loggerId)
+        }
+    }
+    private fun createFieldProviders(providers: Int = 5, fields: Int = 10): List<FieldProvider> {
+        return (1..providers).map { providerIndex ->
+            val fields = (1..fields).associate { fieldIndex ->
+                "provider${providerIndex}_key$fieldIndex" to "provider${providerIndex}_val$fieldIndex"
+            }
+            FieldProvider { fields }
+        }
     }
 
     private fun buildFieldsMap(size: Int, keyIdentifier: String = "key_"): Map<String, String> =


### PR DESCRIPTION
## Problem

Capture.Logger.start() was doing unnecessary eager startup work on the caller thread.

## Solution

- Creating lazily `OkHttpCaptureApiClient` (before named OkHttpClient) which is only called when deviceCode is requested or there is an internal error to report. The internal Gson contructor is also lazy until first `OkHttpCaptureApiClient` usage.
- Creating whole session URL as potentially can never be called.

Additionally renamed some classes to clarify their intention:
- `OkHttpApiClient` <> `OkHttpCaptureApiClient`. Given this is internal to capture and used API backend communication (for now device code generation and internal error reporting)
- `OkHttpNetwork` to `OkHttpCaptureStream`. Also internal to capture and responsible to keep the stream connection with the backend

## Test Results

### Local benchmark improvement with a Fairphone 6

| Metric | Before | After | Diff |
|--------| -------| ------| -------|
| duration |  1,880,327 ns |  1,312,276 ns    | -30.2%    | 
| allocs |  617 allocs   |   530 allocs     |  -14.1%  |


## Verification

- Verified okhttp calls via gradle-test-app (device code/artificial errors/etc)
- Added a new benchmark test to compare internal of Capture.Logger.start via LoggerImpl instance creation

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.