### PR TITLE
Upgrade AGP to 8.13.2

### DIFF
--- a/platform/jvm/gradle/libs.versions.toml
+++ b/platform/jvm/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 androidBenchkmarkPlugin = "1.2.4"
-androidGradlePlugin     = "8.12.0"
+androidGradlePlugin     = "8.13.2"
 androidxCore            = "1.13.1"
 androidxTestCore        = "1.6.1"
 androidxWebkit          = "1.14.0"


### PR DESCRIPTION
Upgrades the Android Gradle Plugin from 8.12.0 to 8.13.2.

AGP 8.13.2 bundles an R8 version compatible with this project’s Kotlin 2.3.20, resolving the D8 Kotlin-metadata rewrite warnings that started appearing after we upgraded the Kotlin version. 