### PR TITLE
test: improve iOS network test failure diagnostics

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -141,6 +141,13 @@ jobs:
       - name: Run iOS tests
         # Bypass rules_apple's hardcoded 60s simulator boot and 150s test-launch timeouts,
         run: env -u ANDROID_NDK_HOME ./bazelw test $(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)') --test_tag_filters=macos_only --test_output=errors --config ci --test_env=REUSE_GLOBAL_SIMULATOR=1 --test_env=STARTUP_TIMEOUT_SEC=300
+      - name: Upload iOS test failure artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-failure-artifacts
+          path: bazel-testlogs/test/platform/swift/unit_integration/**/test.outputs
+          if-no-files-found: warn
   ios_size_comparison:
     name: iOS size comparison
     timeout-minutes: 40

--- a/test/platform/swift/unit_integration/core/network/CaptureNetworkTests.swift
+++ b/test/platform/swift/unit_integration/core/network/CaptureNetworkTests.swift
@@ -17,15 +17,13 @@ final class CaptureNetworkTests: XCTestCase {
     func testHappyPathWithTimeoutAndReconnect() async throws {
         let env = try NetworkTestEnvironment(networkIdleTimeout: 1)
 
-        let streamID = await env.testServer.nextStream()
-        guard streamID != -1 else { XCTFail("Timed out waiting for initial stream"); return }
+        let streamID = try await env.testServer.waitForStream(testName: #function)
 
         // The client timeout is 1s; allow scheduling headroom for the stream to be closed.
         let streamClosed = await env.testServer.streamClosed(streamId: streamID, waitTimeMs: 3000)
         XCTAssertTrue(streamClosed)
 
-        let streamID2 = await env.testServer.nextStream(timeout: 30)
-        guard streamID2 != -1 else { XCTFail("Timed out waiting for reconnect stream"); return }
+        let streamID2 = try await env.testServer.waitForStream(testName: #function, timeout: 30)
         try await env.testServer.handshake(streamId: streamID2)
     }
 
@@ -33,8 +31,7 @@ final class CaptureNetworkTests: XCTestCase {
     func testHappyPathWithKeepAlives() async throws {
         let env = try NetworkTestEnvironment(pingInterval: 0.1)
 
-        let streamID = await env.testServer.nextStream()
-        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
+        let streamID = try await env.testServer.waitForStream(testName: #function)
         try await env.testServer.handshake(streamId: streamID)
 
         // Server timeout is 1s in tests, waiting up to 1.5s. This would have closed the

--- a/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
+++ b/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
@@ -60,7 +60,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
         self.storage = MockStorageProvider()
 
         // Use instance-based server for test isolation
-        self.server = TestApiServer()
+        self.server = try TestApiServer()
 
         let logger = try XCTUnwrap(
             Logger(
@@ -92,8 +92,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
     func testSessionReplay() async throws {
         _ = try self.setUpLogger()
 
-        let streamID = await self.server.nextStream()
-        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
+        let streamID = try await self.server.waitForStream(testName: #function)
         try await self.server.configureAggressiveUploads(streamId: streamID)
 
         // Collect logs until we've seen all expected initial logs.
@@ -140,8 +139,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
         // Add a field prefixed with "_", it should be dropped and not present.
         logger.addField(withKey: "_dar", value: "value_dar")
 
-        let streamID = await self.server.nextStream()
-        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
+        let streamID = try await self.server.waitForStream(testName: #function)
         try await self.server.configureAggressiveUploads(streamId: streamID)
 
         // TODO(Augustyniak): Do `replayScreenshotLog.hasFields` in here after figuring out how to figure out
@@ -247,8 +245,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
 
         _ = try self.setUpLogger(fieldProviders: fieldProviders)
 
-        let streamID = await self.server.nextStream()
-        guard streamID != -1 else { XCTFail("Timed out waiting for API stream"); return }
+        let streamID = try await self.server.waitForStream(testName: #function)
         try await self.server.configureAggressiveUploads(streamId: streamID)
 
         self.logger.log(level: .debug, message: "test field provider failure")

--- a/test/platform/swift/unit_integration/core/network/helper/NetworkTestEnvironment.swift
+++ b/test/platform/swift/unit_integration/core/network/helper/NetworkTestEnvironment.swift
@@ -30,7 +30,7 @@ final class NetworkTestEnvironment {
         // The logger receives the ping interval to use in its handshake when it connects to the
         // server, so we pass the ping interval to the test server.
         let pingIntervalMs = pingInterval.map { Int32($0 * 1000) } ?? -1
-        self.testServer = TestApiServer(tls: true, pingIntervalMs: pingIntervalMs)
+        self.testServer = try TestApiServer(tls: true, pingIntervalMs: pingIntervalMs)
 
         // For each test we create a unique SDK directory to avoid different tests affecting each
         // other.

--- a/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
+++ b/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
@@ -30,10 +30,24 @@ private func checkError(_ errorPtr: UnsafePointer<CChar>?) throws {
 public final class TestApiServer: @unchecked Sendable {
     private let handle: UnsafeMutableRawPointer
     public let port: Int32
+    private let tls: Bool
 
-    public init(tls: Bool = true, pingIntervalMs: Int32 = -1) {
-        self.handle = create_test_api_server_instance(tls, pingIntervalMs)
-        self.port = server_instance_port(self.handle)
+    /// The Rust server constructor waits for its listener to start before returning. Verify that it
+    /// supplied a usable port here so tests fail at setup rather than later as a stream timeout.
+    public init(tls: Bool = true, pingIntervalMs: Int32 = -1) throws {
+        guard let handle = create_test_api_server_instance(tls, pingIntervalMs) else {
+            throw TestServerError("Test API server did not return a server handle")
+        }
+        let port = server_instance_port(handle)
+        guard port > 0 else {
+            destroy_test_api_server_instance(handle)
+            throw TestServerError("Test API server did not report a listening port")
+        }
+
+        self.handle = handle
+        self.port = port
+        self.tls = tls
+        NSLog("[TestApiServer] ready: \(self.readinessDescription)")
     }
 
     deinit {
@@ -42,6 +56,10 @@ public final class TestApiServer: @unchecked Sendable {
 
     public var baseURL: URL {
         URL(string: "https://localhost:\(port)")!
+    }
+
+    public var readinessDescription: String {
+        "url=\(self.baseURL.absoluteString), tls=\(self.tls), port=\(self.port)"
     }
 
     // MARK: - Public async API
@@ -53,12 +71,35 @@ public final class TestApiServer: @unchecked Sendable {
     /// - returns: The stream ID, or -1 on timeout.
     public func nextStream(timeout: TimeInterval = 15) async -> Int32 {
         let deadline = Date().addingTimeInterval(timeout)
+        var attempts = 0
         var streamID = await awaitNextStream()
+        attempts += 1
 
         while streamID == -1, Date() < deadline {
             streamID = await awaitNextStream()
+            attempts += 1
         }
 
+        if streamID == -1 {
+            NSLog(
+                "[TestApiServer] stream wait timed out after \(timeout)s and \(attempts) attempts; "
+                    + self.readinessDescription
+            )
+        }
+
+        return streamID
+    }
+
+    /// Waits until the SDK has connected to this test server. The test name and listener details
+    /// make simulator or URLSession connection failures actionable from the XCTest log.
+    public func waitForStream(testName: String, timeout: TimeInterval = 15) async throws -> Int32 {
+        let streamID = await self.nextStream(timeout: timeout)
+        guard streamID != -1 else {
+            throw TestServerError(
+                "Timed out waiting for API stream in \(testName) after \(timeout)s; "
+                    + self.readinessDescription
+            )
+        }
         return streamID
     }
 

--- a/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
+++ b/test/platform/swift/unit_integration/core/network/helper/TestServerHelpers.swift
@@ -34,6 +34,9 @@ public final class TestApiServer: @unchecked Sendable {
 
     /// The Rust server constructor waits for its listener to start before returning. Verify that it
     /// supplied a usable port here so tests fail at setup rather than later as a stream timeout.
+    ///
+    /// - parameter tls:            Whether the test server uses TLS.
+    /// - parameter pingIntervalMs: The interval, in milliseconds, between server pings.
     public init(tls: Bool = true, pingIntervalMs: Int32 = -1) throws {
         guard let handle = create_test_api_server_instance(tls, pingIntervalMs) else {
             throw TestServerError("Test API server did not return a server handle")
@@ -92,6 +95,11 @@ public final class TestApiServer: @unchecked Sendable {
 
     /// Waits until the SDK has connected to this test server. The test name and listener details
     /// make simulator or URLSession connection failures actionable from the XCTest log.
+    ///
+    /// - parameter testName: The name of the test waiting for a stream.
+    /// - parameter timeout:  The maximum amount of time to wait before failing.
+    ///
+    /// - returns: The connected stream ID.
     public func waitForStream(testName: String, timeout: TimeInterval = 15) async throws -> Int32 {
         let streamID = await self.nextStream(timeout: timeout)
         guard streamID != -1 else {


### PR DESCRIPTION
Improve failure diagnostics for the iOS network tests.

- Verify and log each per-test API server's listener URL, TLS mode, and port at startup.
- Surface stream-connection timeouts as errors that identify the XCTest and server endpoint instead of a bare `-1` timeout.
- Upload Bazel test outputs, including the XCTest result bundles, when the iOS CI test job fails.

The affected tests use a local TLS server and asynchronous URLSession streams. Previous failures reported only that an API stream never arrived, leaving no server endpoint context or retained `.xcresult` artifact for investigation. This change does not retry tests or change their timing; it makes a recurrence diagnosable.

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
