### PR TITLE
Integrated with config.csv to turn on/off the new repoter

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ae96d8b70c486d8ae299e38c95cc2a69b3e80da5d768a2e7b2f2c5e99eda70bc",
+  "checksum": "bf8c38f5c0e31733e76e0aa22c6ebabf7c0927c88faf72a4187b778bb9f977ac",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-api"
         }
@@ -1753,7 +1753,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1890,7 +1890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1946,7 +1946,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -2010,7 +2010,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2116,7 +2116,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2192,7 +2192,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2341,7 +2341,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2478,7 +2478,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2615,7 +2615,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2708,7 +2708,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2772,7 +2772,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -3005,7 +3005,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-device"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3161,7 +3161,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-events"
         }
@@ -3229,7 +3229,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3460,7 +3460,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3539,7 +3539,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3671,7 +3671,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3731,7 +3731,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3819,7 +3819,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-log"
         }
@@ -3919,7 +3919,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -4007,7 +4007,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4095,7 +4095,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4155,7 +4155,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4248,7 +4248,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4509,7 +4509,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4569,7 +4569,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4617,7 +4617,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4665,7 +4665,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4734,7 +4734,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4794,7 +4794,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4896,7 +4896,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-proto"
         }
@@ -5010,7 +5010,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5142,7 +5142,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5214,7 +5214,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5312,7 +5312,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5440,7 +5440,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5524,7 +5524,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5717,7 +5717,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-session"
         }
@@ -5826,7 +5826,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5930,7 +5930,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5986,7 +5986,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-state"
         }
@@ -6095,7 +6095,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6168,7 +6168,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6384,7 +6384,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-time"
         }
@@ -6461,7 +6461,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
+            "Rev": "f906e535ad171308752874e09329c5182b85a9a0"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "71e10f58abb9f8f40e84ad91d59f8984d70314e55ef03d5d4c087f1795d06b8f",
+  "checksum": "ae96d8b70c486d8ae299e38c95cc2a69b3e80da5d768a2e7b2f2c5e99eda70bc",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -1588,7 +1588,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-api"
         }
@@ -1753,7 +1753,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-artifact-upload"
         }
@@ -1890,7 +1890,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-backoff"
         }
@@ -1946,7 +1946,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-bonjson"
         }
@@ -2010,7 +2010,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-bonjson-ffi"
         }
@@ -2116,7 +2116,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-bounded-buffer"
         }
@@ -2192,7 +2192,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-buffer"
         }
@@ -2341,7 +2341,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-client-common"
         }
@@ -2478,7 +2478,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-client-stats"
         }
@@ -2615,7 +2615,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-client-stats-store"
         }
@@ -2708,7 +2708,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-completion"
         }
@@ -2772,7 +2772,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-crash-handler"
         }
@@ -3005,7 +3005,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-device"
         }
@@ -3077,7 +3077,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-error-reporter"
         }
@@ -3161,7 +3161,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-events"
         }
@@ -3229,7 +3229,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-grpc"
         }
@@ -3460,7 +3460,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-grpc-codec"
         }
@@ -3539,7 +3539,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-hyper-network"
         }
@@ -3671,7 +3671,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-internal-logging"
         }
@@ -3731,7 +3731,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-key-value"
         }
@@ -3819,7 +3819,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-log"
         }
@@ -3919,7 +3919,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-log-filter"
         }
@@ -4007,7 +4007,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-log-matcher"
         }
@@ -4095,7 +4095,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-log-metadata"
         }
@@ -4155,7 +4155,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-log-primitives"
         }
@@ -4248,7 +4248,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-logger"
         }
@@ -4509,7 +4509,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-macros"
         }
@@ -4569,7 +4569,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-metadata"
         }
@@ -4617,7 +4617,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-network-quality"
         }
@@ -4665,7 +4665,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-noop-network"
         }
@@ -4734,7 +4734,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-panic"
         }
@@ -4794,7 +4794,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-pgv"
         }
@@ -4896,7 +4896,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-proto"
         }
@@ -5010,7 +5010,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-proto-util"
         }
@@ -5142,7 +5142,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-report-parsers"
         }
@@ -5214,7 +5214,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-report-writer"
         }
@@ -5312,7 +5312,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-resilient-kv"
         }
@@ -5440,7 +5440,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-resource-utilization"
         }
@@ -5524,7 +5524,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-runtime"
         }
@@ -5621,7 +5621,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-server-stats"
         }
@@ -5717,7 +5717,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-session"
         }
@@ -5826,7 +5826,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-session-replay"
         }
@@ -5930,7 +5930,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-shutdown"
         }
@@ -5986,7 +5986,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-state"
         }
@@ -6095,7 +6095,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-stats-common"
         }
@@ -6168,7 +6168,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-test-helpers"
         }
@@ -6384,7 +6384,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-time"
         }
@@ -6461,7 +6461,7 @@
         "Git": {
           "remote": "https://github.com/bitdriftlabs/shared-core.git",
           "commitish": {
-            "Rev": "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+            "Rev": "1bc0185983bf04ef96b348cb1c44665719d905d4"
           },
           "strip_prefix": "bd-workflows"
         }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -299,7 +299,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.2",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -469,7 +469,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -561,7 +561,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "base64",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -724,7 +724,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1100,7 +1100,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd#3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bd-api"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -299,7 +299,7 @@ dependencies = [
 [[package]]
 name = "bd-artifact-upload"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "bd-backoff"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
  "rand 0.10.2",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "bd-workspace-hack",
@@ -351,7 +351,7 @@ dependencies = [
 [[package]]
 name = "bd-bonjson-ffi"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-bonjson",
  "bd-workspace-hack",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "bd-bounded-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "bd-client-stats-store",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "bd-buffer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "bd-client-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -469,7 +469,7 @@ dependencies = [
 [[package]]
 name = "bd-client-stats-store"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "bd-completion"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "bd-crash-handler"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "bd-device"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-key-value",
@@ -561,7 +561,7 @@ dependencies = [
 [[package]]
 name = "bd-error-reporter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "bd-events"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-runtime",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "bd-grpc-codec"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-stats-common",
  "bd-workspace-hack",
@@ -648,7 +648,7 @@ dependencies = [
 [[package]]
 name = "bd-hyper-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -674,7 +674,7 @@ dependencies = [
 [[package]]
 name = "bd-internal-logging"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-log-primitives",
  "bd-proto",
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "bd-key-value"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "base64",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bd-log"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-workspace-hack",
@@ -724,7 +724,7 @@ dependencies = [
 [[package]]
 name = "bd-log-filter"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-client-stats-store",
@@ -742,7 +742,7 @@ dependencies = [
 [[package]]
 name = "bd-log-matcher"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "bd-log-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-log-primitives",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "bd-log-primitives"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "bd-logger"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "bd-macros"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
  "proc-macro2",
@@ -860,7 +860,7 @@ dependencies = [
 [[package]]
 name = "bd-metadata"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 [[package]]
 name = "bd-network-quality"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
 ]
@@ -876,7 +876,7 @@ dependencies = [
 [[package]]
 name = "bd-noop-network"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -888,7 +888,7 @@ dependencies = [
 [[package]]
 name = "bd-panic"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
  "color-backtrace",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "bd-pgv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -911,7 +911,7 @@ dependencies = [
 [[package]]
 name = "bd-proto"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-pgv",
  "bd-workspace-hack",
@@ -926,7 +926,7 @@ dependencies = [
 [[package]]
 name = "bd-proto-util"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "bd-report-parsers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-proto",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "bd-report-writer"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-proto",
  "bd-workspace-hack",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "bd-resilient-kv"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "bd-resource-utilization"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "bd-runtime"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "bd-server-stats"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-stats-common",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "bd-session"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1078,7 +1078,7 @@ dependencies = [
 [[package]]
 name = "bd-session-replay"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-client-common",
@@ -1100,7 +1100,7 @@ dependencies = [
 [[package]]
 name = "bd-shutdown"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "bd-workspace-hack",
  "log",
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "bd-state"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "bd-macros",
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "bd-time"
 version = "1.0.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "async-trait",
  "bd-workspace-hack",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bd-workflows"
 version = "0.1.0"
-source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=1bc0185983bf04ef96b348cb1c44665719d905d4#1bc0185983bf04ef96b348cb1c44665719d905d4"
+source = "git+https://github.com/bitdriftlabs/shared-core.git?rev=f906e535ad171308752874e09329c5182b85a9a0#f906e535ad171308752874e09329c5182b85a9a0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,35 +20,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.103"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "f906e535ad171308752874e09329c5182b85a9a0" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "1.0.7"
 env_logger = { version = "0.11.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,35 +20,35 @@ android_logger = { version = "0.15.1", default-features = false }
 anyhow = "1.0.103"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd", default-features = false, features = [
+bd-api = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-bonjson = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-bonjson-ffi = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-buffer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-client-common = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-client-stats-store = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-crash-handler = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-device = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-error-reporter = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-grpc = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-hyper-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4", default-features = false, features = [
   "ring",
 ] }
-bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
-bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd", default-features = false, features = [
+bd-key-value = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-log = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-log-metadata = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-log-primitives = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-logger = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-noop-network = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-proto = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-report-parsers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-report-writer = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-runtime = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-session = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-shutdown = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
+bd-test-helpers = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4", default-features = false, features = [
   "ring",
 ] }
-bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "3c2135d35f5fc5d3289c370f0af4cee8f5bad8bd" }
+bd-time = { git = "https://github.com/bitdriftlabs/shared-core.git", rev = "1bc0185983bf04ef96b348cb1c44665719d905d4" }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 ctor = "1.0.7"
 env_logger = { version = "0.11.11", default-features = false }

--- a/platform/swift/source/reports/CrashReporterService.swift
+++ b/platform/swift/source/reports/CrashReporterService.swift
@@ -15,6 +15,13 @@ struct CrashReporterSetupResult {
     let diagnosticReporter: DiagnosticEventReporter?
 }
 
+/// The crash reporting state derived from the cached `reports/config.csv` file, read synchronously
+/// at startup before the runtime configuration snapshot is populated.
+private struct RuntimeFileState {
+    let resolution: ReporterInitResolution
+    let bitdriftCrashReporterEnabled: Bool
+}
+
 /// Coordinates crash reporter initialization and exposes the combined state of all active handlers
 /// through the `CrashReporting` protocol, abstracting away which reporters are in use.
 @objc class CrashReporterService: NSObject {
@@ -75,11 +82,11 @@ struct CrashReporterSetupResult {
         var diagnosticReporter: DiagnosticEventReporter?
 
         let initResult: IssueReporterInitResult = measureTime {
-            isBitdriftCrashHandlerEnabled = underlyingLogger.runtimeValue(.bdCrashReporter)
+            let runtimeFileState = resolveRuntimeState(from: sdkBaseURL)
+            isBitdriftCrashHandlerEnabled = runtimeFileState.bitdriftCrashReporterEnabled
 
-            let runtimeState = resolveRuntimeState(from: sdkBaseURL)
-            if runtimeState != .monitoring {
-                return .initialized(runtimeState)
+            if runtimeFileState.resolution != .monitoring {
+                return .initialized(runtimeFileState.resolution)
             }
 
             var reporterInitResolution: ReporterInitResolution?
@@ -247,7 +254,7 @@ private extension CrashReporterService {
         }
     }
 
-    func resolveRuntimeState(from baseURL: URL) -> ReporterInitResolution {
+    func resolveRuntimeState(from baseURL: URL) -> RuntimeFileState {
         let configPath = baseURL.appendingPathComponent(
             Constants.configCSV,
             isDirectory: false
@@ -258,20 +265,34 @@ private extension CrashReporterService {
             // For initial app installation/clear cache, the configuration wasn't written
             // to disk yet, so we intentionally enable crash reporting to not miss any
             // of those early crashes.
-            return .monitoring
+            return RuntimeFileState(
+                resolution: .monitoring,
+                bitdriftCrashReporterEnabled: RuntimeVariable.bdCrashReporter.defaultValue
+            )
         }
 
         guard let config = readCachedValues(contents) else {
-            return .runtimeInvalid
+            return RuntimeFileState(
+                resolution: .runtimeInvalid,
+                bitdriftCrashReporterEnabled: RuntimeVariable.bdCrashReporter.defaultValue
+            )
         }
 
+        // The config file may still only contain the legacy `crash_reporting.enabled` entry if it
+        // was written by an older SDK version, so this key can be absent even in a well-formed file.
+        let bitdriftCrashReporterEnabled = (config[RuntimeVariable.bdCrashReporter.name] as? Bool)
+            ?? RuntimeVariable.bdCrashReporter.defaultValue
+
+        let resolution: ReporterInitResolution
         switch config[RuntimeVariable.crashReporting.name] {
         case let enabled as Bool:
-            return enabled ? .monitoring : .runtimeNotEnabled
+            resolution = enabled ? .monitoring : .runtimeNotEnabled
         case nil:
-            return .runtimeMissingFlag
+            resolution = .runtimeMissingFlag
         default:
-            return .runtimeInvalid
+            resolution = .runtimeInvalid
         }
+
+        return RuntimeFileState(resolution: resolution, bitdriftCrashReporterEnabled: bitdriftCrashReporterEnabled)
     }
 }

--- a/test/platform/swift/unit_integration/core/reports/CrashReporterServiceTests.swift
+++ b/test/platform/swift/unit_integration/core/reports/CrashReporterServiceTests.swift
@@ -76,6 +76,20 @@ final class CrashReporterServiceTests: XCTestCase {
         thenIssueReporterInitStateIs(.initialized(.runtimeMissingFlag))
     }
 
+    func testSetupUsesBitdriftDefaultWhenConfigFileOnlyHasLegacyCrashReportingKey() {
+        givenCrashReporterService()
+        givenConfigFile("crash_reporting.enabled,true")
+        whenInvokingSetup()
+        thenBitdriftCrashHandlerIsConfigured()
+    }
+
+    func testSetupDoesNotCallBitdriftHandlerWhenConfigFileDisablesIt() {
+        givenCrashReporterService()
+        givenConfigFile("crash_reporting.enabled,true\nclient_feature.ios.use_bd_crash_reporter,false")
+        whenInvokingSetup()
+        thenBitdriftCrashHandlerIsNotConfigured()
+    }
+
     // MARK: - Handler initialization
 
     func testSetupCallsConfigureAndStartOnKSCrashHandler() {
@@ -256,8 +270,10 @@ private extension CrashReporterServiceTests {
         environment: MockEnvironment = .device(),
         previousRunInfoController: PreviousRunInfoController? = nil
     ) {
-        logger.mockRuntimeVariable(.bdCrashReporter, with: bitdriftCrashReporterEnabled)
         logger.mockRuntimeVariable(.previousRunInfoRevamped, with: previousRunInfoRevamped)
+        if !bitdriftCrashReporterEnabled {
+            givenConfigFile("crash_reporting.enabled,true\nclient_feature.ios.use_bd_crash_reporter,false")
+        }
         sut = CrashReporterService(
             previousRunInfoController: previousRunInfoController,
             ksCrashHandler: ksCrashHandler,


### PR DESCRIPTION
# Overview
`RuntimeVariables` are not updated on initializing the crash reporters. Using the `config.csv` to provide the most up to date value to turn on/off the new crash reporter.

This PR is related to [this shared-core changes](https://github.com/bitdriftlabs/shared-core/pull/552)