### PR TITLE
avoid rebuilding apk during size CI check

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -142,10 +142,9 @@ jobs:
       - name: Build Bazel APK and AAR
         timeout-minutes: 30
         run: |
-          # Build APK for x86_64 (this also builds the AAR dependency)
-          ./bazelw build --config ci --config release-android --android_platforms=@rules_android//:x86_64 //examples/android:android_app
-          # Build AAR for x86_64 to match the APK architecture and reuse build artifacts
-          ./bazelw build :capture_aar --config ci --config release-android --android_platforms=@rules_android//:x86_64
+          # Make both artifacts top-level outputs so Bazel materializes the AAR
+          # without a separate invocation or executing the shared actions twice.
+          ./bazelw build --config ci --config release-android --android_platforms=@rules_android//:x86_64 //examples/android:android_app :capture_aar
 
       - name: Upload PR APK
         uses: actions/upload-artifact@v4
@@ -164,7 +163,7 @@ jobs:
           stat -c%s "$APK_PATH" > "$APK_SIZE_FILE"
 
           # Get AAR SO size
-          ./tools/capture_so_size.sh x86_64 > so_size_output.txt
+          ./tools/capture_so_size.sh --aar ./bazel-bin/capture_aar_local.aar x86_64 > so_size_output.txt
           SO_SIZE_KB=$(grep "SO_SIZE_KB=" so_size_output.txt | cut -d'=' -f2)
           SO_SIZE_FILE=ci/baseline_so_size_x86_64_kb.txt
           echo "$SO_SIZE_KB" > "$SO_SIZE_FILE"
@@ -233,8 +232,8 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         id: so_size
         run: |
-          # Run the capture_so_size script to get the current SO size
-          ./tools/capture_so_size.sh x86_64 > so_size_output.txt
+          # Reuse the AAR materialized by the Bazel build to get the current SO size.
+          ./tools/capture_so_size.sh --aar ./bazel-bin/capture_aar_local.aar x86_64 > so_size_output.txt
           SO_SIZE_KB=$(grep "SO_SIZE_KB=" so_size_output.txt | cut -d'=' -f2)
           BASELINE_PATH=ci/baseline_so_size_x86_64_kb.txt
 

--- a/tools/capture_so_size.sh
+++ b/tools/capture_so_size.sh
@@ -2,36 +2,83 @@
 
 set -euo pipefail
 
-# Default to arm64-v8a if no architecture specified
-ARCH=${1:-arm64-v8a}
+# Default to arm64-v8a if no architecture is specified. Passing --aar reuses
+# an existing AAR instead of building one, which is useful when CI has already
+# built it as part of another target.
+ARCH="arm64-v8a"
+AAR=""
 
-# Build the .aar with Android release flags
-./bazelw build :capture_aar --config release-android --android_platforms=@rules_android//:"$ARCH"
+usage() {
+    cat <<'EOF'
+Usage: tools/capture_so_size.sh [--aar PATH] [ARCH]
 
-aar=$(pwd)/bazel-bin/capture_aar_local.aar
+Build the capture AAR for ARCH and print its stripped native-library size.
 
-mkdir -p /tmp/bitdrift_so
-pushd /tmp/bitdrift_so
-    # Unzip the .aar, strip the .so and then re-zip it.
-	unzip "$aar"
-	
-	# Determine JNI path based on architecture
-	if [[ "$ARCH" == "x86_64" ]]; then
-	    JNI_PATH="jni/x86_64"
-	else
-	    JNI_PATH="jni/arm64-v8a"
-	fi
-	
-	llvm-strip "$JNI_PATH/libcapture.so"
-	zip -r aar.zip "$JNI_PATH/libcapture.so"
-	# print size in kiB for higher granularity.
-	du -k aar.zip
-	du -h aar.zip
-	
-	# Output just the size in KB for CI parsing
-	size_kb=$(du -k aar.zip | awk '{print $1}')
-	echo "SO_SIZE_KB=$size_kb"
-popd
+Options:
+  --aar PATH  Reuse an existing AAR instead of invoking Bazel.
+  -h, --help  Show this help text.
+EOF
+}
 
-# Cleanup
-rm -rf /tmp/bitdrift_so
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --aar)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --aar requires a path" >&2
+                exit 2
+            fi
+            AAR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            ARCH="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$AAR" ]]; then
+    # Build the .aar with Android release flags for local use.
+    ./bazelw build :capture_aar --config release-android --android_platforms=@rules_android//:"$ARCH"
+    AAR="$PWD/bazel-bin/capture_aar_local.aar"
+elif [[ "$AAR" != /* ]]; then
+    AAR="$PWD/$AAR"
+fi
+
+if [[ ! -f "$AAR" ]]; then
+    echo "error: AAR not found: $AAR" >&2
+    exit 1
+fi
+
+work_dir=$(mktemp -d /tmp/bitdrift_so.XXXXXX)
+trap 'rm -rf "$work_dir"' EXIT
+pushd "$work_dir"
+
+# Unzip the AAR, strip the .so, and re-zip it.
+unzip "$AAR"
+
+# Determine JNI path based on architecture.
+if [[ "$ARCH" == "x86_64" ]]; then
+    JNI_PATH="jni/x86_64"
+else
+    JNI_PATH="jni/arm64-v8a"
+fi
+
+llvm-strip "$JNI_PATH/libcapture.so"
+zip -r aar.zip "$JNI_PATH/libcapture.so"
+# Print size in KiB for higher granularity.
+du -k aar.zip
+du -h aar.zip
+
+# Output just the size in KB for CI parsing.
+size_kb=$(du -k aar.zip | awk '{print $1}')
+echo "SO_SIZE_KB=$size_kb"


### PR DESCRIPTION
Previously we'd build it multiple times with different --config options, which would prevent cache reuse. Instead this explicitly builds it all once then hands the AAR over to the binary size script