### PR TITLE
add a dry-run mode for releases

### DIFF
--- a/.github/workflows/example_apps_android.yaml
+++ b/.github/workflows/example_apps_android.yaml
@@ -7,6 +7,11 @@ on:
         description: Branch or tag to build from. Defaults to main.
         required: false
         default: main
+      dry-run:
+        type: boolean
+        description: Build and validate the archive without uploading it.
+        required: false
+        default: false
   workflow_call:
     inputs:
       release-ref:
@@ -14,6 +19,11 @@ on:
         description: Branch or tag to build from. Defaults to main.
         required: false
         default: main
+      dry-run:
+        type: boolean
+        description: Build and validate the archive without uploading it.
+        required: false
+        default: false
 
 jobs:
   build:
@@ -46,7 +56,10 @@ jobs:
       run: ./ci/prepare_example_apps_android.sh
       env:
         SKIP_PROTO_GEN: 1
+    - name: Verify Android example apps archive
+      run: unzip -t dist/example-apps.android.zip
     - name: Upload Android example apps
+      if: ${{ !inputs.dry-run }}
       uses: actions/upload-artifact@v4
       with:
         name: Android Example Apps

--- a/.github/workflows/example_apps_ios.yaml
+++ b/.github/workflows/example_apps_ios.yaml
@@ -7,6 +7,11 @@ on:
         description: Branch or tag to build from. Defaults to main.
         required: false
         default: main
+      dry-run:
+        type: boolean
+        description: Build and validate the archive without uploading it.
+        required: false
+        default: false
   workflow_call:
     inputs:
       release-ref:
@@ -14,6 +19,11 @@ on:
         description: Branch or tag to build from. Defaults to main.
         required: false
         default: main
+      dry-run:
+        type: boolean
+        description: Build and validate the archive without uploading it.
+        required: false
+        default: false
 
 jobs:
   build:
@@ -38,7 +48,10 @@ jobs:
         run: ./ci/mac_ci_setup.sh
       - name: Build iOS example apps
         run: ./ci/prepare_example_apps_ios.sh
+      - name: Verify iOS example apps archive
+        run: unzip -t dist/example-apps.ios.zip
       - name: Upload iOS example apps to GH
+        if: ${{ !inputs.dry-run }}
         uses: actions/upload-artifact@v4
         with:
           name: iOS Example Apps

--- a/.github/workflows/integrations_android.yaml
+++ b/.github/workflows/integrations_android.yaml
@@ -11,6 +11,11 @@ on:
         description: Branch or tag to build from. Defaults to main.
         required: false
         default: main
+      dry-run:
+        type: boolean
+        description: Build and validate archives without uploading them.
+        required: false
+        default: false
   workflow_dispatch:
     inputs:
       version:
@@ -22,6 +27,11 @@ on:
         description: Branch or tag to build from. Defaults to main.
         required: false
         default: main
+      dry-run:
+        type: boolean
+        description: Build and validate archives without uploading them.
+        required: false
+        default: false
 jobs:
   build-gradle-libraries:
     name: Build Gradle Libraries
@@ -75,25 +85,34 @@ jobs:
       run: |
         readonly dir=$(pwd)
         (cd capture-plugin/build/repos/releases/io/bitdrift/capture-plugin/io.bitdrift.capture-plugin.gradle.plugin/${{ inputs.version }} && zip -r "$dir/capture-plugin-marker-${{ inputs.version }}.android.zip" ./*)
+    - name: Verify integration archives
+      run: |
+        for archive in capture-timber-${{ inputs.version }}.android.zip capture-apollo-${{ inputs.version }}.android.zip capture-plugin-${{ inputs.version }}.android.zip capture-plugin-marker-${{ inputs.version }}.android.zip; do
+          unzip -t "$archive"
+        done
     - name: Upload Timber artifacts
+      if: ${{ !inputs.dry-run }}
       uses: actions/upload-artifact@v4
       with:
         name: capture-timber-${{ inputs.version }}.android.zip
         path: platform/jvm/capture-timber-${{ inputs.version }}.android.zip
         if-no-files-found: error
     - name: Upload Apollo artifacts
+      if: ${{ !inputs.dry-run }}
       uses: actions/upload-artifact@v4
       with:
         name: capture-apollo-${{ inputs.version }}.android.zip
         path: platform/jvm/capture-apollo-${{ inputs.version }}.android.zip
         if-no-files-found: error        
     - name: Upload Gradle Plugin artifacts
+      if: ${{ !inputs.dry-run }}
       uses: actions/upload-artifact@v4
       with:
         name: capture-plugin-${{ inputs.version }}.android.zip
         path: platform/jvm/capture-plugin-${{ inputs.version }}.android.zip
         if-no-files-found: error
     - name: Upload Gradle Plugin marker
+      if: ${{ !inputs.dry-run }}
       uses: actions/upload-artifact@v4
       with:
         name: capture-plugin-marker-${{ inputs.version }}.android.zip

--- a/.github/workflows/release_capture_ios.yaml
+++ b/.github/workflows/release_capture_ios.yaml
@@ -6,14 +6,25 @@ on:
         description: 'The SDK version to release to SwiftPM, ex: 0.9.102'
         required: true
         type: string
+      dry-run:
+        description: Do not trigger the downstream release.
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       version:
         description: 'The SDK version to release to SwiftPM, ex: 0.9.102'
         required: true
         type: string
+      dry-run:
+        description: Do not trigger the downstream release.
+        required: false
+        type: boolean
+        default: false
 jobs:
   release-capture-ios:
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     steps:
       - name: org-read-write-install token
@@ -31,4 +42,3 @@ jobs:
           GH_TOKEN: ${{ steps.org-read-write.outputs.token }}
           # "Update SDK version" workflow id in the capture-ios repo.
           WORKFLOW_ID: 92140498
-

--- a/.github/workflows/release_capture_react.yaml
+++ b/.github/workflows/release_capture_react.yaml
@@ -6,14 +6,25 @@ on:
         description: 'The SDK version to release to React, ex: 0.18.6'
         required: true
         type: string
+      dry-run:
+        description: Do not trigger the downstream release.
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       version:
         description: 'The SDK version to release to React, ex: 0.18.6'
         required: true
         type: string
+      dry-run:
+        description: Do not trigger the downstream release.
+        required: false
+        type: boolean
+        default: false
 jobs:
   release-capture-react:
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     steps:
       - name: org-read-write-install token
@@ -31,4 +42,3 @@ jobs:
           GH_TOKEN: ${{ steps.org-read-write.outputs.token }}
           # "React Native Update Version" workflow id in the capture-es repo.
           WORKFLOW_ID: 184625065 
-

--- a/.github/workflows/release_gh.yaml
+++ b/.github/workflows/release_gh.yaml
@@ -26,6 +26,11 @@ on:
         description: Include Google Play SDK verification file from GOOGLE_PLAY_SDK_VERIFICATION_FILE_CONTENTS secret in the Android AAR.
         required: false
         default: true
+      dry-run:
+        type: boolean
+        description: Build and validate release artifacts without uploading or creating a GitHub release.
+        required: false
+        default: false
       release-ref:
         type: string
         description: Branch or tag to build/release from. Defaults to main.
@@ -71,6 +76,11 @@ on:
         description: Include Google Play SDK verification file from GOOGLE_PLAY_SDK_VERIFICATION_FILE_CONTENTS secret in the Android AAR.
         required: false
         default: true
+      dry-run:
+        type: boolean
+        description: Build and validate release artifacts without uploading or creating a GitHub release.
+        required: false
+        default: false
       release-ref:
         type: string
         description: Branch or tag to build/release from. Defaults to main.
@@ -118,11 +128,15 @@ jobs:
           ./tools/ios_release.sh Capture "${{ inputs.version }}"
           mv ./dist/Capture.ios.zip ./Capture.ios.zip
           mv ./dist/Capture.doccarchive.ios.zip ./Capture.doccarchive.ios.zip
+          unzip -t ./Capture.ios.zip
+          unzip -t ./Capture.doccarchive.ios.zip
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.dry-run }}
         with:
           name: Capture.ios.zip
           path: ./Capture.ios.zip
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.dry-run }}
         with:
           name: Capture.doccarchive.ios.zip
           path: ./Capture.doccarchive.ios.zip
@@ -135,6 +149,7 @@ jobs:
     uses: ./.github/workflows/example_apps_ios.yaml
     with:
       release-ref: ${{ inputs.release-ref }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
   # The Android release build builds capture.aar and accompanying artifacts, like the .pom xml and the symbols corresponding to the .so.
@@ -181,7 +196,10 @@ jobs:
           VERSION: ${{ inputs.version }}
           CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
           INCLUDE_SDK_VERIFICATION_FILE: ${{ inputs.include-sdk-verification-file }}
+      - name: Verify Android release archive
+        run: unzip -t ./dist/Capture.android.zip
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.dry-run }}
         with:
           name: Capture.android.zip
           path: ./dist/Capture.android.zip
@@ -194,6 +212,7 @@ jobs:
     uses: ./.github/workflows/example_apps_android.yaml
     with:
       release-ref: ${{ inputs.release-ref }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
   build-android-integrations:
@@ -206,6 +225,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       release-ref: ${{ inputs.release-ref }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit
 
   create-release:
@@ -216,7 +236,7 @@ jobs:
     # always() is needed because some dependencies may be conditionally skipped
     # (e.g. iOS jobs when platform=android, integrations when capture-only).
     # Without it, a skipped dependency would also skip this job.
-    if: ${{ always() && !failure() && !cancelled() }}
+    if: ${{ always() && !failure() && !cancelled() && !inputs.dry-run }}
     needs: [
       "ios-release-build",
       "build-ios-example-apps",
@@ -331,3 +351,20 @@ jobs:
           CAPTURE_SUFFIX: ${{ inputs.capture-suffix }}
           PLATFORM: ${{ inputs.platform }}
           RELEASE_REF: ${{ inputs.release-ref }}
+
+  dry-run-complete:
+    name: Dry-run complete
+    runs-on: ubuntu-latest
+    if: ${{ always() && !failure() && !cancelled() && inputs.dry-run }}
+    needs: [
+      "ios-release-build",
+      "build-ios-example-apps",
+      "android-release-build",
+      "build-android-example-apps",
+      "build-android-integrations",
+    ]
+    steps:
+      - name: Summarize validated release artifacts
+        run: |
+          echo "Release dry run completed successfully." >> "$GITHUB_STEP_SUMMARY"
+          echo "All selected artifacts were built and archive integrity-checked; no artifacts were uploaded and no GitHub release was created." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release_public.yaml
+++ b/.github/workflows/release_public.yaml
@@ -25,6 +25,11 @@ on:
         description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
         required: false
         default: ''
+      dry-run:
+        type: boolean
+        description: Validate workflow inputs without publishing artifacts.
+        required: false
+        default: false
       release-ref:
         type: string
         description: Branch or tag to release from. Defaults to main.
@@ -63,6 +68,11 @@ on:
         description: 'Custom Android capture artifact suffix including separator (e.g. "-no-jank-stats" -> io.bitdrift:capture-no-jank-stats). Ignored if platform is ios or react-native. Leave empty for standard "capture".'
         required: false
         default: ''
+      dry-run:
+        type: boolean
+        description: Validate workflow inputs without publishing artifacts.
+        required: false
+        default: false
       release-ref:
         type: string
         description: Branch or tag to release from. Defaults to main.
@@ -70,7 +80,7 @@ on:
         default: main
 jobs:
   release-ios:
-    if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
+    if: ${{ !inputs.dry-run && (inputs.platform == 'all' || inputs.platform == 'ios') }}
     name: Upload iOS artifacts to dl.bitdrift.io
     permissions:
       id-token: write # required to use OIDC authentication
@@ -110,7 +120,7 @@ jobs:
       env:
         VERSION: ${{ inputs.version }}
   release-android:
-    if: ${{ inputs.platform == 'all' || inputs.platform == 'android' }}
+    if: ${{ !inputs.dry-run && (inputs.platform == 'all' || inputs.platform == 'android') }}
     name: Upload Android artifacts to bitdrift maven and maven central
     permissions:
       id-token: write # required to use OIDC authentication (set up aws credentials)

--- a/.github/workflows/update_sdk_version.yaml
+++ b/.github/workflows/update_sdk_version.yaml
@@ -39,6 +39,11 @@ on:
         description: Include Google Play SDK verification file from GOOGLE_PLAY_SDK_VERIFICATION_FILE_CONTENTS secret in the Android AAR.
         required: false
         default: true
+      dry-run:
+        type: boolean
+        description: Build and validate release artifacts without publishing or triggering downstream releases.
+        required: false
+        default: false
       release-ref:
         type: string
         description: Branch or tag to release from. Defaults to main.
@@ -74,6 +79,11 @@ on:
         description: Include Google Play SDK verification file from GOOGLE_PLAY_SDK_VERIFICATION_FILE_CONTENTS secret in the Android AAR.
         required: false
         default: true
+      dry-run:
+        type: boolean
+        description: Build and validate release artifacts without publishing or triggering downstream releases.
+        required: false
+        default: false
       release-ref:
         type: string
         description: Branch or tag to release from. Defaults to main.
@@ -99,10 +109,11 @@ jobs:
       android-artifacts: ${{ inputs.android-artifacts }}
       capture-suffix: ${{ inputs.capture-suffix }}
       include-sdk-verification-file: ${{ inputs.include-sdk-verification-file }}
+      dry-run: ${{ inputs.dry-run }}
       release-ref: ${{ inputs.release-ref }}
     secrets: inherit
   public-release:
-    if: ${{ inputs.platform != 'react-native' }}
+    if: ${{ inputs.platform != 'react-native' && !inputs.dry-run }}
     permissions:
       id-token: write # required to use OIDC authentication
       contents: read
@@ -113,20 +124,23 @@ jobs:
       platform: ${{ inputs.platform }}
       android-artifacts: ${{ inputs.android-artifacts }}
       capture-suffix: ${{ inputs.capture-suffix }}
+      dry-run: ${{ inputs.dry-run }}
       release-ref: ${{ inputs.release-ref }}
     secrets: inherit
     needs: gh-release
   capture-ios-release:
-    if: ${{ inputs.platform == 'all' || inputs.platform == 'ios' }}
+    if: ${{ !inputs.dry-run && (inputs.platform == 'all' || inputs.platform == 'ios') }}
     uses: ./.github/workflows/release_capture_ios.yaml
     with:
       version: ${{ inputs.version }}
+      dry-run: ${{ inputs.dry-run }}
     needs: public-release
     secrets: inherit
   capture-react-release:
-    if: ${{ always() && !failure() && !cancelled() && (inputs.platform == 'all' || inputs.platform == 'react-native') }}
+    if: ${{ always() && !failure() && !cancelled() && !inputs.dry-run && (inputs.platform == 'all' || inputs.platform == 'react-native') }}
     uses: ./.github/workflows/release_capture_react.yaml
     with:
       version: ${{ inputs.version }}
+      dry-run: ${{ inputs.dry-run }}
     needs: public-release
     secrets: inherit


### PR DESCRIPTION
this should make it easier to test the release pipeline without doing a real release

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.