### PR TITLE
andr;tooling: Commit starter skill and tool to run android device tests

### DIFF
--- a/.claude/skills/android-launch-run/SKILL.md
+++ b/.claude/skills/android-launch-run/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: android-launch-run
+description: >-
+  Build, install, launch, background, and kill the capture-sdk Android test apps on every connected
+  device or emulator, put those devices into specific power/network states, and capture and parse
+  logcat to answer questions about SDK runtime behaviour. Use this whenever the user wants to run an
+  Android app on a device or emulator, reproduce behaviour under Android restrictions (doze, battery
+  saver, Data Saver, standby buckets, cached-app freezer, airplane mode, background-restricted),
+  verify what the SDK does on backgrounding or process death, compare an emulator against real
+  hardware, or read bitdrift Rust logs (bd_client_stats, bd_logger, bd_api, bd_buffer) out of
+  logcat. Reach for it for anything involving adb device state, RUST_LOG levels via
+  debug.bitdrift.internal_rust_log, lifecycle timing, or flush/upload verification — including
+  questions phrased as "does X still happen when the app is backgrounded?" or "why didn't the
+  upload go out?", even when adb and logcat are never mentioned.
+---
+
+# Android launch & run
+
+Drive real devices and emulators to observe what the SDK actually does at runtime, rather than
+inferring it from source. The core loop is always the same:
+
+**pick devices → set log levels → apply device state → launch → act → capture → parse**
+
+Timing is usually the answer. Most interesting questions here ("did the flush finish before the OS
+cut the network?") are races, so every timestamp must come from the **device clock**. Never compare
+a host-side `date` against a logcat timestamp; they drift by seconds.
+
+## Quick start
+
+```bash
+S=.claude/skills/android-launch-run/scripts
+
+python3 $S/adbctl.py devices                        # what's connected
+python3 $S/adbctl.py install                        # build + install debug app everywhere
+python3 $S/adbctl.py run --scenario background-home # launch, background, capture, parse
+```
+
+Run one declarative scenario across all devices in parallel:
+
+```bash
+python3 $S/run_scenario.py assets/scenarios/minimal-background.json --out /tmp/run1
+```
+
+Parse a capture you already have:
+
+```bash
+python3 $S/parse_logs.py /tmp/run1/<device>/logcat.txt --ref "process ON_STOP"
+```
+
+## Which app
+
+Defaults to `gradle-test-app` (`io.bitdrift.gradletestapp`). Override with `--app`:
+
+| `--app` | Package | Notes |
+|---|---|---|
+| `gradle-test-app` (default) | `io.bitdrift.gradletestapp` | Debuggable; has the diagnostics UI and `bitdrift-lifecycle` logging |
+| `gradle-tv-test-app` | `io.bitdrift.gradletvtestapp` | Android TV |
+| `examples/android` | see module | Built with Bazel, not Gradle |
+
+Install uses Gradle, which invokes Bazel for the Rust `.so`:
+
+```bash
+ANDROID_SERIAL=<serial> ./platform/jvm/gradlew -p platform/jvm :gradle-test-app:installDebug
+```
+
+`rust-target` defaults to `arm64`, correct for most phones and Apple-silicon emulators. Pass
+`-Prust-target=x86_64` for an x86 emulator. First build is slow (Bazel builds the Rust lib);
+subsequent ones are ~1–2 min.
+
+**The app must be debuggable** or the Rust log property is ignored — see below.
+
+## Setting Rust log levels
+
+The SDK reads a system property at startup and converts it to `RUST_LOG`
+(`Capture.setUpInternalLogging`), and only in debuggable builds:
+
+```bash
+adb -s <serial> shell setprop debug.bitdrift.internal_rust_log 'info,bd_client_stats=debug'
+```
+
+Set it **before launching** — it is read once during native library init. It survives until
+reboot. Standard `RUST_LOG` filter syntax applies, and module prefixes work
+(`bd_client_stats=debug` also enables `bd_client_stats::file_manager`).
+
+Pick the narrowest filter that answers the question; `bd=trace` is enormous and will flood the
+buffer, evicting the lines you care about.
+
+| Question | Filter |
+|---|---|
+| Stats flush + disk write | `info,bd_client_stats=debug` |
+| …plus *who* triggered the flush | `info,bd_client_stats=debug,bd_logger=debug` |
+| …plus why an upload failed | add `,bd_api=debug` |
+| Log (not stats) uploads | `info,bd_logger=debug` |
+| Ring buffer to disk | `info,bd_buffer::ring_buffer=debug` |
+
+## Reading the logs
+
+Four independent sources, all on the device clock, so they interleave correctly in one capture:
+
+| Source | Buffer | Gives |
+|---|---|---|
+| `bitdrift-lifecycle` (INFO) | main | **process** lifecycle + window focus, from the test app |
+| `wm_*`, `input_focus`, `am_freeze` | events | OS-side activity lifecycle, focus, freeze |
+| `bd_*::*` (Rust) | main | SDK internals; tag is the full Rust module path |
+| `dumpsys netpolicy` | — | when the OS revoked network (post-run query) |
+
+Capture both buffers together — `-b main,events` — or the OS events and app logs can't be correlated.
+
+**`process ON_STOP` is usually the reference point.** It is what the SDK's background flush hangs
+off, it fires ~700ms after the activity stops (`ProcessLifecycleOwner` debounces), and it lands
+*before* the OS's own `wm_on_stop_called`. Measured on a Pixel 10:
+
+```
+16:10:07.815  bitdrift-lifecycle: window MainActivity focus=false
+16:10:08.889  bitdrift-lifecycle: process ON_STOP           <- reference
+16:10:08.892  bd_logger::logger: state flushing initiated      +3ms
+16:10:08.903  bd_client_stats::stats: received a signal…      +14ms
+16:10:08.907  bd_client_stats::file_manager: writing snapshot +18ms
+16:10:08.917  wm_on_stop_called                              +28ms
+```
+
+For what each Rust line means — and which are safe to draw conclusions from — read
+**`references/log-signatures.md`**. Two traps worth knowing before you interpret anything:
+
+- **`state flushing initiated`** is the only durable marker of a *platform-triggered* flush.
+  `flush_state` is reachable only from a platform bridge, so its presence means Kotlin asked;
+  its absence means an internal timer did.
+- Log text depends on the **shared-core rev pinned in `Cargo.toml`**, not on any local
+  `../shared-core` checkout. They differ. Always confirm a signature against a real capture
+  before building an argument on it.
+
+## Device states
+
+Nine states are supported, each with verified setup, teardown, and a *verify* command — because
+several fail silently:
+
+```bash
+python3 $S/adbctl.py mode battery-saver --on
+python3 $S/adbctl.py mode doze-deep --on
+python3 $S/adbctl.py mode reset          # everything back to default
+```
+
+`airplane` · `battery-saver` · `doze-deep` · `doze-light` · `data-saver` · `standby-restricted` ·
+`bg-restricted` · `freezer` · `idle-allowlist`
+
+**Read `references/device-modes.md` before using any of them.** Ordering matters more than it
+looks: `standby-restricted` is silently reset by launching the app, `data-saver` does nothing
+unless the network is first marked metered, and `doze` can only be forced after the screen is off.
+The reference documents which modes must be applied *before* launch and which *after*
+backgrounding, with the evidence for each.
+
+## Actions
+
+```bash
+python3 $S/adbctl.py action home|back|recents|screen-off|wake|kill|force-stop|freeze|crash-bg
+python3 $S/adbctl.py action wait --seconds 35
+```
+
+`home`, `back`, `recents` and `screen-off` are all different, and not interchangeable:
+
+- **`recents`** does not fire `ON_STOP` at all — the activity stays "started" while the overview is
+  open, so no backgrounding work runs. If a scenario appears to do nothing, check for this first.
+- **`back`** revokes network sooner than `home` (~3.8s vs ~5.0s), so it shortens any race.
+- **`screen-off`** re-locks a phone with a secure keyguard, which invalidates every later run.
+
+## Marking actions in the log
+
+Actions are stamped into logcat on the device clock so they appear inline in the timeline:
+
+```bash
+adb -s <serial> shell log -p i -t ANDROID-RUN "ACTION home"
+```
+
+`adbctl.py` does this automatically. Do it manually if you're driving adb yourself — otherwise
+you'll be reduced to guessing when the action landed relative to what the app did.
+
+## Multi-device
+
+`adbctl.py` and `run_scenario.py` target **every connected device** by default, in parallel, and
+write per-device output directories. Use `--serial <id>` for one device, or `--sequential` when
+the numbers matter: parallel runs add tens of ms of adb and logcat jitter, which is fine for
+pass/fail but can distort sub-second measurements.
+
+Physical devices and emulators frequently disagree. That is a finding, not a bug — check
+`references/flush-matrix.md` for cases where they diverged and why.
+
+## Guard rails that keep runs valid
+
+These come from runs that produced clean-looking but meaningless data:
+
+1. **A locked device invalidates everything.** The app launches behind the keyguard and
+   backgrounds itself during any foreground wait, so the action lands on an already-backgrounded
+   app. `adbctl.py` aborts when `deviceLocked=1`. If the device has a secure lock, ask the user to
+   unlock it; do not attempt to bypass it.
+2. **Screen-off scenarios run last**, since each one re-locks the phone.
+3. **Check for premature `process ON_STOP`.** If it appears *before* the action marker, discard the
+   run. `parse_logs.py` flags this automatically.
+4. **Always restore device state**, even after a failure. A device left in airplane mode or
+   battery saver silently corrupts the next run — and it is someone's actual phone.
+
+## Reference files
+
+Read these as needed rather than upfront:
+
+- **`references/log-signatures.md`** — every log line worth matching, by subsystem, with what it
+  proves and what it doesn't. Read before interpreting any capture.
+- **`references/device-modes.md`** — the nine states: setup, teardown, verification, when each must
+  be applied, and the silent-failure traps.
+- **`references/flush-matrix.md`** — a worked 14-scenario study of stats flushing on backgrounding,
+  with results from an emulator and a Pixel 10. Read it as a template for structuring a
+  multi-scenario investigation, or when the question is specifically about flush/upload behaviour.
+
+## Scenario files
+
+`assets/scenarios/*.json` describe runs declaratively so they're repeatable and diffable:
+
+```json
+{
+  "name": "background-home",
+  "rust_log": "info,bd_client_stats=debug,bd_logger=debug",
+  "modes_before_launch": [],
+  "steps": [
+    {"action": "launch"},
+    {"action": "wait", "seconds": 35, "why": "clear the 30s stats upload debounce"},
+    {"action": "home"},
+    {"action": "wait", "seconds": 40}
+  ],
+  "reference_event": "process ON_STOP"
+}
+```
+
+Add a `why` to any non-obvious wait. A future reader — including you — will otherwise assume it's
+arbitrary and shorten it, which is how the 30s debounce silently invalidated a whole matrix.

--- a/.claude/skills/android-launch-run/assets/scenarios/background-doze.json
+++ b/.claude/skills/android-launch-run/assets/scenarios/background-doze.json
@@ -1,0 +1,15 @@
+{
+  "name": "background-doze",
+  "description": "Background then force deep doze, pre-armed so force-idle lands ~0.3s after ON_STOP rather than ~2s.",
+  "rust_log": "info,bd_client_stats=debug,bd_logger=debug,bd_api=debug",
+  "modes_before_launch": ["doze-prearm"],
+  "steps": [
+    {"action": "launch"},
+    {"action": "wait", "seconds": 35, "why": "clear the 30s stats upload debounce"},
+    {"action": "screen-off"},
+    {"action": "mode", "name": "doze-deep",
+     "why": "doze needs the screen off, so it can only be applied after backgrounding; it therefore races any in-flight upload"},
+    {"action": "wait", "seconds": 40}
+  ],
+  "reference_event": "process ON_STOP"
+}

--- a/.claude/skills/android-launch-run/assets/scenarios/kill-after-background.json
+++ b/.claude/skills/android-launch-run/assets/scenarios/kill-after-background.json
@@ -1,0 +1,15 @@
+{
+  "name": "kill-after-background",
+  "description": "Background, then kill the process 5s later. Tests whether backgrounding work completes before process death.",
+  "rust_log": "info,bd_client_stats=debug,bd_logger=debug",
+  "modes_before_launch": [],
+  "steps": [
+    {"action": "launch"},
+    {"action": "wait", "seconds": 35, "why": "clear the 30s stats upload debounce"},
+    {"action": "home"},
+    {"action": "wait", "seconds": 5, "why": "roughly matches the OS background network cutoff, so the kill lands in the same window"},
+    {"action": "kill"},
+    {"action": "wait", "seconds": 10}
+  ],
+  "reference_event": "process ON_STOP"
+}

--- a/.claude/skills/android-launch-run/assets/scenarios/minimal-background.json
+++ b/.claude/skills/android-launch-run/assets/scenarios/minimal-background.json
@@ -1,0 +1,15 @@
+{
+  "name": "minimal-background",
+  "description": "Launch, sit in the foreground long enough to clear the stats upload debounce, then background via HOME and watch what the SDK does.",
+  "rust_log": "info,bd_client_stats=debug,bd_logger=debug,bd_api=debug",
+  "modes_before_launch": [],
+  "steps": [
+    {"action": "launch"},
+    {"action": "wait", "seconds": 35,
+     "why": "stats.minimum_upload_interval_ms is 30s and the startup upload arms it. Backgrounding sooner means the ON_STOP upload is debounced and never attempted, so the run measures the debounce instead of the thing you asked about."},
+    {"action": "home"},
+    {"action": "wait", "seconds": 40,
+     "why": "long enough to see the ~5s background network cutoff, the upload ack (475ms-17s observed), and at least one ~30s timed flush"}
+  ],
+  "reference_event": "process ON_STOP"
+}

--- a/.claude/skills/android-launch-run/evals/evals.json
+++ b/.claude/skills/android-launch-run/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "android-launch-run",
+  "evals": [
+    {
+      "id": 0,
+      "name": "background-flush-verification",
+      "prompt": "I want to know whether the capture SDK's stats upload actually makes it out when the app goes to the background on my connected Android devices. Install the debug test app, run it, background it with the home button, and tell me whether the stats got written to disk and whether the upload was acked before anything blocked it. Give me the timings.",
+      "expected_output": "Installs debug app, sets a bd_client_stats + bd_logger RUST_LOG filter, waits >30s in foreground to clear the upload debounce, backgrounds via HOME, captures main+events, reports FG vs BG phases separately, distinguishes 'writing snapshot' (disk) from the upload ack, reports the ~5s firewall cutoff, and resets device state.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "doze-comparison",
+      "prompt": "Does deep doze stop the SDK from uploading stats in the background? Check it on every device I have connected and tell me if the emulator and my phone behave differently.",
+      "expected_output": "Pre-arms doze before launch, applies force-idle only after screen-off (documenting the race), runs on all connected devices, verifies doze actually engaged via dumpsys deviceidle get deep, compares per-device results, resets state afterwards.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "recents-no-flush",
+      "prompt": "Something looks off when I leave the app using the app switcher instead of the home button — I don't think the SDK is doing its background work. Can you check what actually happens in each case?",
+      "expected_output": "Runs both recents and home, discovers that recents never fires process ON_STOP (so no flush runs at all) while window focus does drop, and does not misreport the absence as a harness failure.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/android-launch-run/references/device-modes.md
+++ b/.claude/skills/android-launch-run/references/device-modes.md
@@ -1,0 +1,209 @@
+# Device modes
+
+Nine states, each with setup, teardown, and a **verify** command. Several fail silently, so always
+verify rather than assuming the setup command worked.
+
+All commands verified on API 36 (emulator) and API 37 (Pixel 10).
+
+## When each mode can be applied
+
+This ordering is not cosmetic — getting it wrong produces clean-looking runs that measured nothing.
+
+| Mode | Apply before launch? | Evidence |
+|---|---|---|
+| `airplane` | ✅ yes | global, survives launch |
+| `battery-saver` | ✅ yes | after launch: `low_power=1`, `Restrict power: true` |
+| `data-saver` | ✅ yes | global + per-app policy both persist |
+| `bg-restricted` | ✅ yes | appop `RUN_ANY_IN_BACKGROUND: ignore` survives launch |
+| `idle-allowlist` | ✅ yes | persists |
+| **`standby-restricted`** | ❌ **no — launch resets it** | set to `restricted` (45), reads **10 (ACTIVE)** after launch |
+| **`doze-deep` / `doze-light`** | ⚠️ survives launch, but changes the scenario | see below |
+| **`freezer`** | ❌ no | needs an already-running cached process |
+
+### standby-restricted is the trap
+
+Launching the app counts as user interaction and promotes it to the ACTIVE bucket, silently undoing
+the setup. It must be applied **after** backgrounding, which means it lands ~0.3s into whatever the
+app is doing — so it races any in-flight work rather than being cleanly in place.
+
+### doze changes the scenario if applied early
+
+`force-idle deep` then `am start` leaves the device IDLE with the screen asleep — launching does not
+break doze. But the app then sits in `procState=TPSL` (TOP_SLEEPING) with
+`effective=DOZE|APP_BACKGROUND`: **network already blocked before it runs**. Any foreground wait is
+impossible, and you're measuring "launched into a dozing device" rather than "user backgrounded the
+app, then the device dozed."
+
+Prefer the realistic order: pre-arm everything (unplug, un-allowlist, `enable deep`) before launch,
+then after backgrounding issue only `force-idle deep`, so it lands ~0.3s after `ON_STOP` instead of
+~2s. Like `standby-restricted`, it still races in-flight work; there is no way around that with
+adb-forced idle.
+
+---
+
+## The modes
+
+### airplane
+
+```bash
+adb shell cmd connectivity airplane-mode enable      # on
+adb shell cmd connectivity airplane-mode disable     # off
+adb shell cmd connectivity airplane-mode             # verify -> enabled|disabled
+```
+
+Cross-check with `settings get global airplane_mode_on` (1/0) and `cmd wifi status`. On a real
+phone this drops calls and messages — restore it promptly.
+
+### battery-saver
+
+```bash
+adb shell dumpsys battery unplug                                    # required: won't engage while charging
+adb shell dumpsys battery set level 15
+adb shell cmd power set-adaptive-power-saver-enabled false
+adb shell settings put global low_power 1
+# off:
+adb shell settings put global low_power 0 && adb shell dumpsys battery reset
+# verify:
+adb shell settings get global low_power                             # -> 1
+adb shell dumpsys netpolicy | grep 'Restrict power'                 # -> true
+```
+
+`dumpsys battery reset` is what undoes the simulated unplug — without it the device believes it is
+on battery indefinitely.
+
+### doze-deep / doze-light
+
+```bash
+# pre-arm before launch:
+adb shell dumpsys battery unplug
+adb shell dumpsys deviceidle whitelist -<pkg>
+adb shell dumpsys deviceidle enable deep      # or: light
+# after backgrounding, with the screen off:
+adb shell input keyevent KEYCODE_SLEEP
+adb shell dumpsys deviceidle force-idle deep  # or: light
+# off:
+adb shell dumpsys deviceidle unforce && adb shell dumpsys deviceidle enable all
+# verify:
+adb shell dumpsys deviceidle get deep         # -> IDLE (ACTIVE means not dozing)
+adb shell dumpsys deviceidle get light
+```
+
+Requires the screen off. The app must not be on the idle allowlist. Check `effective=` in
+`dumpsys netpolicy` for the `DOZE` reason to confirm it actually reached the app.
+
+### data-saver
+
+```bash
+# mark the network metered FIRST or this is a silent no-op:
+for n in $(adb shell cmd netpolicy list wifi-networks | cut -d';' -f1); do
+  adb shell cmd netpolicy set metered-network "$n" true
+done
+adb shell cmd netpolicy set restrict-background true
+# off:
+adb shell cmd netpolicy set restrict-background false
+for n in ...; do adb shell cmd netpolicy set metered-network "$n" undefined; done
+# verify:
+adb shell cmd netpolicy get restrict-background        # -> enabled
+adb shell cmd netpolicy list wifi-networks             # the active SSID should read 'true'
+```
+
+**Data Saver only restricts metered networks.** On unmetered WiFi — the default for both emulators
+and most home networks — it does nothing at all unless the network is marked metered first.
+
+Also check for a pre-existing per-app policy: `dumpsys netpolicy | grep 'UID=<uid> policy'`.
+`policy=1 (REJECT_METERED_BACKGROUND)` means the user disabled background data for that app in
+Settings, which will confound the result. Either clear it or record it.
+
+### standby-restricted
+
+```bash
+# AFTER backgrounding (see above):
+adb shell am set-standby-bucket <pkg> restricted
+# off:
+adb shell am set-standby-bucket <pkg> active
+# verify:
+adb shell am get-standby-bucket <pkg>     # -> 45
+```
+
+Buckets: 10 ACTIVE · 20 WORKING_SET · 30 FREQUENT · 40 RARE · 45 RESTRICTED. The OS decays buckets
+naturally over time, so a value of 20–40 on an idle app is normal rather than a leftover.
+
+### bg-restricted
+
+```bash
+adb shell am set-bg-restriction-level <pkg> background_restricted
+adb shell cmd appops set <pkg> RUN_ANY_IN_BACKGROUND ignore
+# off:
+adb shell am set-bg-restriction-level <pkg> unrestricted
+adb shell cmd appops set <pkg> RUN_ANY_IN_BACKGROUND allow
+# verify:
+adb shell cmd appops get <pkg> RUN_ANY_IN_BACKGROUND   # -> ignore
+```
+
+⚠ `am get-bg-restriction-level` returns `unknown` on API 36/37 and is **not** a usable check — use
+the appop. Note the appop governs background *execution*, not network directly, so a run where the
+upload still succeeds does not prove background-restricted apps can reach the network.
+
+### freezer
+
+```bash
+# after backgrounding, ~10s later (matching the OS's own behaviour):
+adb shell am freeze --sticky <pkg>
+# off:
+adb shell am unfreeze --sticky <pkg>
+# verify:
+adb logcat -b events | grep am_freeze
+adb shell dumpsys activity processes | grep 'frozen=true'
+```
+
+API 34+ SIGSTOPs cached processes ~10s after backgrounding on its own, so this may fire without
+being asked. The signature of a frozen process is that periodic work simply **stops** — timed
+flushes vanish from the log.
+
+### idle-allowlist
+
+```bash
+adb shell dumpsys deviceidle whitelist +<pkg>     # exempt
+adb shell dumpsys deviceidle whitelist -<pkg>     # remove
+# verify:
+adb shell dumpsys deviceidle whitelist | grep <pkg>
+```
+
+Primarily a **control**: an allowlisted app is exempt from the background firewall chain, so it
+keeps network while backgrounded. Useful for proving that a network failure is caused by the OS
+rather than the app — with the exemption on, a backgrounded app held its stream for 45s with no
+teardown, versus a cutoff at ~5s without it.
+
+---
+
+## The default background network cutoff
+
+Worth knowing even when applying no modes at all: on API 35+ the **background firewall chain**
+(`FIREWALL_CHAIN_BACKGROUND`) revokes a cached app's network ~**5s** after it backgrounds. It is
+enabled by default — `dumpsys netpolicy` shows
+`com.android.server.net.use_metered_firewall_chains: true` — and is *not* doze, battery saver, or
+Data Saver.
+
+Measured, both devices, with no modes applied:
+
+| Hop | Emulator (API 36) | Pixel 10 (API 37) |
+|---|---|---|
+| `ON_STOP` → firewall allow revoked | +4.962s | +4.950s |
+| revoke → socket aborted | +13ms | +51ms |
+
+So any backgrounded network work has roughly a **5-second budget**, and `back` shortens it to
+~3.8s. Because the block covers DNS, the resulting error is `UnknownHostException`.
+
+---
+
+## Always reset
+
+Leave the device as you found it, especially a physical one. `adbctl.py mode reset` restores all
+nine, un-meters every saved WiFi network, resets the simulated battery, and clears
+`svc power stayon`.
+
+Two extras that are easy to forget:
+
+- `svc power stayon false` — harnesses often set it `true` to stop the screen sleeping mid-run.
+- `debug.bitdrift.internal_rust_log` — persists until reboot. Restore it to whatever the user had,
+  or `info`.

--- a/.claude/skills/android-launch-run/references/flush-matrix.md
+++ b/.claude/skills/android-launch-run/references/flush-matrix.md
@@ -1,0 +1,104 @@
+# Worked example: the stats-flush matrix
+
+A 14-scenario study of what happens to **stats flushing** when an app is backgrounded, run on an
+emulator (API 36) and a Pixel 10 (API 37). Read this either as a template for structuring a
+multi-scenario investigation, or when the question is specifically about flush/upload behaviour.
+
+Full data and per-run timelines live in `tools/flush-matrix/` (untracked) if it is still present.
+
+## The question and why the first attempt failed
+
+*"When the app is backgrounded, does its stats upload get out before the OS cuts network?"*
+
+The first four runs all answered "no upload happened" — and all four were wrong. The
+`ON_STOP` upload was being **debounced** by `stats.minimum_upload_interval_ms` (30s), because the
+runs backgrounded the app ~5s after launch and the startup upload had already armed the timer. The
+debounce masked every other variable.
+
+**The fix that made the matrix meaningful:** idle in the foreground for ~35s before backgrounding.
+This is the single most important thing to get right; without it you measure the debounce.
+
+## Structure that worked
+
+Three groups, so each isolates one variable:
+
+1. **Backgrounding method** (no restrictions): HOME, BACK, recents, screen-off — does *how* the app
+   leaves the foreground matter?
+2. **Restriction modes** (HOME as the constant): battery saver, deep/light doze, Data Saver,
+   standby-restricted, bg-restricted, freezer, airplane.
+3. **Exit variants** (backgrounded first): `am kill`, `am force-stop`, JVM crash.
+
+Two axes worth separating explicitly in any results table: **which phase** (foreground vs
+backgrounding) and **which artifact** (disk write vs upload). Conflating them is the easiest way to
+misread results — a foreground disk write succeeding says nothing about the backgrounding flush.
+
+## Findings
+
+**Plain backgrounding does not block the upload.** Unrestricted, the `ON_STOP` upload was acked in
+**475ms–2241ms** against a network cutoff of **3.8–5.1s**. Every unrestricted run passed on both
+devices.
+
+**Battery saver and doze do block it** — enqueued, never acked, on both devices. The socket stayed
+nominally open for another ~4.9s after the enqueue with no response, while the same run's
+foreground upload acked in ~600ms. So these bite *before* the ~5s firewall deadline; a different,
+earlier mechanism.
+
+**Data Saver and standby-restricted diverged by device**: blocked on the emulator, succeeded on the
+Pixel (703ms / 615ms) with the restrictions verifiably in effect. Best explanation is that the
+Pixel's faster upload slips through before the restriction gates the socket — a race the fast
+device wins, not immunity.
+
+**Recents never fires `ON_STOP` at all**, so no backgrounding work runs. Whole-run lifecycle was
+`ON_CREATE`/`ON_START`/`ON_RESUME` only, and the firewall allow was never revoked either. But
+window focus *did* drop, ~334ms in — which is why focus is the only way to observe this state.
+
+**A stalled upload wedges the stats flusher.** The sharpest finding. In airplane mode, with an
+earlier upload outstanding and undeliverable, the `ON_STOP` flush produced **no disk write at
+all** — no `writing snapshot`, no `stats flushed`, and not even
+`flush already in progress, skipping`. `state flushing initiated` fired, so the request reached
+shared-core and then vanished. Reproduced on both devices.
+
+Note what makes that conclusive: `writing snapshot` fires on the timed path too, and the same run
+proves it (a timed flush wrote its snapshot 34s earlier). So its absence after `ON_STOP` means the
+write genuinely did not happen. An earlier version of this finding rested on missing
+`stats flushed`, which is forced-path-only and therefore proved nothing.
+
+**Kill, force-stop and freeze do not beat the upload.** All fired at ~+3.7s; uploads had already
+acked at +552–997ms, and the disk write is durable at ~+100ms.
+
+## Timing constants (both devices)
+
+| Hop | Value |
+|---|---|
+| user action → `process ON_STOP` | 1227–1564ms (`ProcessLifecycleOwner` debounce); screen-off on real hardware 2258–2290ms |
+| `ON_STOP` → forced flush | 9–163ms |
+| forced flush → `writing snapshot` | 6–40ms |
+| upload enqueue → ack | 475ms–2241ms (or never, under restriction) |
+| `ON_STOP` → network cutoff | HOME 4.95–5.00s · BACK 3.77–3.88s · screen-off 4.30–4.56s |
+
+BACK is reproducibly ~1.1s earlier than HOME on both devices, so the "~5s budget" is HOME-specific.
+
+## Mistakes that cost real time
+
+Worth reading before designing a matrix of your own:
+
+1. **The 30s debounce** invalidated the first four runs, and the failure looked like a real finding.
+2. **A locked phone** silently invalidated six runs. The app launched behind the keyguard and
+   backgrounded itself during the foreground wait, so the action landed on an already-backgrounded
+   app. The rows looked plausible and contradicted the emulator. Detect by comparing the reference
+   event against the action marker.
+3. **Screen-off tests re-lock the device**, invalidating everything after them — order them last.
+4. **`am set-standby-bucket` is undone by launching the app**, so that row measured nothing until
+   the mode moved to after-backgrounding.
+5. **Reading the wrong shared-core tree.** Log text came from the rev pinned in `Cargo.toml`, not
+   the local `../shared-core` checkout, and the two differed.
+6. **Grepping `bd_client_stats::stats` only**, which misses `::file_manager` — and
+   `writing snapshot` lives there. This is why the disk-write signal was missed entirely at first.
+   Match the `bd_client_stats*` prefix.
+
+## Not covered
+
+The JVM-crash scenario (the only path that runs `flush(blocking=true)`, with a hardcoded 500ms JNI
+wait) needs UI interaction to trigger — select "JVM crash in background" in the app's App
+Terminations card — so it was never automated. Given observed ack latencies exceed 500ms, the
+blocking flush would likely time out; that remains untested.

--- a/.claude/skills/android-launch-run/references/log-signatures.md
+++ b/.claude/skills/android-launch-run/references/log-signatures.md
@@ -1,0 +1,200 @@
+# Log signatures
+
+Every line worth matching, what it proves, and what it does **not**. All timestamps are on the
+device clock, so sources interleave correctly in a single `-b main,events` capture.
+
+- [1. App-side lifecycle](#1-app-side-lifecycle-bitdrift-lifecycle)
+- [2. OS-side lifecycle](#2-os-side-lifecycle-events-buffer)
+- [3. Flush attribution](#3-flush-attribution-bd_logger)
+- [4. Stats](#4-stats-bd_client_stats)
+- [5. Transport](#5-transport-bd_api)
+- [6. Ring buffers and log uploads](#6-ring-buffers-and-log-uploads)
+- [7. Network cutoff](#7-network-cutoff-dumpsys-netpolicy)
+- [8. Traps](#8-traps)
+
+> ⚠ **Log text tracks the pinned shared-core rev**, from `capture-sdk/Cargo.toml` — not a local
+> `../shared-core` checkout, which is often at a different commit with different wording. One real
+> example: the local tree read `stat upload attempt complete` while the shipped binary logged
+> `stat flush upload attempt complete`. Confirm any signature against a real capture before
+> reasoning from it.
+
+---
+
+## 1. App-side lifecycle (`bitdrift-lifecycle`)
+
+INFO, from `gradle-test-app`'s `LifecycleEventLogger`. Present regardless of Rust log level.
+
+| Line | Meaning |
+|---|---|
+| `process ON_CREATE\|ON_START\|ON_RESUME\|ON_PAUSE\|ON_STOP` | `ProcessLifecycleOwner` events |
+| `window <Activity> focus=true\|false` | `Activity.onWindowFocusChanged` |
+
+**`process ON_STOP` is the canonical reference point** for backgrounding work. It is what the SDK's
+flush hangs off, and `ProcessLifecycleOwner` debounces stop events by ~700ms, so it deliberately
+lags the activity's own `onStop`.
+
+`window … focus=false` is the *earliest* signal the app is leaving the foreground — roughly
+**1050–1090ms** before `process ON_STOP`, measured repeatedly on both an emulator and a Pixel 10.
+It also fires in cases where `ON_STOP` never does (see `recents` below), which makes it the only
+way to observe those.
+
+## 2. OS-side lifecycle (`events` buffer)
+
+No app cooperation needed, so this works against any app, including release builds.
+
+| Tag | Meaning |
+|---|---|
+| `wm_on_paused_called`, `wm_pause_activity` | Activity paused |
+| `wm_on_stop_called`, `wm_stop_activity` | Activity stopped — **not** the process-level event |
+| `wm_on_top_resumed_gained_called` / `…lost_called` | Top-resumed transitions |
+| `input_focus` | `Focus leaving …` / `ViewRootImpl focus=false` |
+| `am_freeze` | Cached-app freezer acting on the process |
+| `wm_task_moved`, `wm_task_to_front` | Task movement |
+
+Tag names vary by Android version — older releases use `am_on_stop_called` rather than
+`wm_on_stop_called`. Match both. Verified present on API 36 and 37.
+
+`wm_on_stop_called` fires **~28ms after** `process ON_STOP`, so it is not a substitute for the
+app-side signal when timing matters.
+
+## 3. Flush attribution (`bd_logger`)
+
+Needs `bd_logger=debug`.
+
+| Line | Tag | Proves |
+|---|---|---|
+| `state flushing initiated` | `bd_logger::logger` | **A platform bridge asked for a flush** |
+| `flush state: completion received` | `bd_logger::async_log_buffer` | A *blocking* flush completed |
+| `flush state: received an error when waiting for completion: …` | `bd_logger::async_log_buffer` | A blocking flush **timed out** — the JNI wait is hardcoded to 500ms |
+
+`state flushing initiated` is the durable platform-vs-internal discriminator: `Logger::flush_state`
+is reachable only from the JNI/Swift bridges, never from inside shared-core. So it present ⇒ Kotlin
+(or Swift) asked; absent ⇒ an internal timer or workflow did.
+
+This matters because **"forced" does not mean "platform-triggered."** A foreground-only run with no
+`flush()` call anywhere still produced five forced stats flushes — shared-core's workflow path
+raises its own flush requests. Attribute with `state flushing initiated`, not with the stats log.
+
+The blocking-flush lines only exist for `flush(blocking=true)`, which on Android is reached only
+from `AppExitLogger.onJvmCrash` — and is skipped entirely when fatal-issue reporting is
+initialized.
+
+## 4. Stats (`bd_client_stats`)
+
+Needs `bd_client_stats=debug`. **Match the tag prefix**, not an enumerated list — the subsystem
+spans several modules (`::stats`, `::file_manager`, …) and new lines get added.
+
+```
+grep -E "bd_client_stats[^:]*::" capture.txt
+```
+
+The lines that carry meaning:
+
+| Line | Tag | Meaning |
+|---|---|---|
+| `received a signal to flush stats to disk` | `::stats` | A **forced** flush request was dequeued |
+| `processing flush to disk tick` | `::stats` | `flush_to_disk()` entered — fires on **both** forced and timed paths |
+| `updating aggregated snapshot file with N metrics` | `::stats` | Merge, with the metric count |
+| **`writing snapshot: stats_uploads/<uuid>`** | `::file_manager` | **The actual disk write.** Fires on both paths |
+| `stats flushed` | `::stats` | A forced flush ran to completion — **forced path only** |
+| `processing upload from disk` | `::stats` | Upload staging |
+| `sending pending flush upload: <uuid> with N metrics` | `::stats` | Upload dispatched |
+| `skipping flush upload, minimum interval not elapsed` | `::stats` | Debounced by `stats.minimum_upload_interval_ms` (30s) |
+| `flush already in progress, skipping` | `::stats` | Request **dropped entirely** — no disk write, no upload |
+| `stat flush upload attempt complete: UploadResponse { success: <bool>, uuid: "<uuid>" }` | `::stats` | Upload result |
+
+### Which line proves a disk write
+
+Use **`writing snapshot`**. It is the file write and it fires on both the forced and timed paths.
+
+`stats flushed` is *not* the disk-write proof: it only ever appears on the forced path, so a timed
+flush writes to disk while logging nothing of the sort. Reasoning from its absence will produce a
+false "no disk write" conclusion. Observed order on the forced path:
+
+```
+received a signal → processing flush to disk tick → updating aggregated snapshot
+  → writing snapshot   ← the write
+  → stats flushed      ← completion marker, ~9ms later
+  → sending pending flush upload
+```
+
+### Classifying a flush
+
+| Kind | Signature |
+|---|---|
+| Platform-triggered | `state flushing initiated`, then `received a signal…` within ~300ms |
+| Internal forced | `received a signal…` with **no** preceding `state flushing initiated` |
+| Timed | `processing flush to disk tick` with **no** `received a signal…` just before |
+| Dropped | `flush already in progress, skipping` |
+
+Counting `processing flush to disk tick` alone over-counts timed flushes, because forced flushes
+emit it too.
+
+### Correlating uploads
+
+Match `sending pending flush upload` to `stat flush upload attempt complete` **by uuid, never by
+order**. Acks arrive out of order, can take 475ms–17s, and may reference an upload from a
+*previous process run* recovered from disk at startup.
+
+## 5. Transport (`bd_api`)
+
+Needs `bd_api=debug`. Explains *why* an upload didn't land.
+
+| Line | Meaning |
+|---|---|
+| `starting new stream` / `sending handshake` / `received handshake` | Connection established |
+| `stream closed due to '<reason>'` | Teardown. `SocketException: Software caused connection abort` = the OS cut it; `UnknownHostException` = DNS blocked |
+| `reconnecting in N ms` | Backoff — escalates fast (263ms → 2.5s → 17s → 91s) |
+| `received ack for stats upload "<uuid>", error: ""` | Server ack |
+
+A backgrounded app blocked by the firewall shows `UnknownHostException` rather than a connect
+error, because the block covers DNS too.
+
+## 6. Ring buffers and log uploads
+
+Separate from stats, and **not** touched by `flush()`, which only makes buffers durable on disk.
+
+| Line | Tag | Meaning |
+|---|---|---|
+| `buffer_id=<id> signaled to flush` | `bd_buffer::ring_buffer` | Buffer told to drain to disk |
+| `buffer_id=<id> signaled to flush not found` | `bd_buffer::ring_buffer` | ⚠ Buffer missing — this path `return`s and can stop later flushes |
+| `flushing logs due to deadline hit` | `bd_logger::consumer` | `log_uploader.batch_deadline_ms` (30s) fired |
+| `flushing N logs` / `flushing N logs from trigger artifact` | `bd_logger::consumer` | Batch dispatched |
+| `completed continuous upload with result: …` | `bd_logger::consumer` | Log upload result |
+| `triggered flush buffer action IDs: {…}` | `bd_logger::log_replay` | Workflow-driven buffer flush |
+
+`flush_state` runs four things concurrently (`tokio::join!`): stats flush **with upload**, all ring
+buffers to disk, session persist, workflow persist. It does **not** dispatch a log upload — those
+run on the consumer's own batch deadline. So a missing log upload after a flush is expected, not a
+failure.
+
+## 7. Network cutoff (`dumpsys netpolicy`)
+
+Queried after the run, not from logcat. Timestamps are device-clock, so they compare directly.
+
+```bash
+adb -s <serial> shell dumpsys netpolicy | grep '<uid>-background'   # event log: when allow was revoked
+adb -s <serial> shell dumpsys netpolicy | grep 'UID=<uid> state='   # authoritative current state
+```
+
+Grepping the dump returns **event-log** lines (`… - Firewall rule changed: <uid>-background-default`),
+which is what you want for timing. The *current* state is the `effective=` field of
+`UID=<uid> state={…}` — do not poll the event log for current state.
+
+`effective=NONE` means unblocked. `effective=APP_BACKGROUND` means the background firewall chain
+has revoked it. Other reasons OR in: `DOZE`, `DATA_SAVER`, `METERED_USER_RESTRICTED`,
+`POWER_SAVE_MODE`.
+
+## 8. Traps
+
+1. **`stats flushed` is not a disk-write signal** — forced path only. Use `writing snapshot`.
+2. **`processing flush to disk tick` fires on forced flushes too** — don't count it as "timed".
+3. **"Forced" ≠ platform-triggered** — use `state flushing initiated`.
+4. **Correlate uploads by uuid**, not order; acks can be seconds late or from a prior process.
+5. **The 30s upload debounce hides everything else.** Background sooner than 30s after the last
+   flush-triggered upload and the upload is suppressed before network or device state matters. A
+   run showing `skipping flush upload, minimum interval not elapsed` measured only the debounce.
+6. **Rust logcat tags are full module paths** (`bd_client_stats::file_manager`). Grepping
+   `bd_client_stats:` with a single colon misses submodules — match the prefix.
+7. **A blocked backgrounded app fails DNS**, so the error is `UnknownHostException`, not a connect
+   failure. Don't read it as a DNS misconfiguration.

--- a/.claude/skills/android-launch-run/scripts/.gitignore
+++ b/.claude/skills/android-launch-run/scripts/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.claude/skills/android-launch-run/scripts/adbctl.py
+++ b/.claude/skills/android-launch-run/scripts/adbctl.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Device control for capture-sdk Android runs.
+
+Subcommands:
+  devices                          list connected devices (serial, api, model, locked)
+  install [--app X] [--serial S]   build + install the debug app (all devices by default)
+  logprop <filter> [--serial S]    set debug.bitdrift.internal_rust_log
+  mode <name> --on|--off           apply/undo a device state; `mode reset` restores everything
+  verify <name>                    print the verification output for a mode
+  action <name> [--seconds N]      home|back|recents|screen-off|wake|kill|force-stop|freeze|...
+  mark <text>                      stamp a device-clock marker into logcat
+  state                            dump the full device state relevant to these runs
+
+Everything targets every connected device in parallel unless --serial or --sequential is given.
+Actions are stamped into logcat with `log -t ANDROID-RUN` so timelines stay on the device clock.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import re
+import subprocess
+import sys
+
+MARKER_TAG = "ANDROID-RUN"
+
+APPS = {
+    "gradle-test-app": (
+        "io.bitdrift.gradletestapp",
+        "io.bitdrift.gradletestapp.ui.activities.MainActivity",
+        ":gradle-test-app:installDebug",
+    ),
+    "gradle-tv-test-app": (
+        "io.bitdrift.gradletvtestapp",
+        "io.bitdrift.gradletvtestapp.MainActivity",
+        ":gradle-tv-test-app:installDebug",
+    ),
+}
+DEFAULT_APP = "gradle-test-app"
+
+
+# ---------------------------------------------------------------- adb plumbing
+
+
+def adb(serial: str, cmd: str, timeout: int = 60) -> str:
+    """Run `adb -s <serial> shell <cmd>` and return stdout with CRs stripped."""
+    try:
+        r = subprocess.run(["adb", "-s", serial, "shell", cmd],
+                           capture_output=True, text=True, timeout=timeout)
+        return r.stdout.replace("\r", "")
+    except subprocess.TimeoutExpired:
+        return ""
+
+
+def devices() -> list[str]:
+    out = subprocess.run(["adb", "devices"], capture_output=True, text=True).stdout
+    return [ln.split()[0] for ln in out.splitlines()[1:]
+            if ln.strip() and ln.split()[-1] == "device"]
+
+
+def resolve_targets(args) -> list[str]:
+    if getattr(args, "serial", None):
+        return [args.serial]
+    found = devices()
+    if not found:
+        sys.exit("no devices connected (check `adb devices`)")
+    return found
+
+
+def fanout(targets: list[str], fn, sequential: bool = False) -> dict[str, object]:
+    """Apply fn(serial) across targets. Parallel by default; sequential when timing matters."""
+    if sequential or len(targets) == 1:
+        return {s: fn(s) for s in targets}
+    with cf.ThreadPoolExecutor(max_workers=len(targets)) as ex:
+        futs = {ex.submit(fn, s): s for s in targets}
+        return {futs[f]: f.result() for f in cf.as_completed(futs)}
+
+
+def api_level(serial: str) -> int:
+    try:
+        return int(adb(serial, "getprop ro.build.version.sdk").strip() or 0)
+    except ValueError:
+        return 0
+
+
+def app_uid(serial: str, pkg: str) -> str | None:
+    for ln in adb(serial, "pm list packages -U").splitlines():
+        if f"{pkg} " in ln:
+            m = re.search(r"uid:(\d+)", ln)
+            if m:
+                return m.group(1)
+    return None
+
+
+def is_locked(serial: str) -> bool:
+    return "deviceLocked=1" in adb(serial, "dumpsys trust")
+
+
+def require_unlocked(serial: str) -> None:
+    """A locked device silently invalidates runs: the app launches behind the keyguard and
+    backgrounds itself, so any later action lands on an already-backgrounded app."""
+    if is_locked(serial):
+        sys.exit(f"{serial}: device is LOCKED. Runs would be invalid — the app launches behind "
+                 f"the keyguard and backgrounds itself. Ask the user to unlock it; do not try to "
+                 f"bypass a secure keyguard.")
+
+
+def mark(serial: str, text: str) -> None:
+    adb(serial, f'log -p i -t {MARKER_TAG} "{text}"')
+
+
+# ---------------------------------------------------------------- modes
+
+def _wifi_networks(serial: str) -> list[str]:
+    return [ln.split(";")[0].strip()
+            for ln in adb(serial, "cmd netpolicy list wifi-networks").splitlines()
+            if ln.split(";")[0].strip()]
+
+
+def mode(serial: str, name: str, on: bool, pkg: str) -> str:
+    """Apply or undo a device state. Returns the verification string."""
+    if name == "airplane":
+        adb(serial, f"cmd connectivity airplane-mode {'enable' if on else 'disable'}")
+
+    elif name == "battery-saver":
+        if on:
+            adb(serial, "dumpsys battery unplug")
+            adb(serial, "dumpsys battery set level 15")
+            adb(serial, "cmd power set-adaptive-power-saver-enabled false")
+            adb(serial, "settings put global low_power 1")
+        else:
+            adb(serial, "settings put global low_power 0")
+            adb(serial, "dumpsys battery reset")
+
+    elif name in ("doze-deep", "doze-light"):
+        depth = "deep" if name == "doze-deep" else "light"
+        if on:
+            adb(serial, "dumpsys battery unplug")
+            adb(serial, f"dumpsys deviceidle whitelist -{pkg}")
+            adb(serial, f"dumpsys deviceidle enable {depth}")
+            adb(serial, f"dumpsys deviceidle force-idle {depth}")
+        else:
+            adb(serial, "dumpsys deviceidle unforce")
+            adb(serial, "dumpsys deviceidle enable all")
+            adb(serial, "dumpsys battery reset")
+
+    elif name == "doze-prearm":
+        # Everything except force-idle, so the final command lands fast after ON_STOP.
+        adb(serial, "dumpsys battery unplug")
+        adb(serial, f"dumpsys deviceidle whitelist -{pkg}")
+        adb(serial, "dumpsys deviceidle enable deep")
+
+    elif name == "data-saver":
+        for nid in _wifi_networks(serial):
+            adb(serial, f"cmd netpolicy set metered-network {nid} "
+                        f"{'true' if on else 'undefined'}")
+        adb(serial, f"cmd netpolicy set restrict-background {'true' if on else 'false'}")
+
+    elif name == "standby-restricted":
+        adb(serial, f"am set-standby-bucket {pkg} {'restricted' if on else 'active'}")
+
+    elif name == "bg-restricted":
+        adb(serial, f"am set-bg-restriction-level {pkg} "
+                    f"{'background_restricted' if on else 'unrestricted'}")
+        adb(serial, f"cmd appops set {pkg} RUN_ANY_IN_BACKGROUND "
+                    f"{'ignore' if on else 'allow'}")
+
+    elif name == "freezer":
+        adb(serial, f"am {'freeze' if on else 'unfreeze'} --sticky {pkg}")
+
+    elif name == "idle-allowlist":
+        adb(serial, f"dumpsys deviceidle whitelist {'+' if on else '-'}{pkg}")
+
+    elif name == "reset":
+        for m in ("airplane", "battery-saver", "doze-deep", "data-saver",
+                  "standby-restricted", "bg-restricted", "freezer", "idle-allowlist"):
+            mode(serial, m, False, pkg)
+        adb(serial, "svc power stayon false")
+        adb(serial, "input keyevent KEYCODE_WAKEUP")
+        adb(serial, "wm dismiss-keyguard")
+
+    else:
+        sys.exit(f"unknown mode: {name}")
+
+    return verify(serial, name, pkg)
+
+
+def verify(serial: str, name: str, pkg: str) -> str:
+    """One-line verification per mode. Several modes fail silently, so always check."""
+    uid = app_uid(serial, pkg) or "?"
+    checks = {
+        "airplane": lambda: adb(serial, "cmd connectivity airplane-mode").strip(),
+        "battery-saver": lambda: "low_power=" + adb(serial, "settings get global low_power").strip()
+                                 + " " + _grep(adb(serial, "dumpsys netpolicy"), "Restrict power"),
+        "doze-deep": lambda: "deep=" + adb(serial, "dumpsys deviceidle get deep").strip(),
+        "doze-light": lambda: "light=" + adb(serial, "dumpsys deviceidle get light").strip(),
+        "data-saver": lambda: adb(serial, "cmd netpolicy get restrict-background").strip()
+                              + " | metered=" + str(sum(
+                                  1 for ln in adb(serial, "cmd netpolicy list wifi-networks").splitlines()
+                                  if ln.strip().endswith("true"))),
+        # get-bg-restriction-level returns 'unknown' on API 36/37 — the appop is the usable check.
+        "bg-restricted": lambda: _grep(adb(serial, f"cmd appops get {pkg} RUN_ANY_IN_BACKGROUND"),
+                                       "RUN_ANY_IN_BACKGROUND"),
+        "standby-restricted": lambda: "bucket=" + adb(serial, f"am get-standby-bucket {pkg}").strip(),
+        "freezer": lambda: "frozen_events=" + str(
+            adb(serial, "dumpsys activity processes").count("frozen=true")),
+        "idle-allowlist": lambda: "allowlisted=" + str(
+            pkg in adb(serial, "dumpsys deviceidle whitelist")),
+        "reset": lambda: state_line(serial, pkg),
+    }
+    fn = checks.get(name)
+    return fn() if fn else f"(no verification for {name})"
+
+
+def _grep(text: str, needle: str) -> str:
+    for ln in text.splitlines():
+        if needle in ln:
+            return ln.strip()
+    return ""
+
+
+def state_line(serial: str, pkg: str) -> str:
+    uid = app_uid(serial, pkg) or "?"
+    eff = ""
+    for ln in adb(serial, "dumpsys netpolicy").splitlines():
+        if f"UID={uid} state=" in ln:
+            m = re.search(r"effective=([A-Z_|]+)", ln)
+            eff = m.group(1) if m else ""
+            break
+    return (f"airplane={adb(serial, 'cmd connectivity airplane-mode').strip()} "
+            f"low_power={adb(serial, 'settings get global low_power').strip()} "
+            f"doze={adb(serial, 'dumpsys deviceidle get deep').strip()}/"
+            f"{adb(serial, 'dumpsys deviceidle get light').strip()} "
+            f"bucket={adb(serial, f'am get-standby-bucket {pkg}').strip()} "
+            f"blocked={eff or 'NONE'}")
+
+
+# ---------------------------------------------------------------- actions
+
+ACTIONS = {
+    "home": "input keyevent KEYCODE_HOME",
+    "back": "input keyevent KEYCODE_BACK",
+    "recents": "input keyevent KEYCODE_APP_SWITCH",
+    "screen-off": "input keyevent KEYCODE_SLEEP",
+    "wake": "input keyevent KEYCODE_WAKEUP",
+}
+
+
+def action(serial: str, name: str, pkg: str, activity: str, seconds: float = 0) -> str:
+    if name == "wait":
+        import time
+        mark(serial, f"ACTION wait {seconds}s")
+        time.sleep(seconds)
+        return f"waited {seconds}s"
+
+    mark(serial, f"ACTION {name}")
+
+    if name in ACTIONS:
+        adb(serial, ACTIONS[name])
+    elif name == "launch":
+        adb(serial, f"am start -W -n {pkg}/{activity}", timeout=90)
+    elif name == "kill":
+        adb(serial, f"am kill {pkg}")
+    elif name == "force-stop":
+        adb(serial, f"am force-stop {pkg}")
+    elif name == "freeze":
+        adb(serial, f"am freeze --sticky {pkg}")
+    elif name == "unfreeze":
+        adb(serial, f"am unfreeze --sticky {pkg}")
+    else:
+        sys.exit(f"unknown action: {name}")
+    return name
+
+
+# ---------------------------------------------------------------- install
+
+def install(app: str, serial: str, repo_root: str = ".") -> str:
+    _, _, task = APPS[app]
+    r = subprocess.run(
+        ["./platform/jvm/gradlew", "-p", "platform/jvm", task],
+        capture_output=True, text=True, cwd=repo_root,
+        env={**__import__("os").environ, "ANDROID_SERIAL": serial},
+        timeout=900,
+    )
+    tail = [ln for ln in r.stdout.splitlines() if "Installed on" in ln or "BUILD" in ln]
+    return "; ".join(tail) or (r.stderr.strip().splitlines() or ["failed"])[-1]
+
+
+# ---------------------------------------------------------------- cli
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--serial", help="target one device (default: all connected)")
+    ap.add_argument("--app", default=DEFAULT_APP, choices=list(APPS))
+    ap.add_argument("--sequential", action="store_true",
+                    help="one device at a time; use when sub-second timings must be trustworthy")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("devices")
+    sub.add_parser("state")
+    sub.add_parser("install")
+    p = sub.add_parser("logprop"); p.add_argument("filter")
+    p = sub.add_parser("mode"); p.add_argument("name")
+    g = p.add_mutually_exclusive_group(); g.add_argument("--on", action="store_true")
+    g.add_argument("--off", action="store_true")
+    p = sub.add_parser("verify"); p.add_argument("name")
+    p = sub.add_parser("action"); p.add_argument("name"); p.add_argument("--seconds", type=float, default=0)
+    p = sub.add_parser("mark"); p.add_argument("text")
+
+    args = ap.parse_args()
+    pkg, activity, _ = APPS[args.app]
+
+    if args.cmd == "devices":
+        for s in devices():
+            print(f"{s:24s} api={api_level(s):3d} "
+                  f"model={adb(s, 'getprop ro.product.model').strip():18s} "
+                  f"uid={app_uid(s, pkg)} locked={is_locked(s)}")
+        return
+
+    targets = resolve_targets(args)
+
+    if args.cmd == "install":
+        for s, out in fanout(targets, lambda s: install(args.app, s), args.sequential).items():
+            print(f"[{s}] {out}")
+        return
+
+    if args.cmd == "logprop":
+        fanout(targets, lambda s: adb(s, f"setprop debug.bitdrift.internal_rust_log "
+                                         f"'{args.filter}'"), args.sequential)
+        print(f"set on {len(targets)} device(s): {args.filter}  "
+              f"(read at launch; set before starting the app)")
+        return
+
+    if args.cmd == "mode":
+        on = args.on or not args.off
+        for s, out in fanout(targets, lambda s: mode(s, args.name, on, pkg), args.sequential).items():
+            print(f"[{s}] {args.name} {'on' if on else 'off'} -> {out}")
+        return
+
+    if args.cmd == "verify":
+        for s, out in fanout(targets, lambda s: verify(s, args.name, pkg), args.sequential).items():
+            print(f"[{s}] {args.name}: {out}")
+        return
+
+    if args.cmd == "action":
+        if args.name == "launch":
+            for s in targets:
+                require_unlocked(s)
+        for s, out in fanout(targets,
+                            lambda s: action(s, args.name, pkg, activity, args.seconds),
+                            args.sequential).items():
+            print(f"[{s}] {out}")
+        return
+
+    if args.cmd == "mark":
+        fanout(targets, lambda s: mark(s, args.text), args.sequential)
+        print(f"marked on {len(targets)} device(s): {args.text}")
+        return
+
+    if args.cmd == "state":
+        for s, out in fanout(targets, lambda s: state_line(s, pkg), args.sequential).items():
+            print(f"[{s}] {out}")
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/android-launch-run/scripts/parse_logs.py
+++ b/.claude/skills/android-launch-run/scripts/parse_logs.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Turn a logcat capture into a device-clock timeline plus a verdict summary.
+
+  python3 parse_logs.py <capture.txt> [--ref "process ON_STOP"] [--uid 10304] [--json]
+
+Everything is measured relative to a reference event (default `process ON_STOP`, the point the
+SDK's backgrounding work hangs off), so offsets read as "+18ms after backgrounding" rather than as
+wall-clock times nobody can hold in their head.
+
+Emits a run-validity warning when the reference event precedes the action marker: that means the
+app was already backgrounded when the action landed (usually a locked device), and the run measured
+nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+LINE = re.compile(
+    r"^(?P<ts>\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d)\s+(?P<pid>\d+)\s+\d+\s+[VDIWEF]\s+(?P<tag>.*?):\s(?P<msg>.*)$"
+)
+
+# (kind, tag regex, message regex, human label). Order matters only for first-match-wins.
+PATTERNS: list[tuple[str, str, str, str]] = [
+    # harness markers
+    ("MARK", r"ANDROID-RUN", r"^ACTION (?P<what>.+)$", ">>> {what}"),
+    # app-side lifecycle
+    ("PROC", r"bitdrift-lifecycle", r"^process (?P<ev>\S+)$", "process {ev}"),
+    ("FOCUS", r"bitdrift-lifecycle", r"^window (?P<act>\S+) focus=(?P<f>\S+)$",
+     "window focus={f} ({act})"),
+    # OS lifecycle (events buffer); tag differs by Android version
+    ("OS_STOP", r"(wm|am)_on_stop_called", r".*", "OS: activity onStop"),
+    ("OS_PAUSE", r"(wm|am)_on_paused_called", r".*", "OS: activity onPause"),
+    ("OS_FOCUS", r"input_focus", r"^(?P<what>Focus leaving|ViewRootImpl focus=false).*",
+     "OS: {what}"),
+    ("OS_FREEZE", r"am_freeze", r".*", "OS: am_freeze"),
+    # flush attribution
+    ("PLATFORM_FLUSH", r"bd_logger::logger", r"^state flushing initiated$",
+     "state flushing initiated  [PLATFORM asked]"),
+    ("BLOCK_OK", r"bd_logger::async_log_buffer", r"^flush state: completion received$",
+     "blocking flush completed"),
+    ("BLOCK_ERR", r"bd_logger::async_log_buffer",
+     r"^flush state: received an error when waiting for completion",
+     "blocking flush TIMED OUT (500ms JNI cap)"),
+    # stats — match the whole bd_client_stats* prefix, not just ::stats
+    ("FORCED", r"bd_client_stats.*", r"^received a signal to flush stats to disk$",
+     "forced flush requested"),
+    ("TICK", r"bd_client_stats.*", r"^processing flush to disk tick$", "flush_to_disk() entered"),
+    ("MERGE", r"bd_client_stats.*", r"^updating aggregated snapshot file with (?P<n>\d+) metrics",
+     "merge snapshot ({n} metrics)"),
+    ("SNAP", r"bd_client_stats.*", r"^writing snapshot: (?P<path>\S+)$",
+     "WROTE SNAPSHOT TO DISK  {path}"),
+    ("FLUSHED", r"bd_client_stats.*", r"^stats flushed$", "stats flushed (forced path complete)"),
+    ("ENQ", r"bd_client_stats.*",
+     r"^sending pending flush upload: (?P<uuid>\S+) with (?P<n>\d+) metrics$",
+     "upload enqueued {uuid} ({n} metrics)"),
+    ("DEBO", r"bd_client_stats.*", r"^skipping flush upload, minimum interval not elapsed$",
+     "upload DEBOUNCED (30s window)"),
+    ("DROPPED", r"bd_client_stats.*", r"^flush already in progress, skipping$",
+     "flush DROPPED (already in progress)"),
+    ("RES", r"bd_client_stats.*",
+     r'^stat flush upload attempt complete: UploadResponse \{ success: (?P<ok>\w+), uuid: "(?P<uuid>[^"]*)"',
+     "upload result success={ok} {uuid}"),
+    # transport
+    ("STREAM_UP", r"bd_api.*", r"^received handshake$", "api stream up"),
+    ("STREAM_DOWN", r"bd_api.*", r"^stream closed due to '(?P<why>.*)'$", "api stream CLOSED: {why}"),
+    # ring buffers / log uploads
+    ("BUF", r"bd_buffer.*", r"^buffer_id=(?P<id>\S+) signaled to flush$", "ring buffer flush {id}"),
+    ("LOGBATCH", r"bd_logger::consumer", r"^flushing (?P<n>\d+) logs", "log batch: {n} logs"),
+]
+COMPILED = [(k, re.compile(t), re.compile(m), lbl) for k, t, m, lbl in PATTERNS]
+
+
+def ts_ms(ts: str) -> int:
+    date, clock = ts.split(" ")
+    mo, dd = (int(x) for x in date.split("-"))
+    hh, mm, rest = clock.split(":")
+    ss, ms = rest.split(".")
+    return ((((mo - 1) * 31 + dd) * 24 + int(hh)) * 3600 + int(mm) * 60 + int(ss)) * 1000 + int(ms)
+
+
+def parse(path: str, pkg: str = "io.bitdrift.gradletestapp") -> list[dict]:
+    """Parse a capture, keeping only events attributable to `pkg`.
+
+    Two sources of cross-talk to filter out. The `events` buffer is system-wide, so `am_freeze` and
+    friends report every app on the device. And the main buffer can carry `bd_*` lines from another
+    bitdrift app installed alongside this one — the pid tells them apart.
+    """
+    out = []
+    with open(path, errors="replace") as fh:
+        for raw in fh:
+            m = LINE.match(raw.rstrip("\n"))
+            if not m:
+                continue
+            tag, msg = m["tag"].strip(), m["msg"].strip()
+            for kind, tre, mre, label in COMPILED:
+                if not tre.fullmatch(tag):
+                    continue
+                mm = mre.search(msg)
+                if not mm:
+                    continue
+                # events-buffer tags are system-wide: require our package in the payload.
+                if kind.startswith("OS_") and pkg not in msg:
+                    break
+                groups = {k: v for k, v in mm.groupdict().items() if v}
+                out.append({"kind": kind, "t": ts_ms(m["ts"]), "ts": m["ts"],
+                            "pid": m["pid"],
+                            "label": label.format(**groups) if groups else label, **groups})
+                break
+
+    # Our pid is whichever process emitted the app-side lifecycle logs. Use it to drop bd_* lines
+    # belonging to a different bitdrift app on the same device.
+    ours = {e["pid"] for e in out if e["kind"] in ("PROC", "FOCUS")}
+    if ours:
+        out = [e for e in out
+               if e["kind"].startswith("OS_") or e["kind"] == "MARK" or e["pid"] in ours]
+    return out
+
+
+def fmt(delta: int) -> str:
+    a = abs(delta)
+    s = "+" if delta >= 0 else "-"
+    return f"{s}{a/1000:.3f}s" if a >= 1000 else f"{s}{a}ms"
+
+
+def summarize(evs: list[dict], ref_label: str) -> dict:
+    ref = next((e for e in evs if e["kind"] == "PROC" and ref_label.endswith(e.get("ev", "\0"))), None)
+    if ref is None:
+        ref = next((e for e in evs if ref_label in e["label"]), None)
+    ref_t = ref["t"] if ref else (evs[0]["t"] if evs else 0)
+
+    after = [e for e in evs if e["t"] >= ref_t - 50]
+    before = [e for e in evs if e["t"] < ref_t - 50]
+    k = lambda src, kind: [e for e in src if e["kind"] == kind]
+
+    # Only an enqueue belonging to this flush counts — a later periodic upload is unrelated.
+    forced_after = k(after, "FORCED")
+    fref = forced_after[0]["t"] if forced_after else ref_t
+    own_enq = [e for e in k(after, "ENQ") if fref <= e["t"] <= fref + 3000]
+    own_debo = [e for e in k(after, "DEBO") if fref <= e["t"] <= fref + 3000]
+
+    res = None
+    if own_enq:
+        res = next((e for e in k(evs, "RES") if e.get("uuid") == own_enq[0].get("uuid")), None)
+
+    action = next((e for e in evs if e["kind"] == "MARK"
+                   and not e["label"].endswith(("launch", "observe-end"))
+                   and "wait" not in e["label"]), None)
+    invalid = bool(ref and action and ref["t"] < action["t"] - 50)
+
+    return {
+        "ref_t": ref_t,
+        "ref_found": ref is not None,
+        "invalid_run": invalid,
+        "fg": {"snapshots": len(k(before, "SNAP")), "uploads_enqueued": len(k(before, "ENQ")),
+               "uploads_ok": len([e for e in k(before, "RES") if e.get("ok") == "true"])},
+        "bg": {
+            "platform_flush": len(k(after, "PLATFORM_FLUSH")),
+            "forced": len(forced_after),
+            "timed": len([e for e in k(evs, "TICK")
+                          if not any(0 <= e["t"] - f["t"] <= 150 for f in k(evs, "FORCED"))]),
+            "dropped": len(k(evs, "DROPPED")),
+            "snapshot_written": len(k(after, "SNAP")),
+            "stats_flushed": len(k(after, "FLUSHED")),
+            "upload": "ENQ" if own_enq else ("DEBO" if own_debo else "NONE"),
+            "upload_result": ("OK" if res and res.get("ok") == "true"
+                              else "FAIL" if res else "NONE"),
+            "ack_ms": (res["t"] - own_enq[0]["t"]) if (res and own_enq) else None,
+        },
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("capture")
+    ap.add_argument("--ref", default="process ON_STOP")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    evs = parse(args.capture)
+    if not evs:
+        sys.exit("no recognised events — check the capture and that RUST_LOG was set before launch")
+    s = summarize(evs, args.ref)
+
+    if args.json:
+        print(json.dumps({"summary": s, "events": evs}, indent=2))
+        return
+
+    print(f"reference: {args.ref}" + ("" if s["ref_found"] else "  (NOT FOUND — offsets are from "
+                                                               "the first event)"))
+    if s["invalid_run"]:
+        print("\n  *** INVALID RUN: the reference event precedes the action marker. The app was "
+              "\n      already backgrounded when the action landed — usually a locked device. "
+              "\n      Discard and re-run with the device unlocked. ***\n")
+    print()
+    for e in evs:
+        d = e["t"] - s["ref_t"]
+        strong = e["kind"] in ("MARK", "SNAP", "PLATFORM_FLUSH", "BLOCK_ERR", "DROPPED")
+        print(f"  {fmt(d):>9}  {'#' if strong else '|'} {e['label']}")
+
+    fg, bg = s["fg"], s["bg"]
+    print(f"\nFOREGROUND (before reference): {fg['snapshots']} snapshot write(s) · "
+          f"{fg['uploads_enqueued']} upload(s) enqueued, {fg['uploads_ok']} acked")
+    print(f"BACKGROUND (after reference):  snapshot written: "
+          f"{'YES' if bg['snapshot_written'] else 'NO'} · "
+          f"platform flush: {bg['platform_flush']} · forced: {bg['forced']} · "
+          f"timed: {bg['timed']} · dropped: {bg['dropped']}")
+    print(f"  upload {bg['upload']}/{bg['upload_result']}"
+          + (f" · ack {bg['ack_ms']}ms" if bg["ack_ms"] is not None else ""))
+    if bg["upload"] == "DEBO":
+        print("  NOTE: debounced by the 30s window — this run did not test upload delivery. "
+              "Idle >30s in the foreground before backgrounding.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/android-launch-run/scripts/run_scenario.py
+++ b/.claude/skills/android-launch-run/scripts/run_scenario.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Run a declarative scenario across every connected device, then parse each capture.
+
+  python3 run_scenario.py <scenario.json> --out /tmp/run1 [--serial S] [--sequential]
+
+Per device it writes <out>/<serial>/{logcat.txt, summary.txt, state.json}.
+
+Parallel across devices by default. Pass --sequential when a sub-second measurement has to be
+trustworthy: concurrent adb round-trips and logcat streams add tens of ms of jitter, which is fine
+for pass/fail but can distort an ack latency in the hundreds of ms.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import adbctl  # noqa: E402
+import parse_logs  # noqa: E402
+
+
+def firewall_revoke(serial: str, uid: str, after_ms: int) -> int | None:
+    """Device-clock ms at which the background firewall chain revoked network for uid.
+
+    Read from the netpolicy *event log*, whose timestamps share the device clock with logcat, so
+    the two can be compared directly. (The current state lives in `effective=` instead.)
+    """
+    best = None
+    for ln in adbctl.adb(serial, "dumpsys netpolicy").splitlines():
+        m = re.search(r"(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d):(\d\d\d) - "
+                      r"Firewall rule changed: " + uid + r"-background-(\w+)", ln)
+        if not m:
+            continue
+        _, mo, dd, hh, mi, ss, ms, st = m.groups()
+        t = ((((int(mo) - 1) * 31 + int(dd)) * 24 + int(hh)) * 3600
+             + int(mi) * 60 + int(ss)) * 1000 + int(ms)
+        if st == "default" and t >= after_ms - 500 and (best is None or t < best):
+            best = t
+    return best
+
+
+def run_on(serial: str, sc: dict, outdir: str, app: str) -> dict:
+    pkg, activity, _ = adbctl.APPS[app]
+    d = os.path.join(outdir, serial)
+    os.makedirs(d, exist_ok=True)
+    logf = os.path.join(d, "logcat.txt")
+
+    adbctl.require_unlocked(serial)
+    adbctl.mode(serial, "reset", False, pkg)
+    adbctl.adb(serial, f"am force-stop {pkg}")
+    if sc.get("rust_log"):
+        adbctl.adb(serial, f"setprop debug.bitdrift.internal_rust_log '{sc['rust_log']}'")
+    adbctl.adb(serial, "svc power stayon true")
+
+    for m in sc.get("modes_before_launch", []):
+        adbctl.mode(serial, m, True, pkg)
+
+    # Capture both buffers: app + Rust logs live in main, OS lifecycle in events.
+    adbctl.adb(serial, "logcat -c -b all")
+    fh = open(logf, "w")
+    cap = subprocess.Popen(["adb", "-s", serial, "logcat", "-v", "threadtime", "-b", "main,events"],
+                           stdout=fh, stderr=subprocess.DEVNULL)
+    time.sleep(1)
+
+    try:
+        for step in sc["steps"]:
+            act = step["action"]
+            if act == "wait":
+                adbctl.action(serial, "wait", pkg, activity, step.get("seconds", 1))
+            elif act == "mode":
+                adbctl.mark(serial, f"ACTION mode {step['name']} on")
+                adbctl.mode(serial, step["name"], True, pkg)
+            else:
+                adbctl.action(serial, act, pkg, activity)
+    finally:
+        adbctl.mark(serial, "ACTION observe-end")
+        time.sleep(1)
+        cap.terminate()
+        try:
+            cap.wait(timeout=5)
+        except Exception:
+            cap.kill()
+        fh.close()
+
+    evs = parse_logs.parse(logf)
+    summ = parse_logs.summarize(evs, sc.get("reference_event", "process ON_STOP"))
+
+    uid = adbctl.app_uid(serial, pkg)
+    revoke = firewall_revoke(serial, uid, summ["ref_t"]) if uid else None
+    summ["net_cutoff_s"] = round((revoke - summ["ref_t"]) / 1000.0, 3) if revoke else None
+    summ["device"] = {"serial": serial, "api": adbctl.api_level(serial), "uid": uid,
+                      "state_after": adbctl.state_line(serial, pkg)}
+
+    with open(os.path.join(d, "state.json"), "w") as f:
+        json.dump(summ, f, indent=2)
+
+    # Human-readable timeline, same view parse_logs.py prints.
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        sys.argv = ["parse_logs", logf, "--ref", sc.get("reference_event", "process ON_STOP")]
+        try:
+            parse_logs.main()
+        except SystemExit:
+            pass
+    with open(os.path.join(d, "summary.txt"), "w") as f:
+        f.write(buf.getvalue())
+
+    adbctl.mode(serial, "reset", False, pkg)
+    adbctl.adb(serial, "svc power stayon false")
+    adbctl.adb(serial, f"am force-stop {pkg}")
+    return summ
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("scenario")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--serial")
+    ap.add_argument("--app", default=adbctl.DEFAULT_APP, choices=list(adbctl.APPS))
+    ap.add_argument("--sequential", action="store_true")
+    args = ap.parse_args()
+
+    sc = json.load(open(args.scenario))
+    targets = [args.serial] if args.serial else adbctl.devices()
+    if not targets:
+        sys.exit("no devices connected")
+    os.makedirs(args.out, exist_ok=True)
+
+    print(f"scenario '{sc['name']}' on {len(targets)} device(s)"
+          f"{' sequentially' if args.sequential else ' in parallel'}")
+
+    fn = lambda s: run_on(s, sc, args.out, args.app)
+    if args.sequential or len(targets) == 1:
+        results = {s: fn(s) for s in targets}
+    else:
+        with cf.ThreadPoolExecutor(max_workers=len(targets)) as ex:
+            futs = {ex.submit(fn, s): s for s in targets}
+            results = {futs[f]: f.result() for f in cf.as_completed(futs)}
+
+    for s, r in results.items():
+        bg, fg = r["bg"], r["fg"]
+        flag = "  *** INVALID (see summary.txt) ***" if r["invalid_run"] else ""
+        print(f"\n[{s}] api={r['device']['api']}{flag}")
+        print(f"  FG: {fg['snapshots']} snapshot(s), {fg['uploads_enqueued']} upload(s) "
+              f"({fg['uploads_ok']} acked)")
+        print(f"  BG: snapshot={'YES' if bg['snapshot_written'] else 'NO'} "
+              f"platform_flush={bg['platform_flush']} upload={bg['upload']}/"
+              f"{bg['upload_result']}"
+              + (f" ack={bg['ack_ms']}ms" if bg["ack_ms"] is not None else ""))
+        print(f"  net cutoff: {r['net_cutoff_s']}s after reference"
+              if r["net_cutoff_s"] else "  net cutoff: not observed")
+    print(f"\noutputs in {args.out}/<serial>/")
+
+
+if __name__ == "__main__":
+    main()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/GradleTestApp.kt
@@ -12,6 +12,7 @@ import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
 import io.bitdrift.gradletestapp.diagnostics.fatalissues.ThirdPartyCrashReportersInitializer
 import io.bitdrift.gradletestapp.diagnostics.lifecycle.ActivitySpanCallbacks
+import io.bitdrift.gradletestapp.diagnostics.lifecycle.LifecycleEventLogger
 import io.bitdrift.gradletestapp.diagnostics.papa.PapaTelemetry
 import io.bitdrift.gradletestapp.diagnostics.startup.AppStartInfoLogger
 import io.bitdrift.gradletestapp.diagnostics.strictmode.StrictModeConfigurator
@@ -26,6 +27,8 @@ import timber.log.Timber
 class GradleTestApp : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        LifecycleEventLogger.install()
 
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/lifecycle/LifecycleEventLogger.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/diagnostics/lifecycle/LifecycleEventLogger.kt
@@ -1,0 +1,64 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.gradletestapp.diagnostics.lifecycle
+
+import android.app.Activity
+import android.util.Log
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.ProcessLifecycleOwner
+
+/**
+ * Emits a minimal, stable set of lifecycle breadcrumbs to logcat so automated harnesses can
+ * correlate app state transitions with SDK behaviour — for example, deciding whether a stats flush
+ * was triggered by backgrounding or by an internal timer.
+ *
+ * Only two things are logged, both at INFO:
+ *  - **process** lifecycle, from [ProcessLifecycleOwner]
+ *  - **window focus**, forwarded by the hosting activity
+ *
+ * Per-activity lifecycle is deliberately omitted. The platform already writes it to the logcat
+ * `events` buffer (`wm_on_stop_called`, `wm_on_paused_called`, `wm_stop_activity`, …), so repeating
+ * it here would only add noise. Process lifecycle is the part the platform does *not* expose, and
+ * it is what the SDK's background flush actually hangs off — `ProcessLifecycleOwner` debounces stop
+ * events by roughly 700ms, so it fires meaningfully later than the activity's own `onStop`.
+ *
+ * Window focus is included because it is the earliest signal that the app is leaving the
+ * foreground, ahead of both the activity stop and the process stop.
+ *
+ * Message formats are kept fixed so they stay cheap to parse:
+ * ```
+ * I bitdrift-lifecycle: process ON_STOP
+ * I bitdrift-lifecycle: window MainActivity focus=false
+ * ```
+ */
+object LifecycleEventLogger {
+    const val TAG = "bitdrift-lifecycle"
+
+    /**
+     * Registers the process-lifecycle observer. Call from `Application.onCreate`, which runs on the
+     * main thread as [ProcessLifecycleOwner] requires.
+     */
+    fun install() {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                Log.i(TAG, "process $event")
+            },
+        )
+    }
+
+    /**
+     * Forwards `Activity.onWindowFocusChanged`, which has no process-level equivalent and so cannot
+     * be observed from [install] alone.
+     */
+    fun onWindowFocusChanged(
+        activity: Activity,
+        hasFocus: Boolean,
+    ) {
+        Log.i(TAG, "window ${activity.javaClass.simpleName} focus=$hasFocus")
+    }
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/activities/MainActivity.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/activities/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import io.bitdrift.gradletestapp.R
 import io.bitdrift.gradletestapp.databinding.ActivityMainBinding
+import io.bitdrift.gradletestapp.diagnostics.lifecycle.LifecycleEventLogger
 
 class MainActivity : AppCompatActivity() {
     private lateinit var appBarConfiguration: AppBarConfiguration
@@ -64,6 +65,11 @@ class MainActivity : AppCompatActivity() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        LifecycleEventLogger.onWindowFocusChanged(this, hasFocus)
     }
 
     override fun onSupportNavigateUp(): Boolean =


### PR DESCRIPTION
Nothing here should be public facing, this is all internal tooling to be used with our test apps.

---
## Summary

Adds tooling to run and observe the Android test app on real devices, so SDK runtime
behaviour (background flushes, uploads, lifecycle timing) can be verified rather than
inferred from source.

- **New `android-launch-run` skill** (`.claude/skills/`) — added abilities to install the debug app, set Rust log
  levels via `debug.bitdrift.internal_rust_log`, drive nine device power/network states (doze,
  battery saver, Data Saver, standby buckets, cached-app freezer, airplane, …), background/kill
  the app, and parse logcat into a device-clock timeline. Targets all connected devices.
  Ships references for the bitdrift log signatures and the per-mode setup/teardown pitfalls.
- **`gradle-test-app` lifecycle breadcrumbs** — new `LifecycleEventLogger` emits two INFO lines
  per foreground/background transition under tag `bitdrift-lifecycle`: process lifecycle (from
  `ProcessLifecycleOwner`) and window focus. Per-activity lifecycle is intentionally omitted —
  the platform already writes that to the logcat `events` buffer. Process lifecycle is the part
  it doesn't expose, and it's what the SDK's background flush hangs off.

Test-app and tooling only; no SDK changes.

## Testing

Verified on a Pixel 10 (API 37) and an API 36 emulator. Sample timeline, measured from
`process ON_STOP`:
```
+3ms bd_logger::logger: state flushing initiated
+14ms bd_client_stats::stats: received a signal to flush stats to disk
+18ms bd_client_stats::file_manager: writing snapshot
+945ms upload acked success=true
+4.98s firewall revoked network
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.