### PR TITLE
build: use Bazel-managed LLVM tools for iOS archives

### DIFF
--- a/.github/actions/configure-buildbuddy-cache/action.yaml
+++ b/.github/actions/configure-buildbuddy-cache/action.yaml
@@ -29,5 +29,6 @@ runs:
           echo "build --remote_cache=grpcs://remote.buildbuddy.io"
           echo "build --remote_upload_local_results"
           echo "build --remote_cache_compression"
+          echo "startup --experimental_remote_repo_contents_cache"
           printf "build --remote_header=x-buildbuddy-api-key=%s\\n" "$BUILDBUDDY_API_KEY"
         } > .buildrc.bb

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,11 +86,38 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.25.0")
 bazel_dep(name = "aspect_rules_js", version = "2.3.8")
 bazel_dep(name = "aspect_rules_ts", version = "3.10.0")
+bazel_dep(name = "llvm", version = "0.8.9")
+
+# The minimal LLVM archive exports its binaries as source files. Make those files visible to the
+# iOS archive-rewrite action while retaining the upstream module's pinned archive definitions.
+single_version_override(
+    module_name = "llvm",
+    patch_strip = 1,
+    patches = ["//bazel/third_party/patches:llvm-public-tool-binaries.patch"],
+    version = "0.8.9",
+)
 
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 
 # Required by android_artifacts for pom_file, it's not in bazel central registry
 bazel_dep(name = "google_bazel_common", version = "0.0.1")
+
+# The iOS archive rewriter needs LLVM's deterministic archive and universal-binary tools.
+# Fetch the minimal, pinned macOS toolchains through Bazel instead of relying on Homebrew.
+llvm_toolchain_minimal = use_extension(
+    "@llvm//extensions:llvm_toolchain_minimal.bzl",
+    "llvm_toolchain_minimal",
+)
+llvm_toolchain_minimal.release(llvm_version = "22.1.7")
+use_repo(
+    llvm_toolchain_minimal,
+    "llvm-toolchain-minimal-22.1.7-darwin-amd64",
+    "llvm-toolchain-minimal-22.1.7-darwin-arm64",
+    "llvm-toolchain-minimal-22.1.7-linux-amd64",
+    "llvm-toolchain-minimal-22.1.7-linux-arm64",
+    "llvm-toolchain-minimal-22.1.7-windows-amd64",
+    "llvm-toolchain-minimal-22.1.7-windows-arm64",
+)
 
 http_jar(
     name = "bazel_diff",

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ $(REPORT_KT): ../api/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs ../ap
 .PHONY: xcframework
 xcframework:
 	echo "NOTE: --xcode_version is overridden in .bazelrc"
-	echo "NOTE: Make sure you brew install llvm, and follow its instructions to add it to your PATH."
 	./bazelw build //:ios_dist
 	echo "XCFramework is archived at bazel-bin/Capture.ios.zip"
 

--- a/bazel/ios/BUILD
+++ b/bazel/ios/BUILD
@@ -14,6 +14,33 @@ sh_binary(
     visibility = ["//visibility:public"],
 )
 
+alias(
+    name = "llvm_ar",
+    actual = select({
+        "@llvm//platforms/config:macos_aarch64_prebuilt": "@llvm-toolchain-minimal-22.1.7-darwin-arm64//:bin/llvm-ar",
+        "@llvm//platforms/config:macos_x86_64_prebuilt": "@llvm-toolchain-minimal-22.1.7-darwin-amd64//:bin/llvm-ar",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "llvm_lipo",
+    actual = select({
+        "@llvm//platforms/config:macos_aarch64_prebuilt": "@llvm-toolchain-minimal-22.1.7-darwin-arm64//:bin/llvm-lipo",
+        "@llvm//platforms/config:macos_x86_64_prebuilt": "@llvm-toolchain-minimal-22.1.7-darwin-amd64//:bin/llvm-lipo",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "llvm_ranlib",
+    actual = select({
+        "@llvm//platforms/config:macos_aarch64_prebuilt": "@llvm-toolchain-minimal-22.1.7-darwin-arm64//:bin/llvm-ranlib",
+        "@llvm//platforms/config:macos_x86_64_prebuilt": "@llvm-toolchain-minimal-22.1.7-darwin-amd64//:bin/llvm-ranlib",
+    }),
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "produce_framework_plist",
     values = {"define": "ios_produce_framework_plist=true"},

--- a/bazel/ios/hack.bzl
+++ b/bazel/ios/hack.bzl
@@ -7,11 +7,19 @@ def _rewrite_xcframework_impl(ctx):
     outdir = ctx.actions.declare_directory(ctx.attr.framwork_name + ".xcframework")
     zip_in = ctx.file.xcframework
     tool = ctx.executable.rewrite_tool
+    ar = ctx.executable.ar
+    lipo = ctx.executable.lipo
+    ranlib = ctx.executable.ranlib
 
     ctx.actions.run_shell(
         inputs = [zip_in],
-        tools = [tool],
+        tools = [tool, ar, lipo, ranlib],
         outputs = [outdir],
+        env = {
+            "AR": ar.path,
+            "LIPO": lipo.path,
+            "RANLIB": ranlib.path,
+        },
         use_default_shell_env = True,
         command = """
 set -euo pipefail
@@ -29,7 +37,25 @@ rsync -a "$DIR/" "{outdir}/"
 rewrite_xcframework = rule(
     implementation = _rewrite_xcframework_impl,
     attrs = {
+        "ar": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
+            default = Label("//bazel/ios:llvm_ar"),
+            executable = True,
+        ),
         "framwork_name": attr.string(default = "Capture"),
+        "lipo": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
+            default = Label("//bazel/ios:llvm_lipo"),
+            executable = True,
+        ),
+        "ranlib": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
+            default = Label("//bazel/ios:llvm_ranlib"),
+            executable = True,
+        ),
         "rewrite_tool": attr.label(executable = True, cfg = "exec"),
         "xcframework": attr.label(allow_single_file = [".zip"]),
     },

--- a/bazel/ios/rewrite_symbols.sh
+++ b/bazel/ios/rewrite_symbols.sh
@@ -2,9 +2,9 @@
 
 set -euxo pipefail
 
-AR=$(which llvm-ar)
-RANLIB=$(which llvm-ranlib)
-LIPO=$(which llvm-lipo)
+: "${AR:?AR is not set or empty}"
+: "${RANLIB:?RANLIB is not set or empty}"
+: "${LIPO:?LIPO is not set or empty}"
 
 # Ensure that ar/ranlib creates deterministic archives.
 export ZERO_AR_DATE=1

--- a/bazel/third_party/patches/llvm-public-tool-binaries.patch
+++ b/bazel/third_party/patches/llvm-public-tool-binaries.patch
@@ -1,0 +1,18 @@
+diff --git a/toolchain/llvm/llvm.bzl b/toolchain/llvm/llvm.bzl
+index 2010c623..8879de3a 100644
+--- a/toolchain/llvm/llvm.bzl
++++ b/toolchain/llvm/llvm.bzl
+@@ -15,7 +15,10 @@ def declare_llvm_targets(*, suffix = ""):
+     )
+-
++
+     # Convenient exports
+-    native.exports_files(native.glob(["bin/*"]))
++    native.exports_files(
++        native.glob(["bin/*"]),
++        visibility = ["//visibility:public"],
++    )
+-
++
+     native.filegroup(
+         name = "clangxx_file",

--- a/ci/check_ios_xcframework_archive_members.sh
+++ b/ci/check_ios_xcframework_archive_members.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-archive_tool=$(xcrun --find llvm-ar)
+# This check only lists archive members; use Xcode's supported archive tool.
+archive_tool=$(xcrun --find ar)
 if [[ -n "${IOS_CAPTURE_XCFRAMEWORK_ROOT:-}" ]]; then
   framework_root="$IOS_CAPTURE_XCFRAMEWORK_ROOT"
 else

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -17,6 +17,3 @@ rm -f /usr/local/bin/python3
 rm -f /usr/local/bin/python3.11
 rm -f /usr/local/bin/python3-config
 rm -f /usr/local/bin/python3.11-config
-
-HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install llvm
-echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
- Fetch the pinned minimal macOS LLVM toolchain through Bazel and pass `llvm-ar`, `llvm-ranlib`, and `llvm-lipo` as declared iOS archive-rewrite tools.
- Select the tool binaries with the platform-aware conditions published by `@llvm`.
- Remove the Homebrew LLVM installation from macOS CI and the local XCFramework build instructions.
- Enable Bazel's remote repository-contents cache for authenticated BuildBuddy CI builds.