### PR TITLE
Version Android AVD snapshot cache

### DIFF
--- a/.github/actions/setup-android-emulator/action.yaml
+++ b/.github/actions/setup-android-emulator/action.yaml
@@ -14,9 +14,6 @@ inputs:
   arch:
     description: Android system-image architecture.
     required: true
-  cache-key:
-    description: GitHub Actions cache key for the AVD snapshot.
-    required: true
   ram-size:
     description: Emulator RAM size.
     required: false
@@ -50,6 +47,26 @@ runs:
         emulator-target: ${{ inputs.target }}
         emulator-arch: ${{ inputs.arch }}
 
+    - name: Determine AVD cache key
+      id: avd-cache-key
+      shell: bash
+      env:
+        API_LEVEL: ${{ inputs.api-level }}
+        TARGET: ${{ inputs.target }}
+        ARCH: ${{ inputs.arch }}
+        PROFILE: ${{ inputs.profile }}
+        RAM_SIZE: ${{ inputs.ram-size }}
+        DISK_SIZE: ${{ inputs.disk-size }}
+        DISABLE_ANIMATIONS: ${{ inputs.disable-animations }}
+      run: |
+        # Bump snapshot-v1 when changing snapshot creation, its defaults, or
+        # compatible SDK/emulator versions. The remaining fields describe the
+        # AVD configuration and prevent incompatible snapshots from sharing a
+        # cache entry.
+        cache_key="${RUNNER_OS}-${RUNNER_ARCH}-avd-snapshot-v1-api${API_LEVEL}-${TARGET}-${ARCH}-${PROFILE}-ram${RAM_SIZE}-disk${DISK_SIZE}-animations${DISABLE_ANIMATIONS}"
+        cache_key="${cache_key// /-}"
+        echo "key=${cache_key}" >> "$GITHUB_OUTPUT"
+
     - name: Restore AVD cache
       id: avd-cache
       uses: actions/cache/restore@v4
@@ -57,7 +74,7 @@ runs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: ${{ inputs.cache-key }}
+        key: ${{ steps.avd-cache-key.outputs.key }}
 
     - name: Kill ADB server to ensure cached keys are used
       shell: bash
@@ -86,4 +103,4 @@ runs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: ${{ inputs.cache-key }}
+        key: ${{ steps.avd-cache-key.outputs.key }}

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -311,7 +311,6 @@ jobs:
         api-level: '23'
         target: default
         arch: x86_64
-        cache-key: ${{ runner.os }}-avd-api-23-2
     - name: Gradle capture-timber unit tests
       working-directory: ./platform/jvm
       run: ./gradlew capture-timber:testReleaseUnitTest --info
@@ -356,7 +355,6 @@ jobs:
           api-level: '31'
           target: default
           arch: x86_64
-          cache-key: ${{ runner.os }}-avd-api31-benchmark
 
       - name: Run Microbenchmarks
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # pin@v2.37.0
@@ -542,7 +540,6 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: google_apis
           arch: x86_64
-          cache-key: ${{ runner.os }}-avd-api${{ matrix.api-level }}-1
       - name: run tests
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # pin@v2.37.0
         timeout-minutes: 15
@@ -560,7 +557,17 @@ jobs:
       - name: Cache hint on hello world failure
         if: ${{ failure() }}
         run: |
-          echo "Android hello world verification failed. If this failed due to what appears to be an adb issue, consider blowing away the AVD cache in the GitHub Actions UI for this workflow."
+          echo "Android hello world verification failed. Emulator diagnostics are available as a workflow artifact."
+      - name: Upload emulator diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-emulator-diagnostics-api-${{ matrix.api-level }}
+          path: |
+            ~/.android/avd/**/*.ini
+            ~/.android/avd/**/*.log
+            /tmp/android-runner/**
+          if-no-files-found: warn
 
   # This is a noop job that completes once all the jobs spawned by the previous step completes. By blocking PR merges on this
   # job completing, we are able to gate it on all the previous jobs without explicitly enumerating them.


### PR DESCRIPTION
- Version the Android AVD snapshot cache from its SDK, emulator, and AVD setup inputs.
- Upload emulator diagnostics when the Android hello-world verification fails.

Just me trying to de-flake the emulator cache issue we seem to be having occasionally 

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
