### PR TITLE
Fix typo in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,7 +8,7 @@ build:libunwind --action_env=PATH=/usr/bin
 
 build --experimental_repository_downloader_retries=3
 build --@protobuf//bazel/flags:prefer_prebuilt_protoc
-buidl --experimental_remote_cache_compression
+build --experimental_remote_cache_compression
 
 build --features=debug_prefix_map_pwd_is_dot
 build --features=oso_prefix_is_pwd


### PR DESCRIPTION
This prevent some build flows to work properly