### PR TITLE
[Android] PreInit buffer + Capture.Logger.startAsync

### DIFF
--- a/platform/jvm/capture-timber/src/main/kotlin/io/bitdrift/capture/timber/CaptureTree.kt
+++ b/platform/jvm/capture-timber/src/main/kotlin/io/bitdrift/capture/timber/CaptureTree.kt
@@ -22,13 +22,9 @@ import timber.log.Timber
  * if the Logger is initialized.
  */
 open class CaptureTree internal constructor(
-    private val internalLogger: ILogger?,
+    private val loggerProvider: () -> ILogger?,
 ) : Timber.Tree() {
-    constructor() : this(Capture.logger())
-
-    // attempts to get the latest logger if one wasn't found at construction time
-    private val logger: ILogger?
-        get() = internalLogger ?: Capture.logger()
+    constructor() : this({ Capture.logger() })
 
     final override fun log(
         priority: Int,
@@ -36,7 +32,7 @@ open class CaptureTree internal constructor(
         message: String,
         t: Throwable?,
     ) {
-        logger?.log(toCaptureLogLevel(priority), extractFields(tag), t) { message }
+        loggerProvider()?.log(toCaptureLogLevel(priority), extractFields(tag), t) { message }
     }
 
     private fun toCaptureLogLevel(priority: Int): LogLevel =

--- a/platform/jvm/capture-timber/src/test/kotlin/io/bitdrift/capture/timber/CaptureTreeTest.kt
+++ b/platform/jvm/capture-timber/src/test/kotlin/io/bitdrift/capture/timber/CaptureTreeTest.kt
@@ -24,7 +24,7 @@ import java.io.IOException
 
 class CaptureTreeTest {
     private val mockLogger: ILogger = mock()
-    private val captureTree = CaptureTree(mockLogger)
+    private val captureTree = CaptureTree { mockLogger }
     private val message = "my_message"
 
     @Test

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -14,6 +14,7 @@ import android.os.strictmode.Violation
 import android.system.Os
 import android.util.Log
 import androidx.annotation.RequiresApi
+import io.bitdrift.capture.Capture.Logger.startAsync
 import io.bitdrift.capture.Capture.Logger.startSpan
 import io.bitdrift.capture.LoggerImpl.SdkConfiguredDuration
 import io.bitdrift.capture.common.MainThreadHandler
@@ -27,11 +28,13 @@ import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
+import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.BuildTypeChecker
 import io.bitdrift.capture.utils.DebugCustomerCallbackException
 import io.bitdrift.capture.utils.invokeCatchingOrThrowOnDebug
 import okhttp3.HttpUrl
 import java.util.UUID
+import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.TimeSource
@@ -68,6 +71,8 @@ internal sealed class LoggerState {
 object Capture {
     internal const val LOG_TAG = "BitdriftCapture"
     private val default: AtomicReference<LoggerState> = AtomicReference(LoggerState.NotStarted)
+    private val preInitInMemoryLoggerRef: AtomicReference<PreInitInMemoryLogger?> =
+        AtomicReference()
 
     /**
      * Returns a handle to the underlying logger instance, if Capture has been started.
@@ -77,7 +82,7 @@ object Capture {
     fun logger(): ILogger? =
         when (val state = default.get()) {
             is LoggerState.NotStarted -> null
-            is LoggerState.Starting -> null
+            is LoggerState.Starting -> preInitInMemoryLoggerRef.get()
             is LoggerState.Started -> state.logger
             is LoggerState.StartFailure -> null
         }
@@ -135,15 +140,19 @@ object Capture {
          *               Compose API base URL.
          * @param context an optional context reference. You should provide the context if called from
          * a [android.content.ContentProvider].
+         * @param executor optional executor used to run the internal SDK initialization off the calling thread.
+         *                 When null, initialization runs synchronously on the calling thread.
          * @param startResult an optional callback invoked with the result of the SDK initialization.
-         *                     The callback is always called on the calling thread before [start] returns.
+         *                     When no [executor] is provided, the callback is invoked on the calling thread
+         *                     before [startAsync] returns. When an [executor] is provided, [startAsync] returns
+         *                     immediately after submitting the init task, and the callback is invoked on the
+         *                     executor thread once initialization completes.
          *                     On success, it receives a [CaptureResult.Success] containing an [ILogger] instance.
          *                     On failure, it receives a [CaptureResult.Failure] with a [SdkStartFailure].
          */
-        @Synchronized
         @JvmStatic
         @JvmOverloads
-        fun start(
+        fun startAsync(
             apiKey: String,
             sessionStrategy: SessionStrategy,
             configuration: Configuration = Configuration(),
@@ -153,7 +162,7 @@ object Capture {
             context: Context? = null,
             startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
         ) {
-            start(
+            startAsync(
                 apiKey,
                 sessionStrategy,
                 configuration,
@@ -182,6 +191,24 @@ object Capture {
             context: Context? = null,
             startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
         ) {
+           // TODO: Start must remain the same
+        }
+        // Single-initialization is enforced by the atomic CAS on `default` below;
+        // no external locking is required. Callers observe the started LoggerImpl via
+        // `Capture.logger()`, published through the AtomicReference (volatile-equivalent semantics).
+        @JvmStatic
+        @JvmOverloads
+        internal fun startAsync(
+            apiKey: String,
+            sessionStrategy: SessionStrategy,
+            configuration: Configuration = Configuration(),
+            fieldProviders: List<FieldProvider> = listOf(),
+            dateProvider: DateProvider? = null,
+            apiUrl: HttpUrl = defaultCaptureApiUrl,
+            bridge: IBridge,
+            context: Context? = null,
+            startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
+        ) {
             // There's nothing we can do if we don't have yet access to the application context.
             if (hasInvalidContext(context)) {
                 val errorMessage = "Attempted to initialize Capture with a null context"
@@ -191,53 +218,67 @@ object Capture {
             }
 
             // Ideally we would use `getAndUpdate` in here but it's available for API 24 and up only.
-            if (default.compareAndSet(LoggerState.NotStarted, LoggerState.Starting)) {
-                initSdk(
-                    apiKey = apiKey,
-                    sessionStrategy = sessionStrategy,
-                    configuration = configuration,
-                    fieldProviders = fieldProviders,
-                    dateProvider = dateProvider,
-                    apiUrl = apiUrl,
-                    bridge = bridge,
-                    context = context,
-                    startResult = startResult,
-                )
-            } else {
+            // Only the CAS winner performs any side effects; concurrent/repeat callers are a no-op.
+            if (!default.compareAndSet(LoggerState.NotStarted, LoggerState.Starting)) {
                 Log.w(LOG_TAG, "Multiple attempts to start Capture")
+                return
             }
+            initSdk(
+                apiKey = apiKey,
+                sessionStrategy = sessionStrategy,
+                configuration = configuration,
+                fieldProviders = fieldProviders,
+                dateProvider = dateProvider,
+                apiUrl = apiUrl,
+                bridge = bridge,
+                context = context,
+                startResult = startResult,
+            )
         }
 
         /**
          * The Id for the current ongoing session.
-         * It's equal to `null` prior to the start of Capture SDK.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [startAsync].
          */
         @JvmStatic
         val sessionId: String?
-            get() = logger()?.sessionId
+            get() = logger()?.takeUnless { it is PreInitInMemoryLogger }?.sessionId
 
         /**
          * The URL for the current ongoing session.
-         * It's equal to `null` prior to the start of Capture SDK.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [startAsync].
          */
         @JvmStatic
         val sessionUrl: String?
-            get() = logger()?.sessionUrl
+            get() = logger()?.takeUnless { it is PreInitInMemoryLogger }?.sessionUrl
 
         /**
          * A canonical identifier for a device that remains consistent as long as an application
          * is not reinstalled.
          *
          * The value of this property is different for apps from the same vendor running on
-         * the same device. It is equal to null prior to the start of bitdrift Capture SDK.
+         * the same device.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [startAsync].
          */
         @JvmStatic
         val deviceId: String?
-            get() = logger()?.deviceId
+            get() = logger()?.takeUnless { it is PreInitInMemoryLogger }?.deviceId
 
         /**
          * Whether workflow-controlled tracing is currently active for this session.
-         * Returns `null` prior to SDK start.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [startAsync].
          */
         @JvmStatic
         val isTracingActive: Boolean?
@@ -274,7 +315,7 @@ object Capture {
         /**
          * Returns a snapshot of the previous app run status, or `null` if not available.
          *
-         * Must be called after [start]. Returns `null` if the logger is not initialized.
+         * Must be called after [startAsync]. Returns `null` if the logger is not initialized.
          *
          */
         @JvmStatic
@@ -305,9 +346,7 @@ object Capture {
             key: String,
             value: String,
         ) {
-            logger()?.let {
-                it.addField(key, value)
-            }
+            logger()?.addField(key, value)
         }
 
         /**
@@ -686,66 +725,107 @@ object Capture {
         context: Context?,
         startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
     ) {
-        try {
-            val startSdkTimer = TimeSource.Monotonic.markNow()
+        val executor = CaptureDispatchers.CommonBackground.executorService
+        val initAction =
+            Runnable {
+                try {
+                    val startSdkTimer = TimeSource.Monotonic.markNow()
 
-            if (!ContextHolder.isInitialized && context != null) {
-                // Make sure the global context is set if no Initializer was used
-                ContextHolder.APP_CONTEXT = context.applicationContext
-            }
+                    if (!ContextHolder.isInitialized && context != null) {
+                        // Make sure the global context is set if no Initializer was used
+                        ContextHolder.APP_CONTEXT = context.applicationContext
+                    }
 
-            val appContext = ContextHolder.APP_CONTEXT
+                    val appContext = ContextHolder.APP_CONTEXT
 
-            // This needs to happen before loading the native library as we set
-            // up logging during library initialization.
-            setUpInternalLogging(appContext)
+                    // This needs to happen before loading the native library as we set
+                    // up logging during library initialization.
+                    setUpInternalLogging(appContext)
 
-            val nativeLoadDuration =
-                measureTime {
-                    CaptureJniLibrary.load()
-                }
+                    val nativeLoadDuration =
+                        measureTime {
+                            CaptureJniLibrary.load()
+                        }
 
-            val (loggerImpl, loggerImplBuildDuration) =
-                measureTimedValue {
-                    LoggerImpl(
-                        apiKey = apiKey,
-                        apiUrl = apiUrl,
-                        context = appContext,
-                        fieldProviders = fieldProviders,
-                        dateProvider = dateProvider ?: SystemDateProvider(),
-                        configuration = configuration,
-                        sessionStrategy = sessionStrategy,
-                        bridge = bridge,
+                    val (loggerImpl, loggerImplBuildDuration) =
+                        measureTimedValue {
+                            LoggerImpl(
+                                apiKey = apiKey,
+                                apiUrl = apiUrl,
+                                context = appContext,
+                                fieldProviders = fieldProviders,
+                                dateProvider = dateProvider ?: SystemDateProvider(),
+                                configuration = configuration,
+                                sessionStrategy = sessionStrategy,
+                                bridge = bridge,
+                            )
+                        }
+
+                    default.set(LoggerState.Started(loggerImpl))
+
+                    preInitInMemoryLoggerRef.getAndSet(null)?.let { preInitLogger ->
+                        preInitLogger.flushToNative(loggerImpl)
+                        preInitLogger.clear()
+                    }
+
+                    // Must be initialized right after the logger state is set to avoid a null
+                    // Capture.logger() reference when onBeforeSend callbacks are triggered.
+                    loggerImpl.initIssueReporter()
+
+                    val sdkConfiguredDuration =
+                        SdkConfiguredDuration(
+                            wholeStartDuration = startSdkTimer.elapsedNow(),
+                            nativeLoadDuration = nativeLoadDuration,
+                            loggerImplBuildDuration = loggerImplBuildDuration,
+                        )
+
+                    loggerImpl.writeSdkStartLog(
+                        appContext = appContext,
+                        sdkConfiguredDuration = sdkConfiguredDuration,
+                        captureStartThread = Thread.currentThread().name,
+                    )
+
+                    startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Success(loggerImpl), executor)
+                } catch (throwable: Throwable) {
+                    reportStartFailure(
+                        errorDetails = "Failed to start Capture: ${throwable.message}",
+                        throwable = throwable,
+                        startResult = startResult,
+                        executor = executor,
                     )
                 }
+            }
 
-            default.set(LoggerState.Started(loggerImpl))
+        // Install the pre-init buffer so log calls made between now and `Started`
+        // are captured. `initSdk` is responsible for draining and clearing it.
+        preInitInMemoryLoggerRef.compareAndSet(null, PreInitInMemoryLogger())
 
-            // Must be initialized right after the logger state is set to avoid a null
-            // Capture.logger() reference when onBeforeSend callbacks are triggered.
-            loggerImpl.initIssueReporter()
-
-            val sdkConfiguredDuration =
-                SdkConfiguredDuration(
-                    wholeStartDuration = startSdkTimer.elapsedNow(),
-                    nativeLoadDuration = nativeLoadDuration,
-                    loggerImplBuildDuration = loggerImplBuildDuration,
-                )
-
-            loggerImpl.writeSdkStartLog(
-                appContext = appContext,
-                sdkConfiguredDuration = sdkConfiguredDuration,
-                captureStartThread = Thread.currentThread().name,
+        runCatching {
+            executor.execute(initAction)
+        }.onFailure { executorFailure ->
+            reportStartFailure(
+                errorDetails = "Executor rejected SDK init: ${executorFailure.message}",
+                throwable = executorFailure,
+                startResult = startResult,
             )
-
-            startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Success(loggerImpl))
-        } catch (throwable: Throwable) {
-            if (throwable.shouldReThrowOnDebugBuild()) throw throwable
-            val errorDetails = "Failed to start Capture: ${throwable.message}"
-            Log.w(LOG_TAG, errorDetails, throwable)
-            default.set(LoggerState.StartFailure)
-            startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)))
         }
+    }
+
+    private fun reportStartFailure(
+        errorDetails: String,
+        throwable: Throwable,
+        startResult: ((CaptureResult<ILogger>) -> Unit)?,
+        executor: Executor? = null,
+    ) {
+        preInitInMemoryLoggerRef.getAndSet(null)?.clear()
+
+        if (throwable.shouldReThrowOnDebugBuild()) throw throwable
+        Log.w(LOG_TAG, errorDetails, throwable)
+        default.set(LoggerState.StartFailure)
+        startResult.invokeCatchingOrThrowOnDebug(
+            CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)),
+            executor,
+        )
     }
 
     private fun Throwable.shouldReThrowOnDebugBuild(): Boolean = this is DebugCustomerCallbackException

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -48,10 +48,12 @@ import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.combineFields
+import io.bitdrift.capture.providers.extractFields
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFields
 import io.bitdrift.capture.providers.toLegacyJniFields
+import io.bitdrift.capture.providers.toThrowableFields
 import io.bitdrift.capture.reports.IssueCallbackConfiguration
 import io.bitdrift.capture.reports.IssueReporter
 import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
@@ -532,15 +534,7 @@ internal class LoggerImpl(
         blocking: Boolean,
         message: () -> String,
     ) {
-        val throwableFields =
-            if (throwable == null) {
-                ArrayFields.EMPTY
-            } else {
-                ArrayFields(
-                    arrayOf("_error", "_error_details"),
-                    arrayOf(throwable.javaClass.name.orEmpty(), throwable.message.orEmpty()),
-                )
-            }
+        val throwableFields = throwable.toThrowableFields()
         logInternal(
             type,
             level,
@@ -624,44 +618,6 @@ internal class LoggerImpl(
         durationS: Double,
     ) {
         CaptureJniLibrary.writeAppUpdateLog(this.loggerId, appVersion, appVersionCode, appSizeBytes, durationS)
-    }
-
-    internal fun extractFields(
-        fields: Map<String, String>?,
-        throwable: Throwable?,
-    ): ArrayFields {
-        val hasThrowable = throwable != null
-        val fieldsSize = fields?.size ?: 0
-
-        if (fieldsSize == 0 && !hasThrowable) {
-            return ArrayFields.EMPTY
-        }
-
-        val throwableFieldCount = if (hasThrowable) 2 else 0
-        val totalSize = fieldsSize + throwableFieldCount
-
-        val keys = ArrayList<String>(totalSize)
-        val values = ArrayList<String>(totalSize)
-
-        fields?.forEach { (key, value) ->
-            @Suppress("SENSELESS_COMPARISON")
-            if (key != null && value != null) {
-                keys.add(key)
-                values.add(value)
-            }
-        }
-
-        throwable?.let {
-            keys.add("_error")
-            values.add(it.javaClass.name.orEmpty())
-            keys.add("_error_details")
-            values.add(it.message.orEmpty())
-        }
-
-        return ArrayFields(
-            keys.toTypedArray(),
-            values.toTypedArray(),
-        )
     }
 
     @Suppress("UnusedPrivateMember")

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Models.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Models.kt
@@ -80,7 +80,7 @@ data object SdkNotStartedError : Error("SDK not started")
 
 /**
  * Represents a failure during SDK initialization.
- * This error is returned via the [Capture.Logger.start] result callback when the SDK
+ * This error is returned via the [Capture.Logger.startAsync] result callback when the SDK
  * fails to initialize.
  *
  * @param reason A message describing what went wrong during initialization.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/PreInitInMemoryLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/PreInitInMemoryLogger.kt
@@ -1,0 +1,308 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+import io.bitdrift.capture.events.span.Span
+import io.bitdrift.capture.network.HttpRequestInfo
+import io.bitdrift.capture.network.HttpResponseInfo
+import io.bitdrift.capture.providers.ArrayFields
+import io.bitdrift.capture.providers.combineFields
+import io.bitdrift.capture.providers.extractFields
+import io.bitdrift.capture.providers.fieldsOf
+import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.providers.toThrowableFields
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+
+internal class PreInitInMemoryLogger : ILogger {
+    private val bufferedCalls = ConcurrentLinkedQueue<BufferedCall>()
+    private val bufferedBytes = AtomicInteger(0)
+    private val droppedCallCount = AtomicInteger(0)
+
+    // Preserve the non-null ILogger contract while initSdk is still in progress. The outer
+    // Capture.Logger getters hide these placeholders by returning null for PreInitInMemoryLogger,
+    // So we keep consumers of ILogger expecting a non-null values
+    override val sessionId: String = UNKNOWN_VALUE
+    override val sessionUrl: String = UNKNOWN_VALUE
+    override val deviceId: String = UNKNOWN_VALUE
+    override val isTracingActive: Boolean = false
+
+    override fun startNewSession() = add(BufferedCall.StartNewSession)
+
+    override fun createTemporaryDeviceCode(completion: (CaptureResult<String>) -> Unit) =
+        add(BufferedCall.CreateTemporaryDeviceCode(completion))
+
+    override fun addField(
+        key: String,
+        value: String,
+    ) = add(BufferedCall.AddField(key, value))
+
+    override fun removeField(key: String) = add(BufferedCall.RemoveField(key))
+
+    override fun setFeatureFlagExposure(
+        name: String,
+        variant: String,
+    ) = add(BufferedCall.StringFeatureFlagExposure(name, variant))
+
+    override fun setEntityId(entityId: String) = add(BufferedCall.SetEntityId(entityId))
+
+    override fun clearEntityId() = add(BufferedCall.ClearEntityId)
+
+    override fun setFeatureFlagExposure(
+        name: String,
+        variant: Boolean,
+    ) = add(BufferedCall.BooleanFeatureFlagExposure(name, variant))
+
+    override fun log(
+        level: LogLevel,
+        fields: Map<String, String>?,
+        throwable: Throwable?,
+        message: () -> String,
+    ) = add(
+        BufferedCall.Log(
+            level = level,
+            fields = extractFields(fields, throwable),
+            occurredAtMs = System.currentTimeMillis(),
+            message = message(),
+        ),
+    )
+
+    override fun log(
+        level: LogLevel,
+        arrayFields: ArrayFields,
+        throwable: Throwable?,
+        message: () -> String,
+    ) = add(
+        BufferedCall.Log(
+            level = level,
+            fields = combineFields(arrayFields, throwable.toThrowableFields()),
+            occurredAtMs = System.currentTimeMillis(),
+            message = message(),
+        ),
+    )
+
+    override fun logAppLaunchTTI(duration: Duration) = add(BufferedCall.AppLaunchTti(duration))
+
+    override fun logScreenView(screenName: String) = add(BufferedCall.ScreenView(screenName))
+
+    override fun startSpan(
+        name: String,
+        level: LogLevel,
+        fields: Map<String, String>?,
+        startTimeMs: Long?,
+        parentSpanId: UUID?,
+    ): Span {
+        add(BufferedCall.StartSpan(name, level, fields?.toMap(), startTimeMs, parentSpanId))
+        return Span(null, name, level, fields?.toFields(), startTimeMs, parentSpanId)
+    }
+
+    override fun log(httpRequestInfo: HttpRequestInfo) = add(BufferedCall.HttpRequest(httpRequestInfo))
+
+    override fun log(httpResponseInfo: HttpResponseInfo) = add(BufferedCall.HttpResponse(httpResponseInfo))
+
+    override fun setSleepMode(sleepMode: SleepMode) = add(BufferedCall.SetSleepMode(sleepMode))
+
+    fun flushToNative(loggerImpl: LoggerImpl) {
+        generateSequence { bufferedCalls.poll() }.forEach { call ->
+            bufferedBytes.addAndGet(-call.sizeBytes)
+            call.replay(loggerImpl)
+        }
+
+        val droppedCalls = droppedCallCount.getAndSet(0)
+        if (droppedCalls > 0) {
+            loggerImpl.logInternal(
+                type = LogType.INTERNALSDK,
+                level = LogLevel.WARNING,
+                arrayFields = fieldsOf("dropped_call_count" to droppedCalls.toString()),
+            ) {
+                "Pre-init logger buffer overflowed while SDK was starting; new buffered calls were dropped"
+            }
+        }
+    }
+
+    fun clear() {
+        bufferedCalls.clear()
+        bufferedBytes.set(0)
+    }
+
+    private fun add(call: BufferedCall) {
+        if (!tryReserveBytes(call.sizeBytes)) {
+            droppedCallCount.incrementAndGet()
+            return
+        }
+
+        bufferedCalls.add(call)
+    }
+
+    private fun tryReserveBytes(bytes: Int): Boolean {
+        do {
+            val currentBytes = bufferedBytes.get()
+            if (bytes > MAX_BUFFER_BYTES - currentBytes) return false
+        } while (!bufferedBytes.compareAndSet(currentBytes, currentBytes + bytes))
+
+        return true
+    }
+
+    private sealed interface BufferedCall {
+        val sizeBytes: Int
+
+        fun replay(logger: IInternalLogger)
+
+        data object StartNewSession : BufferedCall {
+            override val sizeBytes = CALL_OVERHEAD_BYTES
+
+            override fun replay(logger: IInternalLogger) = logger.startNewSession()
+        }
+
+        data class CreateTemporaryDeviceCode(
+            val completion: (CaptureResult<String>) -> Unit,
+        ) : BufferedCall {
+            override val sizeBytes = CALL_OVERHEAD_BYTES
+
+            override fun replay(logger: IInternalLogger) = logger.createTemporaryDeviceCode(completion)
+        }
+
+        data class AddField(
+            val key: String,
+            val value: String,
+        ) : BufferedCall {
+            override val sizeBytes = sized(key, value)
+
+            override fun replay(logger: IInternalLogger) = logger.addField(key, value)
+        }
+
+        data class RemoveField(
+            val key: String,
+        ) : BufferedCall {
+            override val sizeBytes = sized(key)
+
+            override fun replay(logger: IInternalLogger) = logger.removeField(key)
+        }
+
+        data class StringFeatureFlagExposure(
+            val name: String,
+            val variant: String,
+        ) : BufferedCall {
+            override val sizeBytes = sized(name, variant)
+
+            override fun replay(logger: IInternalLogger) = logger.setFeatureFlagExposure(name, variant)
+        }
+
+        data class BooleanFeatureFlagExposure(
+            val name: String,
+            val variant: Boolean,
+        ) : BufferedCall {
+            override val sizeBytes = sized(name)
+
+            override fun replay(logger: IInternalLogger) = logger.setFeatureFlagExposure(name, variant)
+        }
+
+        data class SetEntityId(
+            val entityId: String,
+        ) : BufferedCall {
+            override val sizeBytes = sized(entityId)
+
+            override fun replay(logger: IInternalLogger) = logger.setEntityId(entityId)
+        }
+
+        data object ClearEntityId : BufferedCall {
+            override val sizeBytes = CALL_OVERHEAD_BYTES
+
+            override fun replay(logger: IInternalLogger) = logger.clearEntityId()
+        }
+
+        data class Log(
+            val level: LogLevel,
+            val fields: ArrayFields,
+            val occurredAtMs: Long,
+            val message: String,
+        ) : BufferedCall {
+            override val sizeBytes = sized(message) + fields.sizeBytes()
+
+            override fun replay(logger: IInternalLogger) {
+                logger.logInternal(
+                    type = LogType.NORMAL,
+                    level = level,
+                    arrayFields = fields,
+                    matchingArrayFields = ArrayFields.EMPTY,
+                    attributesOverrides = LogAttributesOverrides.OccurredAt(occurredAtMs),
+                    blocking = false,
+                ) { message }
+            }
+        }
+
+        data class AppLaunchTti(
+            val duration: Duration,
+        ) : BufferedCall {
+            override val sizeBytes = CALL_OVERHEAD_BYTES
+
+            override fun replay(logger: IInternalLogger) = logger.logAppLaunchTTI(duration)
+        }
+
+        data class ScreenView(
+            val screenName: String,
+        ) : BufferedCall {
+            override val sizeBytes = sized(screenName)
+
+            override fun replay(logger: IInternalLogger) = logger.logScreenView(screenName)
+        }
+
+        data class StartSpan(
+            val name: String,
+            val level: LogLevel,
+            val fields: Map<String, String>?,
+            val startTimeMs: Long?,
+            val parentSpanId: UUID?,
+        ) : BufferedCall {
+            override val sizeBytes = sized(name) + fields.sizeBytes()
+
+            override fun replay(logger: IInternalLogger) {
+                logger.startSpan(name, level, fields, startTimeMs, parentSpanId)
+            }
+        }
+
+        data class HttpRequest(
+            val request: HttpRequestInfo,
+        ) : BufferedCall {
+            override val sizeBytes = sized(request.toString())
+
+            override fun replay(logger: IInternalLogger) = logger.log(request)
+        }
+
+        data class HttpResponse(
+            val response: HttpResponseInfo,
+        ) : BufferedCall {
+            override val sizeBytes = sized(response.toString())
+
+            override fun replay(logger: IInternalLogger) = logger.log(response)
+        }
+
+        data class SetSleepMode(
+            val sleepMode: SleepMode,
+        ) : BufferedCall {
+            override val sizeBytes = CALL_OVERHEAD_BYTES
+
+            override fun replay(logger: IInternalLogger) = logger.setSleepMode(sleepMode)
+        }
+    }
+
+    private companion object {
+        private const val MAX_BUFFER_BYTES = 512 * 1024
+        private const val CALL_OVERHEAD_BYTES = 64
+        private const val UNKNOWN_VALUE = "unknown"
+
+        private fun sized(vararg values: String): Int = CALL_OVERHEAD_BYTES + values.sumOf { it.toByteArray(StandardCharsets.UTF_8).size }
+
+        private fun ArrayFields.sizeBytes(): Int = keys.indices.sumOf { sized(keys[it], values[it]) }
+
+        private fun Map<String, String>?.sizeBytes(): Int = this?.entries?.sumOf { sized(it.key, it.value) } ?: 0
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
@@ -30,7 +30,7 @@ import okhttp3.EventListener
  */
 class CaptureOkHttpEventListenerFactory internal constructor(
     private val targetEventListenerFactory: EventListener.Factory?,
-    private val logger: ILogger?,
+    private val loggerProvider: () -> ILogger?,
     private val clock: IClock,
     private val requestFieldProvider: OkHttpRequestFieldProvider,
     private val responseFieldProvider: OkHttpResponseFieldProvider,
@@ -49,7 +49,7 @@ class CaptureOkHttpEventListenerFactory internal constructor(
         responseFieldProvider: OkHttpResponseFieldProvider = DEFAULT_RESPONSE_FIELD_PROVIDER,
     ) : this(
         targetEventListenerFactory = targetEventListenerFactory,
-        logger = Capture.logger(),
+        loggerProvider = { Capture.logger() },
         clock = DefaultClock.getInstance(),
         requestFieldProvider = requestFieldProvider,
         responseFieldProvider = responseFieldProvider,
@@ -70,8 +70,7 @@ class CaptureOkHttpEventListenerFactory internal constructor(
         )
     }
 
-    // attempts to get the latest logger if one wasn't found at construction time
-    private fun getLogger(): ILogger? = logger ?: Capture.logger()
+    private fun getLogger(): ILogger? = loggerProvider()
 
     private companion object {
         private val DEFAULT_REQUEST_FIELD_PROVIDER = OkHttpRequestFieldProvider { emptyMap() }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
@@ -48,7 +48,7 @@ class CaptureOkHttpTracingInterceptor
             }
 
             val propagationMode = getPropagationMode()
-            propagationMode.logInternalStatus()
+            propagationMode.logInternalStatus(currentLogger)
 
             if (!shouldAddTraceHeaders(currentLogger, propagationMode, request)) {
                 return chain.proceed(request)
@@ -96,8 +96,8 @@ class CaptureOkHttpTracingInterceptor
             return TracePropagationMode.fromRuntimeValue(runtimeValue)
         }
 
-        private fun TracePropagationMode.logInternalStatus() {
-            val internalLogger = Capture.logger() as? IInternalLogger
+        private fun TracePropagationMode.logInternalStatus(currentLogger: ILogger) {
+            val internalLogger = currentLogger as? IInternalLogger
             internalLogger?.logInternal(
                 type = LogType.INTERNALSDK,
                 level = LogLevel.INFO,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
@@ -296,6 +296,57 @@ fun Map<String, String>?.toFieldsOrEmpty(): ArrayFields {
 }
 
 /**
+ * Converts optional log fields and throwable details into [ArrayFields].
+ */
+internal fun extractFields(
+    fields: Map<String, String>?,
+    throwable: Throwable?,
+): ArrayFields {
+    val hasThrowable = throwable != null
+    val fieldsSize = fields?.size ?: 0
+
+    if (fieldsSize == 0 && !hasThrowable) {
+        return ArrayFields.EMPTY
+    }
+
+    val throwableFieldCount = if (hasThrowable) 2 else 0
+    val totalSize = fieldsSize + throwableFieldCount
+
+    val keys = ArrayList<String>(totalSize)
+    val values = ArrayList<String>(totalSize)
+
+    fields?.forEach { (key, value) ->
+        @Suppress("SENSELESS_COMPARISON")
+        if (key != null && value != null) {
+            keys.add(key)
+            values.add(value)
+        }
+    }
+
+    throwable?.let {
+        keys.add("_error")
+        values.add(it.javaClass.name.orEmpty())
+        keys.add("_error_details")
+        values.add(it.message.orEmpty())
+    }
+
+    return ArrayFields(
+        keys.toTypedArray(),
+        values.toTypedArray(),
+    )
+}
+
+internal fun Throwable?.toThrowableFields(): ArrayFields =
+    if (this == null) {
+        ArrayFields.EMPTY
+    } else {
+        ArrayFields(
+            arrayOf("_error", "_error_details"),
+            arrayOf(javaClass.name.orEmpty(), message.orEmpty()),
+        )
+    }
+
+/**
  * Combines multiple InternalFields into a single array.
  */
 fun combineFields(vararg arrays: ArrayFields): ArrayFields {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebug.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebug.kt
@@ -10,19 +10,44 @@ package io.bitdrift.capture.utils
 import android.util.Log
 import io.bitdrift.capture.Capture.LOG_TAG
 import io.bitdrift.capture.ContextHolder
+import java.util.concurrent.Executor
 
 /**
  * Safely invokes a customer facing callback with the given [arg]. On failure:
  * - Always logs a warning to logcat.
  * - In debug builds, throws [DebugCustomerCallbackException] so the customer is aware during development.
  * - In release builds, the exception is swallowed to avoid crashing the app.
+ *
+ * If an [executor] is provided, the callback is dispatched through it. If the executor itself
+ * throws (e.g. RejectedExecutionException), the callback is invoked inline as a fallback.
  */
-internal fun <T> ((T) -> Unit)?.invokeCatchingOrThrowOnDebug(arg: T) {
-    runCatching {
-        this?.invoke(arg)
-    }.onFailure { throwable ->
-        DebugCustomerCallbackException.createIfDebug(throwable)?.let { throw it }
+internal fun <T> ((T) -> Unit)?.invokeCatchingOrThrowOnDebug(
+    arg: T,
+    executor: Executor? = null,
+) {
+    val callback = this ?: return
+
+    val action =
+        Runnable {
+            runCatching { callback(arg) }
+                .onFailure { handleCallbackFailure(it) }
+        }
+
+    if (executor == null) {
+        action.run()
+        return
     }
+
+    runCatching { executor.execute(action) }
+        .onFailure { executorFailure ->
+            // Executor rejected/failed — log, surface in debug, then run inline as fallback.
+            handleCallbackFailure(executorFailure)
+            action.run()
+        }
+}
+
+private fun handleCallbackFailure(throwable: Throwable) {
+    DebugCustomerCallbackException.createIfDebug(throwable)?.let { throw it }
 }
 
 /**

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -33,6 +33,10 @@ import org.junit.runners.MethodSorters
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
@@ -54,7 +58,7 @@ class CaptureTest {
     fun aConfigureSkipsLoggerCreationWhenContextNotInitialized() {
         assertThat(Capture.logger()).isNull()
 
-        Logger.start(
+        Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
@@ -67,7 +71,7 @@ class CaptureTest {
     fun aStart_withNullContext_emitsFailureCallback() {
         var capturedResult: CaptureResult<ILogger>? = null
 
-        Logger.start(
+        Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
@@ -122,7 +126,7 @@ class CaptureTest {
 
         var capturedResult: CaptureResult<ILogger>? = null
 
-        Logger.start(
+        Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
@@ -144,7 +148,7 @@ class CaptureTest {
         assertThat(success.value.sessionUrl).isNotEmpty()
         assertThat(success.value.deviceId).isNotEmpty()
 
-        Logger.start(
+        Logger.startAsync(
             apiKey = "test2",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
@@ -152,6 +156,74 @@ class CaptureTest {
 
         // Calling reconfigure a second time does not change the static logger.
         assertThat(logger).isEqualTo(Capture.logger())
+    }
+
+    @Test
+    fun startAsync_withExecutor_emitsSuccessAndUpdatesFlows() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+
+        val latch = CountDownLatch(1)
+        var capturedResult: CaptureResult<ILogger>? = null
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            Logger.startAsync(
+                apiKey = "test1",
+                sessionStrategy = SessionStrategy.Fixed(),
+                dateProvider = null,
+                executor = executor,
+            ) { result ->
+                capturedResult = result
+                latch.countDown()
+            }
+
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(capturedResult).isInstanceOf(CaptureResult.Success::class.java)
+            assertThat(Logger.sessionId).isNotEmpty()
+            assertThat(Logger.sessionUrl).isNotEmpty()
+            assertThat(Logger.deviceId).isNotEmpty()
+            assertThat(Logger.getSdkStatus().initializationState).isNotEqualTo(InitializationState.NOT_STARTED)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun startAsync_buffersLogsWhileStarting() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+
+        val executor = Executors.newSingleThreadExecutor()
+        val blockLatch = CountDownLatch(1)
+        val releaseLatch = CountDownLatch(1)
+        val completionLatch = CountDownLatch(1)
+
+        try {
+            Logger.startAsync(
+                apiKey = "test1",
+                sessionStrategy = SessionStrategy.Fixed(),
+                dateProvider = null,
+                executor =
+                    Executor { command ->
+                        executor.execute {
+                            blockLatch.countDown()
+                            releaseLatch.await(5, TimeUnit.SECONDS)
+                            command.run()
+                        }
+                    },
+            ) {
+                completionLatch.countDown()
+            }
+
+            assertThat(blockLatch.await(5, TimeUnit.SECONDS)).isTrue()
+            Logger.logInfo { "buffered log" }
+            releaseLatch.countDown()
+            assertThat(completionLatch.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(Capture.logger()).isNotNull()
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test
@@ -210,7 +282,7 @@ class CaptureTest {
         setIsDebuggable(debuggable = true)
 
         assertThatThrownBy {
-            Logger.start(
+            Logger.startAsync(
                 apiKey = "test1",
                 sessionStrategy = SessionStrategy.Fixed(),
                 dateProvider = null,
@@ -229,7 +301,7 @@ class CaptureTest {
         initializer.create(ApplicationProvider.getApplicationContext())
         setIsDebuggable(debuggable = false)
 
-        Logger.start(
+        Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTokioThreadTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTokioThreadTest.kt
@@ -33,7 +33,7 @@ class CaptureTokioThreadTest {
         val initializer = ContextHolder()
         initializer.create(ApplicationProvider.getApplicationContext())
 
-        Logger.start(
+        Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
@@ -54,7 +54,7 @@ class ConfigurationTest {
         // We start without configured logger.
         Assertions.assertThat(Capture.logger()).isNull()
 
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
@@ -87,7 +87,7 @@ class ConfigurationTest {
 
         // We perform another attempt to configure the logger to verify that
         // consecutive configure calls are no-ops.
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,
@@ -148,7 +148,7 @@ class ConfigurationTest {
 
         var capturedResult: CaptureResult<ILogger>? = null
 
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test1",
             sessionStrategy = SessionStrategy.Fixed(),
             dateProvider = null,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/SessionUrlTest.kt
@@ -70,7 +70,7 @@ class SessionUrlTest {
     }
 
     private fun startAndReturnLogger(apiUrl: String): ILogger? {
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test",
             apiUrl = apiUrl.toHttpUrl(),
             configuration = Configuration(),

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppLifecycleListenerLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/AppLifecycleListenerLoggerTest.kt
@@ -64,7 +64,7 @@ class AppLifecycleListenerLoggerTest {
     }
 
     @Test
-    fun testAppStartInfoFieldsAreSkippedIfNotCreate() {
+    fun testAppStartAsyncInfoFieldsAreSkippedIfNotCreate() {
         // ARRANGE
         whenever(versionChecker.isAtLeast(35)).thenReturn(true)
 
@@ -84,7 +84,7 @@ class AppLifecycleListenerLoggerTest {
     }
 
     @Test
-    fun testAppStartInfoFieldsAreSkippedIfError() {
+    fun testAppStartAsyncInfoFieldsAreSkippedIfError() {
         // ARRANGE
         whenever(versionChecker.isAtLeast(35)).thenReturn(true)
         val error = RuntimeException("test exception")
@@ -106,7 +106,7 @@ class AppLifecycleListenerLoggerTest {
     }
 
     @Test
-    fun testAppStartInfoFieldsAreLogged() {
+    fun testAppStartAsyncInfoFieldsAreLogged() {
         // ARRANGE
         val launchTime = 10 * 1_000_000L
         val firstFrameTime = 100 * 1_000_000L

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -636,9 +636,9 @@ class CaptureOkHttpEventListenerFactoryTest {
         // ACT
         val factory =
             CaptureOkHttpEventListenerFactory(
-                null,
-                logger,
-                clock,
+                targetEventListenerFactory = null,
+                loggerProvider = { logger },
+                clock = clock,
                 requestFieldProvider = requestFieldProvider,
                 responseFieldProvider = responseFieldProvider,
             )
@@ -747,7 +747,7 @@ class CaptureOkHttpEventListenerFactoryTest {
     ): CaptureOkHttpEventListenerFactory =
         CaptureOkHttpEventListenerFactory(
             targetEventListenerFactory = targetEventListenerCreator,
-            logger = logger,
+            loggerProvider = { logger },
             clock = clock,
             requestFieldProvider = requestFieldProvider,
             responseFieldProvider = responseFieldProvider,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionStrategyTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/session/SessionStrategyTest.kt
@@ -37,7 +37,7 @@ class SessionStrategyTest {
     fun fixedSessionStrategy() {
         val generatedSessionIds = mutableListOf<String>()
 
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test",
             apiUrl = testServerUrl(),
             fieldProviders = listOf(),

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/IssueCallbackConfigurationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/IssueCallbackConfigurationTest.kt
@@ -103,7 +103,7 @@ class IssueCallbackConfigurationTest {
         )
 
     private fun startSdkAndReturnLogger(issueCallbackConfiguration: IssueCallbackConfiguration): IInternalLogger {
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test",
             sessionStrategy = SessionStrategy.Fixed(),
             configuration = Configuration(issueCallbackConfiguration = issueCallbackConfiguration),

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/webview/WebViewCaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/webview/WebViewCaptureTest.kt
@@ -126,7 +126,7 @@ class WebViewCaptureTest {
     }
 
     private fun startSdk(webViewConfiguration: WebViewConfiguration?) {
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "test",
             sessionStrategy = SessionStrategy.Fixed(),
             configuration = Configuration(webViewConfiguration = webViewConfiguration),

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -10,6 +10,7 @@ package io.bitdrift.gradletestapp
 import android.app.Application
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
+import io.bitdrift.capture.Capture
 import io.bitdrift.gradletestapp.diagnostics.fatalissues.ThirdPartyCrashReportersInitializer
 import io.bitdrift.gradletestapp.diagnostics.lifecycle.ActivitySpanCallbacks
 import io.bitdrift.gradletestapp.diagnostics.papa.PapaTelemetry
@@ -18,12 +19,17 @@ import io.bitdrift.gradletestapp.diagnostics.strictmode.StrictModeConfigurator
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.DEFERRED_START_PREFS_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.DIAGNOSTICS_ENABLED_KEY
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
  * A Kotlin app entry point that initializes the Bitdrift Logger automatically only when ConfigState.isDeferredStart is set to false
  */
 class GradleTestApp : Application() {
+    @OptIn(DelicateCoroutinesApi::class)
     override fun onCreate() {
         super.onCreate()
 
@@ -39,6 +45,19 @@ class GradleTestApp : Application() {
             Timber.i("Deferred start enabled - SDK initialization skipped")
         } else {
             CaptureSdkInitializer.initFromPreferences(this, sharedPreferences)
+        }
+
+        triggerManyLogs()
+        GlobalScope.launch(Dispatchers.IO) {
+            triggerManyLogs()
+        }
+    }
+
+    private fun triggerManyLogs(){
+        repeat(125){
+            Capture.Logger.logInfo {
+                "Log info message $it called from ${Thread.currentThread().name}"
+            }
         }
     }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/ConfigState.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/ConfigState.kt
@@ -15,6 +15,7 @@ data class ConfigState(
     val apiUrl: String = "",
     val sessionStrategy: String = "",
     val isDeferredStart: Boolean = false,
+    val isBackgroundStart: Boolean = false,
     val selectedLogLevel: LogLevel = LogLevel.INFO,
     val isSleepModeEnabled: Boolean = false,
     val entityId: String = "",

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/SdkRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/SdkRepository.kt
@@ -16,6 +16,7 @@ import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.SleepMode
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
+import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BACKGROUND_START_PREFS_KEY
 import io.bitdrift.gradletestapp.data.model.GlobalFieldEntry
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BITDRIFT_API_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BITDRIFT_URL_KEY
@@ -23,12 +24,14 @@ import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Comp
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.PREFS_SLEEP_MODE_ENABLED
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.SESSION_REPLAY_ENABLED_PREFS_KEY
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import kotlin.coroutines.resume
 import java.net.URLDecoder
 import java.net.URLEncoder
+import kotlin.coroutines.resume
 
 /**
  * Repository that manages SDK state and operations
@@ -50,9 +53,10 @@ class SdkRepository(
                 putString(BITDRIFT_URL_KEY, apiUrl)
             }
         }
-        return withContext(Dispatchers.Main.immediate) {
-            CaptureSdkInitializer.initFromPreferences(applicationContext, sharedPreferences)
-        }
+        CaptureSdkInitializer.initFromPreferences(applicationContext, sharedPreferences)
+        return CaptureSdkInitializer.sdkInitializationState
+            .filterNotNull()
+            .first()
     }
 
     suspend fun startNewSession(): String? =
@@ -86,6 +90,7 @@ class SdkRepository(
             apiUrl = getApiUrl(),
             sessionStrategy = getSessionStrategy(),
             isDeferredStart = isDeferredStartEnabled(),
+            isBackgroundStart = isBackgroundStartEnabled(),
             isSessionReplayEnabled = isSessionReplayEnabled(),
             isSleepModeEnabled = isSleepModeEnabled(),
         )
@@ -120,6 +125,14 @@ class SdkRepository(
         withContext(Dispatchers.IO) {
             sharedPreferences.getBoolean(
                 DEFERRED_START_PREFS_KEY,
+                false,
+            )
+        }
+
+    suspend fun isBackgroundStartEnabled(): Boolean =
+        withContext(Dispatchers.IO) {
+            sharedPreferences.getBoolean(
+                BACKGROUND_START_PREFS_KEY,
                 false,
             )
         }
@@ -287,6 +300,7 @@ class SdkRepository(
         val apiUrl: String,
         val sessionStrategy: String,
         val isDeferredStart: Boolean,
+        val isBackgroundStart: Boolean,
         val isSessionReplayEnabled: Boolean,
         val isSleepModeEnabled: Boolean,
     )

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/webview/SampleAppWebViewCapture.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/webview/SampleAppWebViewCapture.kt
@@ -23,15 +23,14 @@ import io.bitdrift.capture.events.span.SpanResult
 
 class SampleAppWebViewCapture(
     private val original: WebViewClient,
-    private val logger: ILogger? = Capture.logger(),
+    private val loggerProvider: () -> ILogger? = { Capture.logger() },
 ) : WebViewClient() {
 
     // all WebViewClient callbacks are guaranteed to happen on the main thread, so no need for synchronization
     private var pageLoad: Span? = null
     private var ongoingRequest: PageLoadRequest? = null
 
-    // attempts to get the latest logger if one wasn't found at construction time
-    private fun getLogger(): ILogger? = logger ?: Capture.logger()
+    private fun getLogger(): ILogger? = loggerProvider()
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         if (ongoingRequest == null) {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/CaptureSdkInitializer.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/CaptureSdkInitializer.kt
@@ -18,7 +18,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.Configuration
-import io.bitdrift.capture.InitializationState
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
@@ -27,7 +26,7 @@ import io.bitdrift.capture.reports.IssueCallbackConfiguration
 import io.bitdrift.capture.reports.IssueReportCallback
 import io.bitdrift.capture.reports.Report
 import io.bitdrift.capture.webview.WebViewConfiguration
-import io.bitdrift.gradletestapp.data.repository.SdkRepository
+import io.bitdrift.gradletestapp.diagnostics.strictmode.StrictModeConfigurator
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_CONSOLE_LOGS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_ERRORS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_LONG_TASKS_KEY
@@ -38,8 +37,17 @@ import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Com
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_WEB_VITALS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_MONITORING_ENABLED_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment
+import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BACKGROUND_START_PREFS_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BITDRIFT_API_KEY
+import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.DIAGNOSTICS_ENABLED_KEY
 import io.sentry.Sentry
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
@@ -52,7 +60,10 @@ import java.util.concurrent.Executors
  */
 object CaptureSdkInitializer {
     private val userUuid = UUID.randomUUID().toString()
-    private val bitdriftSessionUrlKey = "bitdrift_session_url"
+    private const val BITDRIFT_SESSION_URL_KEY = "bitdrift_session_url"
+    private val _sdkInitializationState = MutableStateFlow<Boolean?>(null)
+
+    val sdkInitializationState: StateFlow<Boolean?> = _sdkInitializationState.asStateFlow()
 
     val currentUserUuid: String
         get() = userUuid
@@ -64,36 +75,59 @@ object CaptureSdkInitializer {
     fun initFromPreferences(
         applicationContext: Context,
         sharedPreferences: SharedPreferences,
-    ): Boolean {
+    ) {
 
         val persistedSdkConfigResult = getPersistedCaptureSdkSettings(
             applicationContext,
             sharedPreferences,
         )
 
-        return when (persistedSdkConfigResult) {
+        when (persistedSdkConfigResult) {
 
             is PersistedSdkConfigResult.Success -> {
-                startCaptureSdk(persistedSdkConfigResult.captureSdkInitSettings, applicationContext)
+                startCaptureSdk(
+                    persistedSdkConfigResult.captureSdkInitSettings,
+                    applicationContext,
+                    sharedPreferences,
+                )
                 logPreviousRunInfoToBitdrift()
-                return Capture.Logger.getSdkStatus().initializationState != InitializationState.NOT_STARTED
             }
 
             is PersistedSdkConfigResult.Failed -> {
                 Timber.i(persistedSdkConfigResult.message)
-                false
+                _sdkInitializationState.value = false
             }
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     @SuppressLint("LogNotTimber")
     @ExperimentalBitdriftApi
     private fun startCaptureSdk(
         settings: CaptureSdkInitSettings,
         context: Context,
+        sharedPreferences: SharedPreferences,
     ) {
+        val shouldStartInBackground =
+            sharedPreferences.getBoolean(BACKGROUND_START_PREFS_KEY, false)
 
-        Capture.Logger.start(
+
+        val shouldEnableStrictMode = sharedPreferences.getBoolean(DIAGNOSTICS_ENABLED_KEY, false)
+        if (shouldEnableStrictMode) {
+            StrictModeConfigurator.install()
+        }
+
+        if (shouldStartInBackground) {
+            GlobalScope.launch(Dispatchers.IO) {
+                startCaptureSdk(settings, context)
+            }
+        } else {
+            startCaptureSdk(settings, context)
+        }
+    }
+
+    private fun startCaptureSdk(settings: CaptureSdkInitSettings, context: Context){
+        Capture.Logger.startAsync(
             apiKey = settings.apiKey,
             apiUrl = settings.apiUrl,
             configuration = settings.configuration,
@@ -104,13 +138,18 @@ object CaptureSdkInitializer {
             when (startResult) {
                 is CaptureResult.Success -> {
                     val logger = startResult.value
-                    Log.d("bitdrift","SDK started successfully. sessionId=${logger.sessionId}, sessionUrl=${logger.sessionUrl}, userUuid=${userUuid}")
+                    Log.d(
+                        "bitdrift",
+                        "SDK started successfully. sessionId=${logger.sessionId}, sessionUrl=${logger.sessionUrl}, userUuid=${userUuid}"
+                    )
                     Capture.Logger.setEntityId(userUuid)
                     addSessionUrlToThirdPartySdks(context, logger.sessionUrl)
+                    _sdkInitializationState.value = true
                 }
 
                 is CaptureResult.Failure -> {
-                    Log.d("bitdrift","SDK failed to start: ${startResult.error.message}")
+                    Log.d("bitdrift", "SDK failed to start: ${startResult.error.message}")
+                    _sdkInitializationState.value = false
                     // Re-throwing on debug builds so we can get immediate signal of
                     // any issues at Capture.Logger.start internals during the development phase.
                     throw IllegalStateException(startResult.error.message)
@@ -136,12 +175,12 @@ object CaptureSdkInitializer {
         }
         val fatalIssueReporterEnabled =
             sharedPreferences.getBoolean(
-                ConfigurationSettingsFragment.Companion.FATAL_ISSUE_ENABLED_PREFS_KEY,
+                ConfigurationSettingsFragment.FATAL_ISSUE_ENABLED_PREFS_KEY,
                 true,
             )
         val sessionReplayEnabled =
             sharedPreferences.getBoolean(
-                ConfigurationSettingsFragment.Companion.SESSION_REPLAY_ENABLED_PREFS_KEY,
+                ConfigurationSettingsFragment.SESSION_REPLAY_ENABLED_PREFS_KEY,
                 true,
             )
 
@@ -186,7 +225,7 @@ object CaptureSdkInitializer {
         sharedPreferences: SharedPreferences
     ): SessionStrategy =
         if (sharedPreferences.getString(
-                ConfigurationSettingsFragment.Companion.SESSION_STRATEGY_PREFS_KEY,
+                ConfigurationSettingsFragment.SESSION_STRATEGY_PREFS_KEY,
                 ConfigurationSettingsFragment.SessionStrategyPreferences.FIXED.displayName,
             ) == "Fixed"
         ) {
@@ -200,9 +239,9 @@ object CaptureSdkInitializer {
                 inactivityThresholdMins = thresholdMins,
                 onSessionIdChanged = { sessionId ->
                     val message =
-                        "Bitdrift Logger session id updated due to inactivity: $sessionId. Callback triggered in ${Thread.currentThread().name} thread"
+                        "bitdrift Logger session id updated due to inactivity: $sessionId. Callback triggered in ${Thread.currentThread().name} thread"
                     Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
-                    Timber.Forest.i(message)
+                    Timber.i(message)
                 },
             )
         }
@@ -253,19 +292,19 @@ object CaptureSdkInitializer {
 
     private fun addSessionUrlToThirdPartySdks(applicationContext: Context, sessionUrl: String) {
         if (Sentry.isEnabled()) {
-            Sentry.setExtra(bitdriftSessionUrlKey, sessionUrl)
+            Sentry.setExtra(BITDRIFT_SESSION_URL_KEY, sessionUrl)
         }
 
         if (Bugsnag.isStarted()) {
             val frontendTabName = "bitdrift_session_url"
-            Bugsnag.addMetadata(frontendTabName, bitdriftSessionUrlKey, sessionUrl)
+            Bugsnag.addMetadata(frontendTabName, BITDRIFT_SESSION_URL_KEY, sessionUrl)
         }
 
         FirebaseApp.getApps(applicationContext)
             .firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
             ?.let {
                 FirebaseCrashlytics.getInstance()
-                    .setCustomKey(bitdriftSessionUrlKey, sessionUrl)
+                    .setCustomKey(BITDRIFT_SESSION_URL_KEY, sessionUrl)
             }
     }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/ConfigurationSettingsFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/ConfigurationSettingsFragment.kt
@@ -103,6 +103,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         backendCategory.addPreference(buildSwitchPreference(context))
         backendCategory.addPreference(buildSessionReplaySwitch(context))
         backendCategory.addPreference(buildDeferredStartSwitch(context))
+        backendCategory.addPreference(buildBackgroundStartSwitch(context))
         backendCategory.addPreference(buildWebViewMonitoringPreference(context))
         backendCategory.addPreference(buildDiagnosticsSwitch(context))
 
@@ -176,6 +177,9 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
     private fun buildDeferredStartSwitch(context: Context): SwitchPreference =
         buildSwitchPreference(context, DEFERRED_START_PREFS_KEY, DEFERRED_START_TITLE, false)
 
+    private fun buildBackgroundStartSwitch(context: Context): SwitchPreference =
+        buildSwitchPreference(context, BACKGROUND_START_PREFS_KEY, BACKGROUND_START_TITLE, false)
+
     private fun buildSessionReplaySwitch(context: Context): SwitchPreference =
         buildSwitchPreference(context, SESSION_REPLAY_ENABLED_PREFS_KEY, SESSION_REPLAY_TITLE, true)
 
@@ -222,6 +226,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         const val SESSION_STRATEGY_PREFS_KEY = "sessionStrategy"
         const val FATAL_ISSUE_ENABLED_PREFS_KEY = "fatalIssueEnabled"
         const val DEFERRED_START_PREFS_KEY = "deferredStart"
+        const val BACKGROUND_START_PREFS_KEY = "backgroundStart"
         const val SESSION_REPLAY_ENABLED_PREFS_KEY = "sessionReplayEnabled"
         const val DIAGNOSTICS_ENABLED_KEY = "diagnosticsEnabled"
         const val WEBVIEW_MONITORING_PREFS_KEY = "webviewMonitoring"
@@ -233,6 +238,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         private const val SESSION_STRATEGY_TITLE = "Session Strategy"
         private const val FATAL_ISSUE_TITLE = "Fatal Issue Reporter"
         private const val DEFERRED_START_TITLE = "Deferred SDK Start"
+        private const val BACKGROUND_START_TITLE = "Start SDK On Background Thread"
         private const val SESSION_REPLAY_TITLE = "Session Replay"
         private const val DIAGNOSTICS_TITLE = "Diagnostics Tools"
         private const val WEBVIEW_MONITORING_TITLE = "WebView Monitoring"

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -31,6 +31,7 @@ import io.bitdrift.gradletestapp.data.repository.NetworkTestingRepository
 import io.bitdrift.gradletestapp.data.repository.SdkRepository
 import io.bitdrift.gradletestapp.data.repository.StressTestRepository
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -55,6 +56,11 @@ class MainViewModel(
     init {
         viewModelScope.launch {
             initializeSdkConfig()
+            CaptureSdkInitializer.sdkInitializationState
+                .filterNotNull()
+                .collect {
+                    refreshSdkState()
+                }
         }
     }
 
@@ -68,6 +74,7 @@ class MainViewModel(
                         apiUrl = cfg.apiUrl,
                         sessionStrategy = cfg.sessionStrategy,
                         isDeferredStart = cfg.isDeferredStart,
+                        isBackgroundStart = cfg.isBackgroundStart,
                         isSleepModeEnabled = cfg.isSleepModeEnabled,
                         entityId = CaptureSdkInitializer.currentUserUuid,
                     ),
@@ -75,11 +82,15 @@ class MainViewModel(
         }
         val persistedFields = sdkRepository.restoreGlobalFields()
         _uiState.update { it.copy(globalFields = persistedFields) }
+        refreshSdkState()
+        checkAutoInitialization()
+    }
+
+    private suspend fun refreshSdkState() {
         updateSdkState()
         if (_uiState.value.session.isSdkInitialized) {
             checkConnectivity()
         }
-        checkAutoInitialization()
     }
 
     private fun checkAutoInitialization() {

--- a/platform/jvm/gradle-tv-test-app/src/main/java/io/bitdrift/gradletvtestapp/GradleTvTestApp.kt
+++ b/platform/jvm/gradle-tv-test-app/src/main/java/io/bitdrift/gradletvtestapp/GradleTvTestApp.kt
@@ -34,7 +34,7 @@ class GradleTvTestApp : Application() {
             return false
         }
 
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = apiKey,
             apiUrl = apiUrl,
             sessionStrategy = SessionStrategy.ActivityBased(inactivityThresholdMins = 30L),

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -28,10 +28,13 @@ import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.webview.WebViewBridgeMessageHandler
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.After
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.time.Duration
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -51,7 +54,7 @@ class LogBenchmarkTest {
     private fun startLogger(fieldProviders: List<FieldProvider> = listOf(), configuration: Configuration = Configuration()) {
         CaptureJniLibrary.load()
 
-        Capture.Logger.start(
+        Capture.Logger.startAsync(
             apiKey = "[test_api_key]",
             apiUrl = "https://api-test.bitdrift.dev".toHttpUrl(),
             context = InstrumentationRegistry.getInstrumentation().targetContext,
@@ -59,6 +62,13 @@ class LogBenchmarkTest {
             fieldProviders = fieldProviders,
             configuration =  configuration,
         )
+    }
+
+    @Ignore("TODO: Fran. Still prototyping")
+    @After
+    fun tearDown() {
+        destroyCurrentLogger()
+        Capture.Logger.resetShared()
     }
 
     private fun createFieldProviders(providers: Int = 5, fields: Int = 10): List<FieldProvider> {
@@ -168,7 +178,7 @@ class LogBenchmarkTest {
             handler.log(message)
         }
     }
-    
+
     @Test
     fun startNewSession() = benchmarkCaptureOperation{
         Capture.Logger.startNewSession()
@@ -194,6 +204,40 @@ class LogBenchmarkTest {
         Capture.Logger.clearEntityId()
     }
 
+    @Ignore("TODO: Fran. Still prototyping")
+    @Test
+    fun sdkStartOnMainThread() {
+        benchmarkSdkStart(initSdkExecutor = null)
+    }
+
+    @Ignore("TODO: Fran. Still prototyping")
+    @Test
+    fun sdkStartOnBackgroundThread() {
+        val executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "capture-sdk-start-background-thread")
+            }
+        try {
+            benchmarkSdkStart(initSdkExecutor = executor)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    private fun benchmarkSdkStart(initSdkExecutor: Executor?){
+        benchmarkRule.measureRepeated {
+            Capture.Logger.startAsync(
+                apiKey = "[test_api_key]",
+                apiUrl = "https://api-test.bitdrift.dev".toHttpUrl(),
+                context = InstrumentationRegistry.getInstrumentation().targetContext,
+                sessionStrategy = SessionStrategy.Fixed(),
+                executor = initSdkExecutor,
+            )
+            destroyCurrentLogger()
+            Capture.Logger.resetShared()
+        }
+    }
+
     private fun benchmarkCaptureOperation(configuration: Configuration = Configuration(), captureSdkOperation: () -> Unit ) {
         startLogger(fieldProviders = createFieldProviders(), configuration = configuration)
 
@@ -203,6 +247,13 @@ class LogBenchmarkTest {
     private fun getInternalLogger(): IInternalLogger {
         startLogger()
         return Capture.logger() as IInternalLogger
+    }
+
+    private fun destroyCurrentLogger() {
+        (Capture.logger() as? IInternalLogger)?.let {
+            CaptureJniLibrary.shutdown((it as io.bitdrift.capture.LoggerImpl).loggerId)
+            CaptureJniLibrary.destroyLogger(it.loggerId)
+        }
     }
 
     private fun buildFieldsMap(size: Int, keyIdentifier: String = "key_"): Map<String, String> =


### PR DESCRIPTION
A slight variation of https://github.com/bitdriftlabs/capture-sdk/pull/1060

Here we still have a PreInit memory buffer but exposing a new of Capture.Logger.startAsync API which will initialize internals of the SDK in an existing dedicated single thread scheduler (CaptureDispatchers.CommonBackgrouhnd)

Validated with this session https://timeline.bitdrift.dev/s/5f943df5-0fd5-40b4-8e69-a38959124a2a?utm_source=sdk (With an intentional internal delay of 5 seconds for initSdk)

<img width="721" height="597" alt="Screenshot 2026-08-04 at 15 46 20" src="https://github.com/user-attachments/assets/9b26275e-9701-4110-a342-0a1200c67f74" />

<img width="1691" height="361" alt="Screenshot 2026-08-04 at 15 46 47" src="https://github.com/user-attachments/assets/50aaea66-21a0-414f-8298-7265b8de5131" />

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.