### PR TITLE
[BIT-9197] iOS - Implement a way to remotely toggle the `WKWebView` capture

### DIFF
--- a/platform/swift/source/LoggerProvider.swift
+++ b/platform/swift/source/LoggerProvider.swift
@@ -7,4 +7,5 @@
 
 protocol LoggingProvider {
     func getLogging() -> Logging?
+    func runtimeValue<T: RuntimeValue>(_ variable: RuntimeVariable<T>) -> T
 }

--- a/platform/swift/source/RuntimeVariable.swift
+++ b/platform/swift/source/RuntimeVariable.swift
@@ -24,6 +24,12 @@ struct RuntimeVariable<T: RuntimeValue> {
     let defaultValue: T
 }
 
+extension Logging {
+    func runtimeValue<T: RuntimeValue>(_ variable: RuntimeVariable<T>) -> T {
+        (self as? Logger)?.runtimeValue(variable) ?? variable.defaultValue
+    }
+}
+
 extension RuntimeVariable {
     func load(loggerID: LoggerID) -> T {
         if T.self == Bool.self {
@@ -128,6 +134,16 @@ extension RuntimeVariable<Bool> {
     // ignoring the revamped resolver signals (cleanExit, appUpdate, osUpdate, etc.).
     static let previousRunInfoRevamped = RuntimeVariable(
         name: "client_feature.ios.previous_run_info_revamped",
+        defaultValue: true
+    )
+
+    static let webviewInstrumentation = RuntimeVariable(
+        name: "client_feature.ios.webview_instrumentation",
+        defaultValue: true
+    )
+
+    static let webviewSwizzling = RuntimeVariable(
+        name: "client_feature.ios.webview_swizzling",
         defaultValue: true
     )
 }

--- a/platform/swift/source/integrations/webview/WebViewInstrumenter.swift
+++ b/platform/swift/source/integrations/webview/WebViewInstrumenter.swift
@@ -41,6 +41,10 @@ final class WebViewInstrumenter {
     }
 
     private func performCaptureInstrument(_ configuration: WKWebViewConfiguration) {
+        guard loggingProvider.runtimeValue(.webviewInstrumentation) else {
+            return
+        }
+
         let userContentController = configuration.userContentController
 
         guard !userContentController.userScripts.contains(where: { $0.source.hasPrefix(Self.scriptMarker) }) else {

--- a/platform/swift/source/integrations/webview/WebViewIntegration.swift
+++ b/platform/swift/source/integrations/webview/WebViewIntegration.swift
@@ -40,7 +40,7 @@ final class WebViewIntegration {
         }
 
         hasSwizzledWebViewInit.update { hasSwizzled in
-            guard !hasSwizzled, !disableSwizzling else {
+            guard !hasSwizzled, !disableSwizzling, logger.runtimeValue(.webviewSwizzling) else {
                 return
             }
 

--- a/platform/swift/source/integrations/webview/WebViewIntegration.swift
+++ b/platform/swift/source/integrations/webview/WebViewIntegration.swift
@@ -26,7 +26,7 @@ extension Integration {
 }
 
 final class WebViewIntegration {
-    private var hasSwizzledWebViewInit = Atomic(false)
+    private var hasBeenConfigured = Atomic(false)
     private let underlyingLogger = Atomic<Logging?>(nil)
 
     static let shared: WebViewIntegration = .init()
@@ -39,7 +39,7 @@ final class WebViewIntegration {
             storedLogger = logger
         }
 
-        hasSwizzledWebViewInit.update { hasSwizzled in
+        hasBeenConfigured.update { hasSwizzled in
             guard !hasSwizzled, !disableSwizzling, logger.runtimeValue(.webviewSwizzling) else {
                 return
             }
@@ -62,7 +62,7 @@ extension WebViewIntegration {
     /// Exchanging the method twice should in theory restore the original implementation.
     /// Note: This should only be used in tests.
     func disableWebViewSwizzling() {
-        hasSwizzledWebViewInit.update { hasSwizzled in
+        hasBeenConfigured.update { hasSwizzled in
             guard hasSwizzled else {
                 return
             }

--- a/platform/swift/source/integrations/webview/WebViewLoggingProvider.swift
+++ b/platform/swift/source/integrations/webview/WebViewLoggingProvider.swift
@@ -18,4 +18,8 @@ struct WebViewLoggingProvider: LoggingProvider {
     func getLogging() -> (any Logging)? {
         explicitLogger ?? WebViewIntegration.shared.getLogger()
     }
+
+    func runtimeValue<T: RuntimeValue>(_ variable: RuntimeVariable<T>) -> T {
+        getLogging()?.runtimeValue(variable) ?? variable.defaultValue
+    }
 }

--- a/test/platform/swift/unit_integration/core/integrations/webview/WebViewInstrumenterTests.swift
+++ b/test/platform/swift/unit_integration/core/integrations/webview/WebViewInstrumenterTests.swift
@@ -43,6 +43,31 @@ final class WebViewInstrumenterTests: XCTestCase {
 
         self.thenUserScriptCount(is: 1)
     }
+
+    func testCaptureInstrumentDoesNothingWhenRuntimeFlagDisabled() {
+        self.sut = WebViewInstrumenter.make(
+            loggingProvider: FakeLoggingProvider(logger: self.logger, webviewInstrumentationEnabled: false)
+        )
+
+        self.whenInstrumenting()
+
+        self.thenUserScriptCount(is: 0)
+    }
+}
+
+private struct FakeLoggingProvider: LoggingProvider {
+    let logger: Logging?
+    let webviewInstrumentationEnabled: Bool
+
+    func getLogging() -> Logging? { self.logger }
+
+    func runtimeValue<T: RuntimeValue>(_ variable: RuntimeVariable<T>) -> T {
+        if T.self == Bool.self {
+            // swiftlint:disable:next force_cast
+            return self.webviewInstrumentationEnabled as! T
+        }
+        return variable.defaultValue
+    }
 }
 
 private extension WebViewInstrumenterTests {

--- a/test/platform/swift/unit_integration/core/integrations/webview/WebViewIntegrationSwizzlingTests.swift
+++ b/test/platform/swift/unit_integration/core/integrations/webview/WebViewIntegrationSwizzlingTests.swift
@@ -40,3 +40,57 @@ private extension WebViewIntegrationSwizzlingTests {
         XCTAssertTrue(webView.configuration.userContentController.userScripts.isEmpty)
     }
 }
+
+@MainActor
+final class WebViewIntegrationSwizzlingRuntimeFlagTests: XCTestCase {
+    private var loggerBridge: MockLoggerBridging!
+    private var logger: Logger!
+
+    override func setUp() {
+        super.setUp()
+        WebViewIntegration.shared.disableWebViewSwizzling()
+
+        self.loggerBridge = MockLoggerBridging()
+        self.logger = Logger(
+            withAPIKey: "123",
+            remoteErrorReporter: nil,
+            configuration: .init(
+                rootFileURL: FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "bitdrift_test_\(UUID().uuidString)"
+                )
+            ),
+            sessionStrategy: .fixed(),
+            dateProvider: nil,
+            fieldProviders: [],
+            enableNetwork: false,
+            storageProvider: MockStorageProvider(),
+            timeProvider: MockTimeProvider(),
+            loggerBridgingFactoryProvider: MockLoggerBridgingFactory(logger: self.loggerBridge)
+        )
+    }
+
+    override func tearDown() {
+        WebViewIntegration.shared.disableWebViewSwizzling()
+        super.tearDown()
+    }
+
+    func testSwizzlingDisabledByRuntimeFlagSkipsAutomaticInstrumentation() {
+        self.loggerBridge.mockRuntimeVariable(.webviewSwizzling, with: false)
+
+        Integration.webView().start(with: self.logger, disableSwizzling: false)
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+        XCTAssertTrue(webView.configuration.userContentController.userScripts.isEmpty)
+    }
+
+    func testSwizzlingDisabledByRuntimeFlagDoesNotAffectManualInstrumentation() {
+        self.loggerBridge.mockRuntimeVariable(.webviewSwizzling, with: false)
+
+        Integration.webView().start(with: self.logger, disableSwizzling: false)
+
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        self.logger.instrument(webView: webView)
+
+        XCTAssertEqual(webView.configuration.userContentController.userScripts.count, 1)
+    }
+}

--- a/test/platform/swift/unit_integration/core/integrations/webview/WebViewIntegrationTests.swift
+++ b/test/platform/swift/unit_integration/core/integrations/webview/WebViewIntegrationTests.swift
@@ -120,6 +120,7 @@ final class WebViewIntegrationTests: XCTestCase {
 
     func testConcurrentStartOnlySwizzlesWebViewInitOnce() throws {
         let logger = try XCTUnwrap(self.logger)
+        WebViewIntegration.shared.disableWebViewSwizzling()
 
         DispatchQueue.concurrentPerform(iterations: 50) { _ in
             Integration.webView().start(with: logger, disableSwizzling: false)


### PR DESCRIPTION
# Overview
This PR intoduces two feature flags:
1. A flag to remotely enable/disable the swizzling mechanism. Its default value is `true`. The goal is to mitigate any issues caused by swizzling without disabling the `WKWebView` capture feature entirely (e.g. customers can still manually instrument `WKWebView`). Flag is `client_feature.ios.webview_swizzling`
2. A flag to prevent injecting the js SDK into `WKWebView`, which effectively disables `WKWebView` capture (this is the actual feature flag for the feature itself). Flag is `client_feature.ios.webview_instrumentation`