### PR TITLE
improve speed of formatters

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,7 @@ load("@rules_apple//apple:apple.bzl", "apple_static_framework_import")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_compiler_plugin", "kt_kotlinc_options")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_javac_options")
+load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_pkg//:pkg.bzl", "pkg_zip")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(
@@ -12,6 +13,7 @@ load(
 )
 load("//bazel:android_debug_info.bzl", "android_debug_info")
 load("//bazel:framework_imports_extractor.bzl", "framework_imports_extractor")
+load("//bazel:rustfmt.bzl", "rustfmt_runner")
 load("//bazel/android:artifacts.bzl", "android_artifacts")
 load("//bazel/ios:hack.bzl", "rewrite_xcframework")
 
@@ -23,6 +25,23 @@ alias(
 alias(
     name = "android_app",
     actual = "//examples/android:android_app",
+)
+
+multirun(
+    name = "ktlint_fix_all",
+    commands = [
+        "//bazel/android:_test_suite_lib_ktlint_fix",
+        "//platform/jvm/capture:_capture_logger_lib_ktlint_fix",
+        "//platform/jvm/capture:_test_ktlint_fix",
+        "//platform/jvm/common:_lib_ktlint_fix",
+        "//platform/jvm/replay:_lib_ktlint_fix",
+        "//platform/jvm/replay:_test_ktlint_fix",
+    ],
+    jobs = 0,
+)
+
+rustfmt_runner(
+    name = "rustfmt",
 )
 
 rewrite_xcframework(

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .ONESHELL: # support multiline commands
 # support loop constructs
 SHELL=bash
+FORMAT_MAKE_FLAGS=--no-print-directory --silent
 
 .PHONY: build
 build:
@@ -8,11 +9,11 @@ build:
 
 .PHONY: ktlint
 ktlint:
-	./bazelw query 'kind(ktlint_fix, //...)' | xargs -n1 ./bazelw run
+	./bazelw run //:ktlint_fix_all
 
 .PHONY: rustfmt
 rustfmt:
-	RUSTFMT_CONFIG=$(pwd)/rustfmt.toml ./bazelw run @rules_rust//:rustfmt
+	./bazelw run //:rustfmt
 
 .PHONY: buildifier
 buildifier:
@@ -20,7 +21,7 @@ buildifier:
 
 .PHONY: lint-yaml
 lint-yaml:
-	taplo lint
+	taplo lint $$(git ls-files -- '*.toml')
 
 .PHONY: lint-shell
 lint-shell:
@@ -30,17 +31,31 @@ lint-shell:
 fix-yaml:
 	taplo fmt
 
-.PHONY: fix-swift
-fix-swift:
+.PHONY: fix-swiftlint
+fix-swiftlint:
 # tools/lint:fix doesn't warn about all docstring violations.
-# For this reason format doc strings first (by running tools/lint:fix) and validate whether
-# any doc string violations are left next (by running tools/lint:lint-docstrings).
 # WebViewBridgeScript.swift is auto-generated; swiftlint's --format flag reindents it via
 # SourceKit regardless of `excluded` in .swiftlint.yml, so it's passed an explicit file list here.
-	swiftlint --quiet --fix --format --force-exclude $$(git ls-files -- '*.swift' ':!:platform/swift/source/integrations/webview/WebViewBridgeScript.swift') && ./bazelw run tools/lint:lint-docstrings
+	swiftlint --quiet --fix --format --force-exclude $$(git ls-files -- '*.swift' ':!:platform/swift/source/integrations/webview/WebViewBridgeScript.swift')
+
+.PHONY: lint-docstrings
+lint-docstrings:
+# Format doc strings first (by running tools/lint:fix) and validate whether any violations remain.
+	./bazelw run tools/lint:lint-docstrings
+
+.PHONY: fix-swift
+fix-swift: fix-swiftlint lint-docstrings
+
+.PHONY: format-bazel
+format-bazel:
+	+@$(MAKE) $(FORMAT_MAKE_FLAGS) ktlint; \
+	$(MAKE) $(FORMAT_MAKE_FLAGS) rustfmt
 
 .PHONY: format
-format: lint-shell ktlint rustfmt buildifier fix-swift lint-yaml
+format:
+	+@$(MAKE) $(FORMAT_MAKE_FLAGS) buildifier; \
+	$(MAKE) $(FORMAT_MAKE_FLAGS) -j4 format-bazel lint-shell fix-swiftlint lint-yaml; \
+	$(MAKE) $(FORMAT_MAKE_FLAGS) lint-docstrings
 
 # Use repin when you get Error: Digests do not match
 .PHONY: repin

--- a/bazel/android/build.bzl
+++ b/bazel/android/build.bzl
@@ -72,6 +72,7 @@ def _jvm_lint_support(name, srcs, require_javadocs):
     ktlint_fix(
         name = "_{}_ktlint_fix".format(name),
         srcs = srcs,
+        visibility = ["//visibility:public"],
     )
 
     ktlint_test(

--- a/bazel/rustfmt.bzl
+++ b/bazel/rustfmt.bzl
@@ -1,0 +1,51 @@
+def _rustfmt_runner_impl(ctx):
+    rustfmt_toolchain = ctx.toolchains[Label("@rules_rust//rust/rustfmt:toolchain_type")]
+    launcher = ctx.actions.declare_file(ctx.label.name + ".sh")
+
+    ctx.actions.write(
+        output = launcher,
+        content = """\
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "${{BUILD_WORKSPACE_DIRECTORY}}"
+rustfmt_runfile="{rustfmt_runfile}"
+rustfmt="${{RUNFILES_DIR:-}}/$rustfmt_runfile"
+if [[ ! -x "$rustfmt" ]]; then
+  rustfmt="$(grep -sm1 "^$rustfmt_runfile " "${{RUNFILES_MANIFEST_FILE:-/dev/null}}" | cut -d ' ' -f 2- || true)"
+fi
+if [[ ! -x "$rustfmt" ]]; then
+  rustfmt="$0.runfiles/$rustfmt_runfile"
+fi
+if [[ ! -x "$rustfmt" ]]; then
+  rustfmt="$(grep -sm1 "^$rustfmt_runfile " "$0.runfiles_manifest" | cut -d ' ' -f 2- || true)"
+fi
+if [[ ! -x "$rustfmt" ]]; then
+  echo "Unable to locate rustfmt in Bazel runfiles" >&2
+  exit 1
+fi
+
+rust_sources=()
+while IFS= read -r -d '' source; do
+  rust_sources+=("$source")
+done < <(git ls-files -z -- '*.rs')
+
+"$rustfmt" --config-path "$BUILD_WORKSPACE_DIRECTORY/rustfmt.toml" "${{rust_sources[@]}}"
+""".format(
+            rustfmt_runfile = rustfmt_toolchain.rustfmt.owner.workspace_name + "/bin/rustfmt",
+        ),
+        is_executable = True,
+    )
+
+    runfiles = ctx.runfiles(
+        files = [launcher],
+        transitive_files = rustfmt_toolchain.all_files,
+    )
+
+    return [DefaultInfo(executable = launcher, runfiles = runfiles)]
+
+rustfmt_runner = rule(
+    implementation = _rustfmt_runner_impl,
+    executable = True,
+    toolchains = ["@rules_rust//rust/rustfmt:toolchain_type"],
+)

--- a/ci/setup_linux_format.sh
+++ b/ci/setup_linux_format.sh
@@ -12,14 +12,16 @@ chmod +x "$formatter_dir/buildifier"
 
 # The binaries above dynamically link a library provided by Swift, so download Swift + update the
 # LD_LIBRARY_PATH tell the system how to find them.
-swift_archive_name="swift-5.7.3-RELEASE-ubuntu22.04"
-curl -OL "https://download.swift.org/swift-5.7.3-release/ubuntu2204/swift-5.7.3-RELEASE/$swift_archive_name.tar.gz"
+# Keep this aligned with the Swift language version used by macOS CI's selected Xcode.
+# ci/mac_ci_setup.sh currently selects Xcode 26.0.1, which uses Swift 6.2.
+swift_archive_name="swift-6.2.3-RELEASE-ubuntu22.04"
+curl -OL "https://download.swift.org/swift-6.2.3-release/ubuntu2204/swift-6.2.3-RELEASE/$swift_archive_name.tar.gz"
 tar xf "$swift_archive_name.tar.gz"
 mv "$swift_archive_name" "$formatter_dir/swift"
 
 # swiftlint provides static linting of Swift code.
 pushd "$(mktemp -d)"
-curl -OL https://github.com/realm/SwiftLint/releases/download/0.57.0/swiftlint_linux.zip
+curl -OL https://github.com/realm/SwiftLint/releases/download/0.59.1/swiftlint_linux.zip
 unzip swiftlint_linux.zip
 mv swiftlint "$formatter_dir/swiftlint"
 chmod +x "$formatter_dir/swiftlint"


### PR DESCRIPTION
- The fix-all target for ktlint cuts of 10s
- Using rustfmt directly against the *.rs glob is much faster than using the rules_rust native version
- Run formatters in parallel where safe
- Update swiftlint/swift to support newer Swift syntax