### PR TITLE
[Android] Capture.Logger.preInit

### DIFF
--- a/platform/jvm/capture-timber/src/main/kotlin/io/bitdrift/capture/timber/CaptureTree.kt
+++ b/platform/jvm/capture-timber/src/main/kotlin/io/bitdrift/capture/timber/CaptureTree.kt
@@ -22,13 +22,9 @@ import timber.log.Timber
  * if the Logger is initialized.
  */
 open class CaptureTree internal constructor(
-    private val internalLogger: ILogger?,
+    private val loggerProvider: () -> ILogger?,
 ) : Timber.Tree() {
-    constructor() : this(Capture.logger())
-
-    // attempts to get the latest logger if one wasn't found at construction time
-    private val logger: ILogger?
-        get() = internalLogger ?: Capture.logger()
+    constructor() : this({ Capture.logger() })
 
     final override fun log(
         priority: Int,
@@ -36,7 +32,7 @@ open class CaptureTree internal constructor(
         message: String,
         t: Throwable?,
     ) {
-        logger?.log(toCaptureLogLevel(priority), extractFields(tag), t) { message }
+        loggerProvider()?.log(toCaptureLogLevel(priority), extractFields(tag), t) { message }
     }
 
     private fun toCaptureLogLevel(priority: Int): LogLevel =

--- a/platform/jvm/capture-timber/src/test/kotlin/io/bitdrift/capture/timber/CaptureTreeTest.kt
+++ b/platform/jvm/capture-timber/src/test/kotlin/io/bitdrift/capture/timber/CaptureTreeTest.kt
@@ -24,7 +24,7 @@ import java.io.IOException
 
 class CaptureTreeTest {
     private val mockLogger: ILogger = mock()
-    private val captureTree = CaptureTree(mockLogger)
+    private val captureTree = CaptureTree { mockLogger }
     private val message = "my_message"
 
     @Test

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -14,6 +14,7 @@ import android.os.strictmode.Violation
 import android.system.Os
 import android.util.Log
 import androidx.annotation.RequiresApi
+import io.bitdrift.capture.Capture.Logger.start
 import io.bitdrift.capture.Capture.Logger.startSpan
 import io.bitdrift.capture.LoggerImpl.SdkConfiguredDuration
 import io.bitdrift.capture.common.MainThreadHandler
@@ -32,6 +33,7 @@ import io.bitdrift.capture.utils.DebugCustomerCallbackException
 import io.bitdrift.capture.utils.invokeCatchingOrThrowOnDebug
 import okhttp3.HttpUrl
 import java.util.UUID
+import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.TimeSource
@@ -43,6 +45,12 @@ internal sealed class LoggerState {
      * The logger has not yet been started.
      */
     data object NotStarted : LoggerState()
+
+
+    /**
+     * The logger is in pre-init in memory buffer state
+     */
+    data object PreInit : LoggerState()
 
     /**
      * The logger is in the process of being started. Subsequent attempts to start the logger will be ignored.
@@ -68,6 +76,8 @@ internal sealed class LoggerState {
 object Capture {
     internal const val LOG_TAG = "BitdriftCapture"
     private val default: AtomicReference<LoggerState> = AtomicReference(LoggerState.NotStarted)
+    private val preInitInMemoryLoggerRef: AtomicReference<PreInitInMemoryLogger?> =
+        AtomicReference()
 
     /**
      * Returns a handle to the underlying logger instance, if Capture has been started.
@@ -77,7 +87,8 @@ object Capture {
     fun logger(): ILogger? =
         when (val state = default.get()) {
             is LoggerState.NotStarted -> null
-            is LoggerState.Starting -> null
+            is LoggerState.PreInit -> preInitInMemoryLoggerRef.get()
+            is LoggerState.Starting -> preInitInMemoryLoggerRef.get()
             is LoggerState.Started -> state.logger
             is LoggerState.StartFailure -> null
         }
@@ -121,6 +132,15 @@ object Capture {
             }
 
         /**
+         * Sends a signal to keep logs in memory while internal SDK is being initialized
+         */
+        @JvmStatic
+        fun preInit(){
+            default.compareAndSet(LoggerState.NotStarted, LoggerState.PreInit)
+            preInitInMemoryLoggerRef.compareAndSet(null, PreInitInMemoryLogger())
+        }
+
+        /**
          * Initializes the Capture SDK with the specified API key, providers, and configuration.
          * Calling other SDK methods has no effect unless the logger has been initialized.
          * Subsequent calls to this function will have no effect.
@@ -136,11 +156,13 @@ object Capture {
          * @param context an optional context reference. You should provide the context if called from
          * a [android.content.ContentProvider].
          * @param startResult an optional callback invoked with the result of the SDK initialization.
-         *                     The callback is always called on the calling thread before [start] returns.
+         *                     When no [executor] is provided, the callback is invoked on the calling thread
+         *                     before [start] returns. When an [executor] is provided, [start] returns
+         *                     immediately after submitting the init task, and the callback is invoked on the
+         *                     executor thread once initialization completes.
          *                     On success, it receives a [CaptureResult.Success] containing an [ILogger] instance.
          *                     On failure, it receives a [CaptureResult.Failure] with a [SdkStartFailure].
          */
-        @Synchronized
         @JvmStatic
         @JvmOverloads
         fun start(
@@ -166,9 +188,9 @@ object Capture {
             )
         }
 
-        // Note that we need to use @Synchronized to prevent multiple loggers from being initialized,
-        // while subsequent logger access relies on volatile reads.
-        @Synchronized
+        // Single-initialization is enforced by the atomic CAS on `default` below;
+        // no external locking is required. Callers observe the started LoggerImpl via
+        // `Capture.logger()`, published through the AtomicReference (volatile-equivalent semantics).
         @JvmStatic
         @JvmOverloads
         internal fun start(
@@ -191,53 +213,71 @@ object Capture {
             }
 
             // Ideally we would use `getAndUpdate` in here but it's available for API 24 and up only.
-            if (default.compareAndSet(LoggerState.NotStarted, LoggerState.Starting)) {
-                initSdk(
-                    apiKey = apiKey,
-                    sessionStrategy = sessionStrategy,
-                    configuration = configuration,
-                    fieldProviders = fieldProviders,
-                    dateProvider = dateProvider,
-                    apiUrl = apiUrl,
-                    bridge = bridge,
-                    context = context,
-                    startResult = startResult,
-                )
-            } else {
+            // Only the CAS winner performs any side effects; concurrent/repeat callers are a no-op.
+            val didStart =
+                default.compareAndSet(LoggerState.NotStarted, LoggerState.Starting) ||
+                        default.compareAndSet(LoggerState.PreInit, LoggerState.Starting)
+            if (!didStart) {
                 Log.w(LOG_TAG, "Multiple attempts to start Capture")
+                return
             }
+
+            initSdk(
+                apiKey = apiKey,
+                sessionStrategy = sessionStrategy,
+                configuration = configuration,
+                fieldProviders = fieldProviders,
+                dateProvider = dateProvider,
+                apiUrl = apiUrl,
+                bridge = bridge,
+                context = context,
+                startResult = startResult,
+            )
         }
 
         /**
          * The Id for the current ongoing session.
-         * It's equal to `null` prior to the start of Capture SDK.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [start].
          */
         @JvmStatic
         val sessionId: String?
-            get() = logger()?.sessionId
+            get() = logger()?.takeUnless { it is PreInitInMemoryLogger }?.sessionId
 
         /**
          * The URL for the current ongoing session.
-         * It's equal to `null` prior to the start of Capture SDK.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [start].
          */
         @JvmStatic
         val sessionUrl: String?
-            get() = logger()?.sessionUrl
+            get() = logger()?.takeUnless { it is PreInitInMemoryLogger }?.sessionUrl
 
         /**
          * A canonical identifier for a device that remains consistent as long as an application
          * is not reinstalled.
          *
          * The value of this property is different for apps from the same vendor running on
-         * the same device. It is equal to null prior to the start of bitdrift Capture SDK.
+         * the same device.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [start].
          */
         @JvmStatic
         val deviceId: String?
-            get() = logger()?.deviceId
+            get() = logger()?.takeUnless { it is PreInitInMemoryLogger }?.deviceId
 
         /**
          * Whether workflow-controlled tracing is currently active for this session.
-         * Returns `null` prior to SDK start.
+         *
+         * Returns `null` until the Capture SDK has finished starting successfully.
+         * To obtain a guaranteed non-null value, use the [ILogger] instance delivered
+         * via [CaptureResult.Success] to the `startResult` callback passed to [start].
          */
         @JvmStatic
         val isTracingActive: Boolean?
@@ -305,9 +345,7 @@ object Capture {
             key: String,
             value: String,
         ) {
-            logger()?.let {
-                it.addField(key, value)
-            }
+            logger()?.addField(key, value)
         }
 
         /**
@@ -686,66 +724,97 @@ object Capture {
         context: Context?,
         startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
     ) {
-        try {
-            val startSdkTimer = TimeSource.Monotonic.markNow()
+        val initAction =
+            Runnable {
+                try {
+                    val startSdkTimer = TimeSource.Monotonic.markNow()
 
-            if (!ContextHolder.isInitialized && context != null) {
-                // Make sure the global context is set if no Initializer was used
-                ContextHolder.APP_CONTEXT = context.applicationContext
-            }
+                    if (!ContextHolder.isInitialized && context != null) {
+                        // Make sure the global context is set if no Initializer was used
+                        ContextHolder.APP_CONTEXT = context.applicationContext
+                    }
 
-            val appContext = ContextHolder.APP_CONTEXT
+                    val appContext = ContextHolder.APP_CONTEXT
 
-            // This needs to happen before loading the native library as we set
-            // up logging during library initialization.
-            setUpInternalLogging(appContext)
+                    // This needs to happen before loading the native library as we set
+                    // up logging during library initialization.
+                    setUpInternalLogging(appContext)
 
-            val nativeLoadDuration =
-                measureTime {
-                    CaptureJniLibrary.load()
-                }
+                    val nativeLoadDuration =
+                        measureTime {
+                            CaptureJniLibrary.load()
+                        }
 
-            val (loggerImpl, loggerImplBuildDuration) =
-                measureTimedValue {
-                    LoggerImpl(
-                        apiKey = apiKey,
-                        apiUrl = apiUrl,
-                        context = appContext,
-                        fieldProviders = fieldProviders,
-                        dateProvider = dateProvider ?: SystemDateProvider(),
-                        configuration = configuration,
-                        sessionStrategy = sessionStrategy,
-                        bridge = bridge,
+                    val (loggerImpl, loggerImplBuildDuration) =
+                        measureTimedValue {
+                            LoggerImpl(
+                                apiKey = apiKey,
+                                apiUrl = apiUrl,
+                                context = appContext,
+                                fieldProviders = fieldProviders,
+                                dateProvider = dateProvider ?: SystemDateProvider(),
+                                configuration = configuration,
+                                sessionStrategy = sessionStrategy,
+                                bridge = bridge,
+                            )
+                        }
+
+                    default.set(LoggerState.Started(loggerImpl))
+
+                    preInitInMemoryLoggerRef.getAndSet(null)?.let { preInitLogger ->
+                        preInitLogger.flushToNative(loggerImpl)
+                        preInitLogger.clear()
+                    }
+
+                    // Must be initialized right after the logger state is set to avoid a null
+                    // Capture.logger() reference when onBeforeSend callbacks are triggered.
+                    loggerImpl.initIssueReporter()
+
+                    val sdkConfiguredDuration =
+                        SdkConfiguredDuration(
+                            wholeStartDuration = startSdkTimer.elapsedNow(),
+                            nativeLoadDuration = nativeLoadDuration,
+                            loggerImplBuildDuration = loggerImplBuildDuration,
+                        )
+
+                    loggerImpl.writeSdkStartLog(
+                        appContext = appContext,
+                        sdkConfiguredDuration = sdkConfiguredDuration,
+                        captureStartThread = Thread.currentThread().name,
+                    )
+
+                    startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Success(loggerImpl))
+                } catch (throwable: Throwable) {
+                    reportStartFailure(
+                        errorDetails = "Failed to start Capture: ${throwable.message}",
+                        throwable = throwable,
+                        startResult = startResult,
                     )
                 }
+            }
 
-            default.set(LoggerState.Started(loggerImpl))
+        // Install the pre-init buffer so log calls made between now and `Started`
+        // are captured. `initSdk` is responsible for draining and clearing it.
+        preInitInMemoryLoggerRef.compareAndSet(null, PreInitInMemoryLogger())
 
-            // Must be initialized right after the logger state is set to avoid a null
-            // Capture.logger() reference when onBeforeSend callbacks are triggered.
-            loggerImpl.initIssueReporter()
+        initAction.run()
+    }
 
-            val sdkConfiguredDuration =
-                SdkConfiguredDuration(
-                    wholeStartDuration = startSdkTimer.elapsedNow(),
-                    nativeLoadDuration = nativeLoadDuration,
-                    loggerImplBuildDuration = loggerImplBuildDuration,
-                )
+    private fun reportStartFailure(
+        errorDetails: String,
+        throwable: Throwable,
+        startResult: ((CaptureResult<ILogger>) -> Unit)?,
+        executor: Executor? = null,
+    ) {
+        preInitInMemoryLoggerRef.getAndSet(null)?.clear()
 
-            loggerImpl.writeSdkStartLog(
-                appContext = appContext,
-                sdkConfiguredDuration = sdkConfiguredDuration,
-                captureStartThread = Thread.currentThread().name,
-            )
-
-            startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Success(loggerImpl))
-        } catch (throwable: Throwable) {
-            if (throwable.shouldReThrowOnDebugBuild()) throw throwable
-            val errorDetails = "Failed to start Capture: ${throwable.message}"
-            Log.w(LOG_TAG, errorDetails, throwable)
-            default.set(LoggerState.StartFailure)
-            startResult.invokeCatchingOrThrowOnDebug(CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)))
-        }
+        if (throwable.shouldReThrowOnDebugBuild()) throw throwable
+        Log.w(LOG_TAG, errorDetails, throwable)
+        default.set(LoggerState.StartFailure)
+        startResult.invokeCatchingOrThrowOnDebug(
+            CaptureResult.Failure(SdkStartFailure(errorDetails, throwable)),
+            executor,
+        )
     }
 
     private fun Throwable.shouldReThrowOnDebugBuild(): Boolean = this is DebugCustomerCallbackException

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -48,10 +48,12 @@ import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.combineFields
+import io.bitdrift.capture.providers.extractFields
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.providers.toFields
 import io.bitdrift.capture.providers.toLegacyJniFields
+import io.bitdrift.capture.providers.toThrowableFields
 import io.bitdrift.capture.reports.IssueCallbackConfiguration
 import io.bitdrift.capture.reports.IssueReporter
 import io.bitdrift.capture.reports.exitinfo.ILatestAppExitInfoProvider
@@ -532,15 +534,7 @@ internal class LoggerImpl(
         blocking: Boolean,
         message: () -> String,
     ) {
-        val throwableFields =
-            if (throwable == null) {
-                ArrayFields.EMPTY
-            } else {
-                ArrayFields(
-                    arrayOf("_error", "_error_details"),
-                    arrayOf(throwable.javaClass.name.orEmpty(), throwable.message.orEmpty()),
-                )
-            }
+        val throwableFields = throwable.toThrowableFields()
         logInternal(
             type,
             level,
@@ -624,44 +618,6 @@ internal class LoggerImpl(
         durationS: Double,
     ) {
         CaptureJniLibrary.writeAppUpdateLog(this.loggerId, appVersion, appVersionCode, appSizeBytes, durationS)
-    }
-
-    internal fun extractFields(
-        fields: Map<String, String>?,
-        throwable: Throwable?,
-    ): ArrayFields {
-        val hasThrowable = throwable != null
-        val fieldsSize = fields?.size ?: 0
-
-        if (fieldsSize == 0 && !hasThrowable) {
-            return ArrayFields.EMPTY
-        }
-
-        val throwableFieldCount = if (hasThrowable) 2 else 0
-        val totalSize = fieldsSize + throwableFieldCount
-
-        val keys = ArrayList<String>(totalSize)
-        val values = ArrayList<String>(totalSize)
-
-        fields?.forEach { (key, value) ->
-            @Suppress("SENSELESS_COMPARISON")
-            if (key != null && value != null) {
-                keys.add(key)
-                values.add(value)
-            }
-        }
-
-        throwable?.let {
-            keys.add("_error")
-            values.add(it.javaClass.name.orEmpty())
-            keys.add("_error_details")
-            values.add(it.message.orEmpty())
-        }
-
-        return ArrayFields(
-            keys.toTypedArray(),
-            values.toTypedArray(),
-        )
     }
 
     @Suppress("UnusedPrivateMember")

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/PreInitInMemoryLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/PreInitInMemoryLogger.kt
@@ -1,0 +1,183 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+import io.bitdrift.capture.events.span.Span
+import io.bitdrift.capture.network.HttpRequestInfo
+import io.bitdrift.capture.network.HttpResponseInfo
+import io.bitdrift.capture.providers.ArrayFields
+import io.bitdrift.capture.providers.combineFields
+import io.bitdrift.capture.providers.extractFields
+import io.bitdrift.capture.providers.fieldsOf
+import io.bitdrift.capture.providers.toFields
+import io.bitdrift.capture.providers.toThrowableFields
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+
+internal class PreInitInMemoryLogger : ILogger {
+    private val bufferedLoggerCalls = ConcurrentLinkedQueue<(IInternalLogger) -> Unit>()
+    private val droppedCallCount = AtomicInteger(0)
+
+    // Preserve the non-null ILogger contract while initSdk is still in progress. The outer
+    // Capture.Logger getters hide these placeholders by returning null for PreInitInMemoryLogger,
+    // So we keep consumers of ILogger expecting a non-null values
+    override val sessionId: String = UNKNOWN_VALUE
+
+    override val sessionUrl: String = UNKNOWN_VALUE
+
+    override val deviceId: String = UNKNOWN_VALUE
+
+    override val isTracingActive: Boolean = false
+
+    override fun startNewSession() {
+        addLoggerCall { it.startNewSession() }
+    }
+
+    override fun createTemporaryDeviceCode(completion: (CaptureResult<String>) -> Unit) {
+        addLoggerCall { it.createTemporaryDeviceCode(completion) }
+    }
+
+    override fun addField(
+        key: String,
+        value: String,
+    ) {
+        addLoggerCall { it.addField(key, value) }
+    }
+
+    override fun removeField(key: String) {
+        addLoggerCall { it.removeField(key) }
+    }
+
+    override fun setFeatureFlagExposure(
+        name: String,
+        variant: String,
+    ) {
+        addLoggerCall { it.setFeatureFlagExposure(name, variant) }
+    }
+
+    override fun setEntityId(entityId: String) {
+        addLoggerCall { it.setEntityId(entityId) }
+    }
+
+    override fun clearEntityId() {
+        addLoggerCall { it.clearEntityId() }
+    }
+
+    override fun setFeatureFlagExposure(
+        name: String,
+        variant: Boolean,
+    ) {
+        addLoggerCall { it.setFeatureFlagExposure(name, variant) }
+    }
+
+    override fun log(
+        level: LogLevel,
+        fields: Map<String, String>?,
+        throwable: Throwable?,
+        message: () -> String,
+    ) {
+        val occurredAtMs = System.currentTimeMillis()
+        addLoggerCall { logger ->
+            logger.logInternal(
+                type = LogType.NORMAL,
+                level = level,
+                arrayFields = extractFields(fields, throwable),
+                matchingArrayFields = ArrayFields.EMPTY,
+                attributesOverrides = LogAttributesOverrides.OccurredAt(occurredAtMs),
+                blocking = false,
+                message = message,
+            )
+        }
+    }
+
+    override fun log(
+        level: LogLevel,
+        arrayFields: ArrayFields,
+        throwable: Throwable?,
+        message: () -> String,
+    ) {
+        val occurredAtMs = System.currentTimeMillis()
+        addLoggerCall { logger ->
+            logger.logInternal(
+                type = LogType.NORMAL,
+                level = level,
+                arrayFields = combineFields(arrayFields, throwable.toThrowableFields()),
+                matchingArrayFields = ArrayFields.EMPTY,
+                attributesOverrides = LogAttributesOverrides.OccurredAt(occurredAtMs),
+                blocking = false,
+                message = message,
+            )
+        }
+    }
+
+    override fun logAppLaunchTTI(duration: Duration) {
+        addLoggerCall { it.logAppLaunchTTI(duration) }
+    }
+
+    override fun logScreenView(screenName: String) {
+        addLoggerCall { it.logScreenView(screenName) }
+    }
+
+    override fun startSpan(
+        name: String,
+        level: LogLevel,
+        fields: Map<String, String>?,
+        startTimeMs: Long?,
+        parentSpanId: UUID?,
+    ): Span {
+        addLoggerCall { it.startSpan(name, level, fields, startTimeMs, parentSpanId) }
+        return Span(null, name, level, fields?.toFields(), startTimeMs, parentSpanId)
+    }
+
+    override fun log(httpRequestInfo: HttpRequestInfo) {
+        addLoggerCall { it.log(httpRequestInfo) }
+    }
+
+    override fun log(httpResponseInfo: HttpResponseInfo) {
+        addLoggerCall { it.log(httpResponseInfo) }
+    }
+
+    override fun setSleepMode(sleepMode: SleepMode) {
+        addLoggerCall { it.setSleepMode(sleepMode) }
+    }
+
+    fun flushToNative(loggerImpl: LoggerImpl) {
+        bufferedLoggerCalls.forEach { it(loggerImpl) }
+        bufferedLoggerCalls.clear()
+
+        val droppedCalls = droppedCallCount.getAndSet(0)
+        if (droppedCalls > 0) {
+            loggerImpl.logInternal(
+                type = LogType.INTERNALSDK,
+                level = LogLevel.WARNING,
+                arrayFields = fieldsOf("dropped_call_count" to droppedCalls.toString()),
+            ) {
+                "Pre-init logger buffer overflowed while SDK was starting; oldest buffered calls were evicted"
+            }
+        }
+    }
+
+    fun clear() {
+        bufferedLoggerCalls.clear()
+    }
+
+    private fun addLoggerCall(logCall: (IInternalLogger) -> Unit) {
+        if (bufferedLoggerCalls.size >= MAX_LOG_CALL_SIZE) {
+            bufferedLoggerCalls.poll()
+            droppedCallCount.incrementAndGet()
+        }
+        bufferedLoggerCalls.add(logCall)
+    }
+
+    private companion object {
+        private const val MAX_LOG_CALL_SIZE = 512
+        private const val UNKNOWN_VALUE = "unknown"
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactory.kt
@@ -30,7 +30,7 @@ import okhttp3.EventListener
  */
 class CaptureOkHttpEventListenerFactory internal constructor(
     private val targetEventListenerFactory: EventListener.Factory?,
-    private val logger: ILogger?,
+    private val loggerProvider: () -> ILogger?,
     private val clock: IClock,
     private val requestFieldProvider: OkHttpRequestFieldProvider,
     private val responseFieldProvider: OkHttpResponseFieldProvider,
@@ -49,7 +49,7 @@ class CaptureOkHttpEventListenerFactory internal constructor(
         responseFieldProvider: OkHttpResponseFieldProvider = DEFAULT_RESPONSE_FIELD_PROVIDER,
     ) : this(
         targetEventListenerFactory = targetEventListenerFactory,
-        logger = Capture.logger(),
+        loggerProvider = { Capture.logger() },
         clock = DefaultClock.getInstance(),
         requestFieldProvider = requestFieldProvider,
         responseFieldProvider = responseFieldProvider,
@@ -70,8 +70,7 @@ class CaptureOkHttpEventListenerFactory internal constructor(
         )
     }
 
-    // attempts to get the latest logger if one wasn't found at construction time
-    private fun getLogger(): ILogger? = logger ?: Capture.logger()
+    private fun getLogger(): ILogger? = loggerProvider()
 
     private companion object {
         private val DEFAULT_REQUEST_FIELD_PROVIDER = OkHttpRequestFieldProvider { emptyMap() }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpTracingInterceptor.kt
@@ -48,7 +48,7 @@ class CaptureOkHttpTracingInterceptor
             }
 
             val propagationMode = getPropagationMode()
-            propagationMode.logInternalStatus()
+            propagationMode.logInternalStatus(currentLogger)
 
             if (!shouldAddTraceHeaders(currentLogger, propagationMode, request)) {
                 return chain.proceed(request)
@@ -96,8 +96,8 @@ class CaptureOkHttpTracingInterceptor
             return TracePropagationMode.fromRuntimeValue(runtimeValue)
         }
 
-        private fun TracePropagationMode.logInternalStatus() {
-            val internalLogger = Capture.logger() as? IInternalLogger
+        private fun TracePropagationMode.logInternalStatus(currentLogger: ILogger) {
+            val internalLogger = currentLogger as? IInternalLogger
             internalLogger?.logInternal(
                 type = LogType.INTERNALSDK,
                 level = LogLevel.INFO,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
@@ -296,6 +296,57 @@ fun Map<String, String>?.toFieldsOrEmpty(): ArrayFields {
 }
 
 /**
+ * Converts optional log fields and throwable details into [ArrayFields].
+ */
+internal fun extractFields(
+    fields: Map<String, String>?,
+    throwable: Throwable?,
+): ArrayFields {
+    val hasThrowable = throwable != null
+    val fieldsSize = fields?.size ?: 0
+
+    if (fieldsSize == 0 && !hasThrowable) {
+        return ArrayFields.EMPTY
+    }
+
+    val throwableFieldCount = if (hasThrowable) 2 else 0
+    val totalSize = fieldsSize + throwableFieldCount
+
+    val keys = ArrayList<String>(totalSize)
+    val values = ArrayList<String>(totalSize)
+
+    fields?.forEach { (key, value) ->
+        @Suppress("SENSELESS_COMPARISON")
+        if (key != null && value != null) {
+            keys.add(key)
+            values.add(value)
+        }
+    }
+
+    throwable?.let {
+        keys.add("_error")
+        values.add(it.javaClass.name.orEmpty())
+        keys.add("_error_details")
+        values.add(it.message.orEmpty())
+    }
+
+    return ArrayFields(
+        keys.toTypedArray(),
+        values.toTypedArray(),
+    )
+}
+
+internal fun Throwable?.toThrowableFields(): ArrayFields =
+    if (this == null) {
+        ArrayFields.EMPTY
+    } else {
+        ArrayFields(
+            arrayOf("_error", "_error_details"),
+            arrayOf(javaClass.name.orEmpty(), message.orEmpty()),
+        )
+    }
+
+/**
  * Combines multiple InternalFields into a single array.
  */
 fun combineFields(vararg arrays: ArrayFields): ArrayFields {

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebug.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/utils/InvokeCatchingOrThrowOnDebug.kt
@@ -10,19 +10,44 @@ package io.bitdrift.capture.utils
 import android.util.Log
 import io.bitdrift.capture.Capture.LOG_TAG
 import io.bitdrift.capture.ContextHolder
+import java.util.concurrent.Executor
 
 /**
  * Safely invokes a customer facing callback with the given [arg]. On failure:
  * - Always logs a warning to logcat.
  * - In debug builds, throws [DebugCustomerCallbackException] so the customer is aware during development.
  * - In release builds, the exception is swallowed to avoid crashing the app.
+ *
+ * If an [executor] is provided, the callback is dispatched through it. If the executor itself
+ * throws (e.g. RejectedExecutionException), the callback is invoked inline as a fallback.
  */
-internal fun <T> ((T) -> Unit)?.invokeCatchingOrThrowOnDebug(arg: T) {
-    runCatching {
-        this?.invoke(arg)
-    }.onFailure { throwable ->
-        DebugCustomerCallbackException.createIfDebug(throwable)?.let { throw it }
+internal fun <T> ((T) -> Unit)?.invokeCatchingOrThrowOnDebug(
+    arg: T,
+    executor: Executor? = null,
+) {
+    val callback = this ?: return
+
+    val action =
+        Runnable {
+            runCatching { callback(arg) }
+                .onFailure { handleCallbackFailure(it) }
+        }
+
+    if (executor == null) {
+        action.run()
+        return
     }
+
+    runCatching { executor.execute(action) }
+        .onFailure { executorFailure ->
+            // Executor rejected/failed — log, surface in debug, then run inline as fallback.
+            handleCallbackFailure(executorFailure)
+            action.run()
+        }
+}
+
+private fun handleCallbackFailure(throwable: Throwable) {
+    DebugCustomerCallbackException.createIfDebug(throwable)?.let { throw it }
 }
 
 /**

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureTest.kt
@@ -33,6 +33,10 @@ import org.junit.runners.MethodSorters
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
@@ -152,6 +156,74 @@ class CaptureTest {
 
         // Calling reconfigure a second time does not change the static logger.
         assertThat(logger).isEqualTo(Capture.logger())
+    }
+
+    @Test
+    fun startAsync_withExecutor_emitsSuccessAndUpdatesFlows() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+
+        val latch = CountDownLatch(1)
+        var capturedResult: CaptureResult<ILogger>? = null
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            Logger.start(
+                apiKey = "test1",
+                sessionStrategy = SessionStrategy.Fixed(),
+                dateProvider = null,
+                executor = executor,
+            ) { result ->
+                capturedResult = result
+                latch.countDown()
+            }
+
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(capturedResult).isInstanceOf(CaptureResult.Success::class.java)
+            assertThat(Logger.sessionId).isNotEmpty()
+            assertThat(Logger.sessionUrl).isNotEmpty()
+            assertThat(Logger.deviceId).isNotEmpty()
+            assertThat(Logger.getSdkStatus().initializationState).isNotEqualTo(InitializationState.NOT_STARTED)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun startAsync_buffersLogsWhileStarting() {
+        val initializer = ContextHolder()
+        initializer.create(ApplicationProvider.getApplicationContext())
+
+        val executor = Executors.newSingleThreadExecutor()
+        val blockLatch = CountDownLatch(1)
+        val releaseLatch = CountDownLatch(1)
+        val completionLatch = CountDownLatch(1)
+
+        try {
+            Logger.start(
+                apiKey = "test1",
+                sessionStrategy = SessionStrategy.Fixed(),
+                dateProvider = null,
+                executor =
+                    Executor { command ->
+                        executor.execute {
+                            blockLatch.countDown()
+                            releaseLatch.await(5, TimeUnit.SECONDS)
+                            command.run()
+                        }
+                    },
+            ) {
+                completionLatch.countDown()
+            }
+
+            assertThat(blockLatch.await(5, TimeUnit.SECONDS)).isTrue()
+            Logger.logInfo { "buffered log" }
+            releaseLatch.countDown()
+            assertThat(completionLatch.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThat(Capture.logger()).isNotNull()
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -636,9 +636,9 @@ class CaptureOkHttpEventListenerFactoryTest {
         // ACT
         val factory =
             CaptureOkHttpEventListenerFactory(
-                null,
-                logger,
-                clock,
+                targetEventListenerFactory = null,
+                loggerProvider = { logger },
+                clock = clock,
                 requestFieldProvider = requestFieldProvider,
                 responseFieldProvider = responseFieldProvider,
             )
@@ -747,7 +747,7 @@ class CaptureOkHttpEventListenerFactoryTest {
     ): CaptureOkHttpEventListenerFactory =
         CaptureOkHttpEventListenerFactory(
             targetEventListenerFactory = targetEventListenerCreator,
-            logger = logger,
+            loggerProvider = { logger },
             clock = clock,
             requestFieldProvider = requestFieldProvider,
             responseFieldProvider = responseFieldProvider,

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -9,36 +9,50 @@ package io.bitdrift.gradletestapp
 
 import android.app.Application
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.preference.PreferenceManager
+import io.bitdrift.capture.Capture
 import io.bitdrift.gradletestapp.diagnostics.fatalissues.ThirdPartyCrashReportersInitializer
 import io.bitdrift.gradletestapp.diagnostics.lifecycle.ActivitySpanCallbacks
 import io.bitdrift.gradletestapp.diagnostics.papa.PapaTelemetry
 import io.bitdrift.gradletestapp.diagnostics.startup.AppStartInfoLogger
-import io.bitdrift.gradletestapp.diagnostics.strictmode.StrictModeConfigurator
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.DEFERRED_START_PREFS_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.DIAGNOSTICS_ENABLED_KEY
 import timber.log.Timber
+import kotlin.time.measureTime
 
 /**
  * A Kotlin app entry point that initializes the Bitdrift Logger automatically only when ConfigState.isDeferredStart is set to false
  */
 class GradleTestApp : Application() {
     override fun onCreate() {
-        super.onCreate()
+        val duration = measureTime {
+            super.onCreate()
 
-        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+            Capture.Logger.preInit()
 
-        ThirdPartyCrashReportersInitializer.init(this)
+            val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
 
-        if (areAdditionalDiagnosticToolsEnabled(sharedPreferences)) {
-            attachDiagnosticTools()
+            if (areAdditionalDiagnosticToolsEnabled(sharedPreferences)) {
+                attachDiagnosticTools()
+            }
+
+            ThirdPartyCrashReportersInitializer.init(this)
+
+            if (hasDeferredSdkStartConfigured(sharedPreferences)) {
+                Timber.i("Deferred start enabled - SDK initialization skipped")
+            } else {
+                CaptureSdkInitializer.initFromPreferences(this, sharedPreferences)
+            }
+
         }
-
-        if (hasDeferredSdkStartConfigured(sharedPreferences)) {
-            Timber.i("Deferred start enabled - SDK initialization skipped")
-        } else {
-            CaptureSdkInitializer.initFromPreferences(this, sharedPreferences)
+        val onStartDurationMessage =
+            "onCreate duration is ${duration.inWholeMilliseconds} ms"
+        Log.d("bitdrift gradle-test-app", onStartDurationMessage)
+        Capture.Logger.logInfo { onStartDurationMessage }
+        repeat(10){
+            Capture.Logger.logInfo { "Log $it emitted from ${Thread.currentThread().name}" }
         }
     }
 
@@ -49,7 +63,6 @@ class GradleTestApp : Application() {
         sharedPreferences.getBoolean(DEFERRED_START_PREFS_KEY, false)
 
     private fun attachDiagnosticTools() {
-        StrictModeConfigurator.install()
         ActivitySpanCallbacks.create()
         AppStartInfoLogger.register(this)
         PapaTelemetry.install()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/ConfigState.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/ConfigState.kt
@@ -15,6 +15,7 @@ data class ConfigState(
     val apiUrl: String = "",
     val sessionStrategy: String = "",
     val isDeferredStart: Boolean = false,
+    val isBackgroundStart: Boolean = false,
     val selectedLogLevel: LogLevel = LogLevel.INFO,
     val isSleepModeEnabled: Boolean = false,
     val entityId: String = "",

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/SdkRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/SdkRepository.kt
@@ -16,6 +16,7 @@ import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.LogLevel
 import io.bitdrift.capture.SleepMode
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
+import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BACKGROUND_START_PREFS_KEY
 import io.bitdrift.gradletestapp.data.model.GlobalFieldEntry
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BITDRIFT_API_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BITDRIFT_URL_KEY
@@ -23,12 +24,14 @@ import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Comp
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.PREFS_SLEEP_MODE_ENABLED
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.SESSION_REPLAY_ENABLED_PREFS_KEY
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import kotlin.coroutines.resume
 import java.net.URLDecoder
 import java.net.URLEncoder
+import kotlin.coroutines.resume
 
 /**
  * Repository that manages SDK state and operations
@@ -50,9 +53,10 @@ class SdkRepository(
                 putString(BITDRIFT_URL_KEY, apiUrl)
             }
         }
-        return withContext(Dispatchers.Main.immediate) {
-            CaptureSdkInitializer.initFromPreferences(applicationContext, sharedPreferences)
-        }
+        CaptureSdkInitializer.initFromPreferences(applicationContext, sharedPreferences)
+        return CaptureSdkInitializer.sdkInitializationState
+            .filterNotNull()
+            .first()
     }
 
     suspend fun startNewSession(): String? =
@@ -86,6 +90,7 @@ class SdkRepository(
             apiUrl = getApiUrl(),
             sessionStrategy = getSessionStrategy(),
             isDeferredStart = isDeferredStartEnabled(),
+            isBackgroundStart = isBackgroundStartEnabled(),
             isSessionReplayEnabled = isSessionReplayEnabled(),
             isSleepModeEnabled = isSleepModeEnabled(),
         )
@@ -120,6 +125,14 @@ class SdkRepository(
         withContext(Dispatchers.IO) {
             sharedPreferences.getBoolean(
                 DEFERRED_START_PREFS_KEY,
+                false,
+            )
+        }
+
+    suspend fun isBackgroundStartEnabled(): Boolean =
+        withContext(Dispatchers.IO) {
+            sharedPreferences.getBoolean(
+                BACKGROUND_START_PREFS_KEY,
                 false,
             )
         }
@@ -287,6 +300,7 @@ class SdkRepository(
         val apiUrl: String,
         val sessionStrategy: String,
         val isDeferredStart: Boolean,
+        val isBackgroundStart: Boolean,
         val isSessionReplayEnabled: Boolean,
         val isSleepModeEnabled: Boolean,
     )

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/webview/SampleAppWebViewCapture.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/webview/SampleAppWebViewCapture.kt
@@ -23,15 +23,14 @@ import io.bitdrift.capture.events.span.SpanResult
 
 class SampleAppWebViewCapture(
     private val original: WebViewClient,
-    private val logger: ILogger? = Capture.logger(),
+    private val loggerProvider: () -> ILogger? = { Capture.logger() },
 ) : WebViewClient() {
 
     // all WebViewClient callbacks are guaranteed to happen on the main thread, so no need for synchronization
     private var pageLoad: Span? = null
     private var ongoingRequest: PageLoadRequest? = null
 
-    // attempts to get the latest logger if one wasn't found at construction time
-    private fun getLogger(): ILogger? = logger ?: Capture.logger()
+    private fun getLogger(): ILogger? = loggerProvider()
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         if (ongoingRequest == null) {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/CaptureSdkInitializer.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/init/CaptureSdkInitializer.kt
@@ -18,7 +18,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import io.bitdrift.capture.Capture
 import io.bitdrift.capture.CaptureResult
 import io.bitdrift.capture.Configuration
-import io.bitdrift.capture.InitializationState
 import io.bitdrift.capture.experimental.ExperimentalBitdriftApi
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
@@ -27,7 +26,7 @@ import io.bitdrift.capture.reports.IssueCallbackConfiguration
 import io.bitdrift.capture.reports.IssueReportCallback
 import io.bitdrift.capture.reports.Report
 import io.bitdrift.capture.webview.WebViewConfiguration
-import io.bitdrift.gradletestapp.data.repository.SdkRepository
+import io.bitdrift.gradletestapp.diagnostics.strictmode.StrictModeConfigurator
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_CONSOLE_LOGS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_ERRORS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_LONG_TASKS_KEY
@@ -38,8 +37,17 @@ import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Com
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_ENABLE_WEB_VITALS_KEY
 import io.bitdrift.gradletestapp.ui.compose.components.WebViewSettingsDialog.Companion.WEBVIEW_MONITORING_ENABLED_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment
+import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BACKGROUND_START_PREFS_KEY
 import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.BITDRIFT_API_KEY
+import io.bitdrift.gradletestapp.ui.fragments.ConfigurationSettingsFragment.Companion.DIAGNOSTICS_ENABLED_KEY
 import io.sentry.Sentry
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
@@ -52,7 +60,10 @@ import java.util.concurrent.Executors
  */
 object CaptureSdkInitializer {
     private val userUuid = UUID.randomUUID().toString()
-    private val bitdriftSessionUrlKey = "bitdrift_session_url"
+    private const val BITDRIFT_SESSION_URL_KEY = "bitdrift_session_url"
+    private val _sdkInitializationState = MutableStateFlow<Boolean?>(null)
+
+    val sdkInitializationState: StateFlow<Boolean?> = _sdkInitializationState.asStateFlow()
 
     val currentUserUuid: String
         get() = userUuid
@@ -64,35 +75,59 @@ object CaptureSdkInitializer {
     fun initFromPreferences(
         applicationContext: Context,
         sharedPreferences: SharedPreferences,
-    ): Boolean {
+    ) {
 
         val persistedSdkConfigResult = getPersistedCaptureSdkSettings(
             applicationContext,
             sharedPreferences,
         )
 
-        return when (persistedSdkConfigResult) {
+        when (persistedSdkConfigResult) {
 
             is PersistedSdkConfigResult.Success -> {
-                startCaptureSdk(persistedSdkConfigResult.captureSdkInitSettings, applicationContext)
+                startCaptureSdk(
+                    persistedSdkConfigResult.captureSdkInitSettings,
+                    applicationContext,
+                    sharedPreferences,
+                )
                 logPreviousRunInfoToBitdrift()
-                return Capture.Logger.getSdkStatus().initializationState != InitializationState.NOT_STARTED
             }
 
             is PersistedSdkConfigResult.Failed -> {
                 Timber.i(persistedSdkConfigResult.message)
-                false
+                _sdkInitializationState.value = false
             }
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     @SuppressLint("LogNotTimber")
     @ExperimentalBitdriftApi
     private fun startCaptureSdk(
         settings: CaptureSdkInitSettings,
         context: Context,
+        sharedPreferences: SharedPreferences,
     ) {
+        val shouldStartInBackground =
+            sharedPreferences.getBoolean(BACKGROUND_START_PREFS_KEY, false)
 
+        if (shouldStartInBackground) {
+            GlobalScope.launch(Dispatchers.IO) {
+                startCaptureSdk(settings, context)
+            }
+        } else {
+            startCaptureSdk(settings, context)
+        }
+
+        val shouldEnableStrictMode = sharedPreferences.getBoolean(DIAGNOSTICS_ENABLED_KEY, false)
+        if (shouldEnableStrictMode) {
+            StrictModeConfigurator.install()
+        }
+
+
+    }
+
+    private fun startCaptureSdk(settings: CaptureSdkInitSettings, context: Context){
         Capture.Logger.start(
             apiKey = settings.apiKey,
             apiUrl = settings.apiUrl,
@@ -107,10 +142,12 @@ object CaptureSdkInitializer {
                     Log.d("bitdrift","SDK started successfully. sessionId=${logger.sessionId}, sessionUrl=${logger.sessionUrl}, userUuid=${userUuid}")
                     Capture.Logger.setEntityId(userUuid)
                     addSessionUrlToThirdPartySdks(context, logger.sessionUrl)
+                    _sdkInitializationState.value = true
                 }
 
                 is CaptureResult.Failure -> {
                     Log.d("bitdrift","SDK failed to start: ${startResult.error.message}")
+                    _sdkInitializationState.value = false
                     // Re-throwing on debug builds so we can get immediate signal of
                     // any issues at Capture.Logger.start internals during the development phase.
                     throw IllegalStateException(startResult.error.message)
@@ -136,12 +173,12 @@ object CaptureSdkInitializer {
         }
         val fatalIssueReporterEnabled =
             sharedPreferences.getBoolean(
-                ConfigurationSettingsFragment.Companion.FATAL_ISSUE_ENABLED_PREFS_KEY,
+                ConfigurationSettingsFragment.FATAL_ISSUE_ENABLED_PREFS_KEY,
                 true,
             )
         val sessionReplayEnabled =
             sharedPreferences.getBoolean(
-                ConfigurationSettingsFragment.Companion.SESSION_REPLAY_ENABLED_PREFS_KEY,
+                ConfigurationSettingsFragment.SESSION_REPLAY_ENABLED_PREFS_KEY,
                 true,
             )
 
@@ -186,7 +223,7 @@ object CaptureSdkInitializer {
         sharedPreferences: SharedPreferences
     ): SessionStrategy =
         if (sharedPreferences.getString(
-                ConfigurationSettingsFragment.Companion.SESSION_STRATEGY_PREFS_KEY,
+                ConfigurationSettingsFragment.SESSION_STRATEGY_PREFS_KEY,
                 ConfigurationSettingsFragment.SessionStrategyPreferences.FIXED.displayName,
             ) == "Fixed"
         ) {
@@ -200,9 +237,9 @@ object CaptureSdkInitializer {
                 inactivityThresholdMins = thresholdMins,
                 onSessionIdChanged = { sessionId ->
                     val message =
-                        "Bitdrift Logger session id updated due to inactivity: $sessionId. Callback triggered in ${Thread.currentThread().name} thread"
+                        "bitdrift Logger session id updated due to inactivity: $sessionId. Callback triggered in ${Thread.currentThread().name} thread"
                     Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
-                    Timber.Forest.i(message)
+                    Timber.i(message)
                 },
             )
         }
@@ -253,19 +290,19 @@ object CaptureSdkInitializer {
 
     private fun addSessionUrlToThirdPartySdks(applicationContext: Context, sessionUrl: String) {
         if (Sentry.isEnabled()) {
-            Sentry.setExtra(bitdriftSessionUrlKey, sessionUrl)
+            Sentry.setExtra(BITDRIFT_SESSION_URL_KEY, sessionUrl)
         }
 
         if (Bugsnag.isStarted()) {
             val frontendTabName = "bitdrift_session_url"
-            Bugsnag.addMetadata(frontendTabName, bitdriftSessionUrlKey, sessionUrl)
+            Bugsnag.addMetadata(frontendTabName, BITDRIFT_SESSION_URL_KEY, sessionUrl)
         }
 
         FirebaseApp.getApps(applicationContext)
             .firstOrNull { it.name == FirebaseApp.DEFAULT_APP_NAME }
             ?.let {
                 FirebaseCrashlytics.getInstance()
-                    .setCustomKey(bitdriftSessionUrlKey, sessionUrl)
+                    .setCustomKey(BITDRIFT_SESSION_URL_KEY, sessionUrl)
             }
     }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/ConfigurationSettingsFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/ConfigurationSettingsFragment.kt
@@ -103,6 +103,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         backendCategory.addPreference(buildSwitchPreference(context))
         backendCategory.addPreference(buildSessionReplaySwitch(context))
         backendCategory.addPreference(buildDeferredStartSwitch(context))
+        backendCategory.addPreference(buildBackgroundStartSwitch(context))
         backendCategory.addPreference(buildWebViewMonitoringPreference(context))
         backendCategory.addPreference(buildDiagnosticsSwitch(context))
 
@@ -176,6 +177,9 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
     private fun buildDeferredStartSwitch(context: Context): SwitchPreference =
         buildSwitchPreference(context, DEFERRED_START_PREFS_KEY, DEFERRED_START_TITLE, false)
 
+    private fun buildBackgroundStartSwitch(context: Context): SwitchPreference =
+        buildSwitchPreference(context, BACKGROUND_START_PREFS_KEY, BACKGROUND_START_TITLE, false)
+
     private fun buildSessionReplaySwitch(context: Context): SwitchPreference =
         buildSwitchPreference(context, SESSION_REPLAY_ENABLED_PREFS_KEY, SESSION_REPLAY_TITLE, true)
 
@@ -222,6 +226,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         const val SESSION_STRATEGY_PREFS_KEY = "sessionStrategy"
         const val FATAL_ISSUE_ENABLED_PREFS_KEY = "fatalIssueEnabled"
         const val DEFERRED_START_PREFS_KEY = "deferredStart"
+        const val BACKGROUND_START_PREFS_KEY = "backgroundStart"
         const val SESSION_REPLAY_ENABLED_PREFS_KEY = "sessionReplayEnabled"
         const val DIAGNOSTICS_ENABLED_KEY = "diagnosticsEnabled"
         const val WEBVIEW_MONITORING_PREFS_KEY = "webviewMonitoring"
@@ -233,6 +238,7 @@ class ConfigurationSettingsFragment : PreferenceFragmentCompat() {
         private const val SESSION_STRATEGY_TITLE = "Session Strategy"
         private const val FATAL_ISSUE_TITLE = "Fatal Issue Reporter"
         private const val DEFERRED_START_TITLE = "Deferred SDK Start"
+        private const val BACKGROUND_START_TITLE = "Start SDK On Background Thread"
         private const val SESSION_REPLAY_TITLE = "Session Replay"
         private const val DIAGNOSTICS_TITLE = "Diagnostics Tools"
         private const val WEBVIEW_MONITORING_TITLE = "WebView Monitoring"

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -31,6 +31,7 @@ import io.bitdrift.gradletestapp.data.repository.NetworkTestingRepository
 import io.bitdrift.gradletestapp.data.repository.SdkRepository
 import io.bitdrift.gradletestapp.data.repository.StressTestRepository
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -55,6 +56,11 @@ class MainViewModel(
     init {
         viewModelScope.launch {
             initializeSdkConfig()
+            CaptureSdkInitializer.sdkInitializationState
+                .filterNotNull()
+                .collect {
+                    refreshSdkState()
+                }
         }
     }
 
@@ -68,6 +74,7 @@ class MainViewModel(
                         apiUrl = cfg.apiUrl,
                         sessionStrategy = cfg.sessionStrategy,
                         isDeferredStart = cfg.isDeferredStart,
+                        isBackgroundStart = cfg.isBackgroundStart,
                         isSleepModeEnabled = cfg.isSleepModeEnabled,
                         entityId = CaptureSdkInitializer.currentUserUuid,
                     ),
@@ -75,11 +82,15 @@ class MainViewModel(
         }
         val persistedFields = sdkRepository.restoreGlobalFields()
         _uiState.update { it.copy(globalFields = persistedFields) }
+        refreshSdkState()
+        checkAutoInitialization()
+    }
+
+    private suspend fun refreshSdkState() {
         updateSdkState()
         if (_uiState.value.session.isSdkInitialized) {
             checkConnectivity()
         }
-        checkAutoInitialization()
     }
 
     private fun checkAutoInitialization() {

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -28,9 +28,13 @@ import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.webview.WebViewBridgeMessageHandler
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.After
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -59,6 +63,13 @@ class LogBenchmarkTest {
             fieldProviders = fieldProviders,
             configuration =  configuration,
         )
+    }
+
+    @Ignore("TODO: Fran. Still prototyping")
+    @After
+    fun tearDown() {
+        destroyCurrentLogger()
+        Capture.Logger.resetShared()
     }
 
     private fun createFieldProviders(providers: Int = 5, fields: Int = 10): List<FieldProvider> {
@@ -168,7 +179,7 @@ class LogBenchmarkTest {
             handler.log(message)
         }
     }
-    
+
     @Test
     fun startNewSession() = benchmarkCaptureOperation{
         Capture.Logger.startNewSession()
@@ -194,6 +205,40 @@ class LogBenchmarkTest {
         Capture.Logger.clearEntityId()
     }
 
+    @Ignore("TODO: Fran. Still prototyping")
+    @Test
+    fun sdkStartOnMainThread() {
+        benchmarkSdkStart(initSdkExecutor = null)
+    }
+
+    @Ignore("TODO: Fran. Still prototyping")
+    @Test
+    fun sdkStartOnBackgroundThread() {
+        val executor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "capture-sdk-start-background-thread")
+            }
+        try {
+            benchmarkSdkStart(initSdkExecutor = executor)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    private fun benchmarkSdkStart(initSdkExecutor: Executor?){
+        benchmarkRule.measureRepeated {
+            Capture.Logger.start(
+                apiKey = "[test_api_key]",
+                apiUrl = "https://api-test.bitdrift.dev".toHttpUrl(),
+                context = InstrumentationRegistry.getInstrumentation().targetContext,
+                sessionStrategy = SessionStrategy.Fixed(),
+                executor = initSdkExecutor,
+            )
+            destroyCurrentLogger()
+            Capture.Logger.resetShared()
+        }
+    }
+
     private fun benchmarkCaptureOperation(configuration: Configuration = Configuration(), captureSdkOperation: () -> Unit ) {
         startLogger(fieldProviders = createFieldProviders(), configuration = configuration)
 
@@ -203,6 +248,13 @@ class LogBenchmarkTest {
     private fun getInternalLogger(): IInternalLogger {
         startLogger()
         return Capture.logger() as IInternalLogger
+    }
+
+    private fun destroyCurrentLogger() {
+        (Capture.logger() as? IInternalLogger)?.let {
+            CaptureJniLibrary.shutdown((it as io.bitdrift.capture.LoggerImpl).loggerId)
+            CaptureJniLibrary.destroyLogger(it.loggerId)
+        }
     }
 
     private fun buildFieldsMap(size: Int, keyIdentifier: String = "key_"): Map<String, String> =


### PR DESCRIPTION
A slight variation of https://github.com/bitdriftlabs/capture-sdk/pull/1060

Here we expose a new public API Capture.Logger.preInit, that can be called before initial Capture.Logger.start call so any logs are not missed during initialization of start (in case this gets called off main thread)



