### PR TITLE
ci: run Clippy with platform tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,8 +41,8 @@ build:noclippy --output_groups=-clippy_checks
 test --build_tests_only
 test --test_env=RUST_BACKTRACE=full --java_runtime_version=remotejdk_11
 
-# Shared configuration for all CI tasks.
-build:ci --config=clippy
+# Shared configuration for all CI tasks. Clippy runs in its dedicated workflow so
+# artifact builds do not pay for lint-aspect analysis.
 build:ci --config=force-xcode-version
 build:ci --define build_config=ci
 
@@ -91,9 +91,6 @@ build:nocache --noremote_upload_local_results
 build:nocache --bes_results_url=
 build:nocache --bes_backend=
 build:nocache --remote_cache=
-
-# Convenience config for disabling targets that build on macos only (e.g. iOS targets).
-build:nomacos --test_tag_filters=-macos_only --build_tag_filters=-macos_only
 
 # We run this with release-common to be as indicative of production as possible, and add in as much debug information we
 # can to allow using perf to generate flamegraphs.

--- a/.github/actions/check-clippy-config/action.yaml
+++ b/.github/actions/check-clippy-config/action.yaml
@@ -1,0 +1,14 @@
+name: Check Clippy configuration
+description: Reports whether files that require a full Clippy run changed.
+
+outputs:
+  changed:
+    description: Whether Clippy configuration changed.
+    value: ${{ steps.check.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      run: ./ci/check_clippy_config.sh

--- a/.github/actions/files-changed/action.yaml
+++ b/.github/actions/files-changed/action.yaml
@@ -1,0 +1,40 @@
+name: Files changed
+description: Reports whether a regex or exact list of repository files changed.
+
+inputs:
+  regex:
+    description: Extended regular expression matched against changed paths.
+    required: false
+  files:
+    description: Newline-delimited exact file paths to match.
+    required: false
+
+outputs:
+  changed:
+    description: Whether relevant files changed.
+    value: ${{ steps.check.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      env:
+        FILES: ${{ inputs.files }}
+        REGEX: ${{ inputs.regex }}
+      run: |
+        if [[ -n "$FILES" && -n "$REGEX" ]]; then
+          echo "Provide either files or regex, not both."
+          exit 2
+        elif [[ -n "$FILES" ]]; then
+          files=()
+          while IFS= read -r file || [[ -n "$file" ]]; do
+            [[ -n "$file" ]] && files+=("$file")
+          done <<< "$FILES"
+          ./ci/files_changed.sh --files "${files[@]}"
+        elif [[ -n "$REGEX" ]]; then
+          ./ci/files_changed.sh "$REGEX"
+        else
+          echo "Provide files or regex."
+          exit 2
+        fi

--- a/.github/actions/run-bazel-tests/action.yaml
+++ b/.github/actions/run-bazel-tests/action.yaml
@@ -1,0 +1,21 @@
+name: Run Bazel tests
+description: Runs a runner slice's full or affected Bazel test set.
+
+inputs:
+  slice:
+    description: "Runner slice to test: all, linux_runner, or macos_runner."
+    required: true
+  mode:
+    description: Whether to run the full or affected test slice.
+    required: true
+  affected-targets-path:
+    description: Newline-delimited affected Bazel test labels for affected mode.
+    required: false
+    default: /tmp/impacted_test_targets.txt
+
+runs:
+  using: composite
+  steps:
+    - name: Run Bazel tests
+      shell: bash
+      run: ./ci/run_bazel_tests.sh '${{ inputs.slice }}' '${{ inputs.mode }}' '${{ inputs.affected-targets-path }}'

--- a/.github/actions/run-clippy/action.yaml
+++ b/.github/actions/run-clippy/action.yaml
@@ -1,0 +1,21 @@
+name: Run Clippy
+description: Runs the full or affected Bazel Clippy slice for a platform.
+
+inputs:
+  slice:
+    description: "Runner slice to lint: all, linux_runner, or macos_runner."
+    required: true
+  mode:
+    description: Whether to lint all targets or only the affected target file.
+    required: true
+  affected-targets-path:
+    description: Newline-delimited affected Bazel labels for affected mode.
+    required: false
+    default: /tmp/impacted_clippy_targets.txt
+
+runs:
+  using: composite
+  steps:
+    - name: Run Clippy
+      shell: bash
+      run: ./ci/run_clippy.sh '${{ inputs.slice }}' '${{ inputs.mode }}' '${{ inputs.affected-targets-path }}'

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -37,44 +37,39 @@ jobs:
       - name: Check for Bazel build file changes
         id: bazel_check
         run: ./ci/check_bazel.sh //examples/android:android_app
-        continue-on-error: true
 
       - name: Check for workflow file changes
         id: workflow_check
-        run: ./ci/files_changed.sh '^(\.github/workflows/android\.yaml|MODULE\.bazel|MODULE\.bazel\.lock)$'
-        continue-on-error: true
+        uses: ./.github/actions/files-changed
+        with:
+          regex: '^(\.github/workflows/android\.yaml|MODULE\.bazel|MODULE\.bazel\.lock)$'
 
       - name: Check for relevant Gradle changes
         id: gradle_check
-        run: ./ci/files_changed.sh "^platform/jvm/gradle-test-app/.*\.(gradle|kts|kt|xml)$" && ./ci/files_changed.sh "^platform/jvm/capture/src/test/.*$"
-        continue-on-error: true
+        uses: ./.github/actions/files-changed
+        with:
+          regex: '^(platform/jvm/gradle-test-app/.*\.(gradle|kts|kt|xml)|platform/jvm/capture/src/test/.*)$'
 
       - name: Check for Cargo.toml changes
         id: cargo_check
-        run: ./ci/files_changed.sh Cargo.toml
-        continue-on-error: true
+        uses: ./.github/actions/files-changed
+        with:
+          files: Cargo.toml
 
       - name: Determine if tests should run
         id: check_changes_separate
         run: |
-          bazel_status="${{ steps.bazel_check.outputs.check_result }}"
-          workflow_status="${{ steps.workflow_check.outputs.check_result }}"
-          gradle_status="${{ steps.gradle_check.outputs.check_result }}"
-          cargo_status="${{ steps.cargo_check.outputs.check_result }}"
+          bazel_changed="${{ steps.bazel_check.outputs.changed }}"
+          workflow_changed="${{ steps.workflow_check.outputs.changed }}"
+          gradle_changed="${{ steps.gradle_check.outputs.changed }}"
+          cargo_changed="${{ steps.cargo_check.outputs.changed }}"
 
-          # Check if any status indicates a relevant change or error
-          if [[ "$bazel_status" == "1" || "$workflow_status" == "1" || "$gradle_status" == "1" || "$cargo_status" == "1" ]]; then
-            echo "An unexpected issue occurred during checks."
-            exit 1
-          elif [[ "$bazel_status" == "0" || "$workflow_status" == "0" || "$gradle_status" == "0" || "$cargo_status" == "0" ]]; then
+          if [[ "$bazel_changed" == "true" || "$workflow_changed" == "true" || "$gradle_changed" == "true" || "$cargo_changed" == "true" ]]; then
             echo "Changes detected in one or more checks. Running tests."
             echo "run_tests=true" >> $GITHUB_ENV
-          elif [[ "$bazel_status" == "2" && "$workflow_status" == "2" && "$gradle_status" == "2" && "$cargo_status" == "2" ]]; then
+          else
             echo "No relevant changes found."
             echo "run_tests=false" >> $GITHUB_ENV
-          else
-            echo "Unknown issue."
-            exit 1
           fi
         shell: bash
 

--- a/.github/workflows/crash_reporter.yaml
+++ b/.github/workflows/crash_reporter.yaml
@@ -27,29 +27,23 @@ jobs:
 
       - name: Check for crash reporter changes
         id: crash_check
-        run: |
-          ./ci/files_changed.sh '^(platform/crash/|Cargo\.toml$|Cargo\.lock$|Cargo\.Bazel\.lock$|MODULE\.bazel$|MODULE\.bazel\.lock$|\.cargo/|\.github/workflows/crash_reporter\.yaml$)'
-        continue-on-error: true
+        uses: ./.github/actions/files-changed
+        with:
+          regex: '^(platform/crash/|Cargo\.toml$|Cargo\.lock$|Cargo\.Bazel\.lock$|MODULE\.bazel$|MODULE\.bazel\.lock$|\.cargo/|\.github/workflows/crash_reporter\.yaml$)'
 
       - name: Determine if tests should run
         id: check_changes
         run: |
-          crash_status="${{ steps.crash_check.outputs.check_result }}"
+          crash_changed="${{ steps.crash_check.outputs.changed }}"
 
-          echo "crash_status: $crash_status"
+          echo "crash_changed: $crash_changed"
 
-          if [[ "$crash_status" == "1" ]]; then
-            echo "An unexpected issue occurred during checks."
-            exit 1
-          elif [[ "$crash_status" == "0" ]]; then
+          if [[ "$crash_changed" == "true" ]]; then
             echo "Changes detected in crash reporter files. Running tests."
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$crash_status" == "2" ]]; then
+          else
             echo "No relevant crash reporter changes found."
             echo "run_tests=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unknown issue."
-            exit 1
           fi
         shell: bash
 

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -19,7 +19,10 @@ jobs:
     name: pre_check
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.check_changes.outputs.run_tests }}
+      should_run: ${{ github.event_name == 'push' || steps.check_changes.outputs.run_tests }}
+      has_affected_clippy_targets: ${{ steps.bazel_check.outputs.has_affected_clippy_targets }}
+      workflow_changed: ${{ steps.workflow_check.outputs.changed }}
+      clippy_config_changed: ${{ steps.clippy_config_check.outputs.changed }}
     steps:
       # Checkout repo to Github Actions runner
       - name: Checkout
@@ -36,34 +39,42 @@ jobs:
         id: bazel_check
         run: |
           ./ci/check_bazel.sh //examples/swift:ios_app //platform/swift //test/platform/swift
-        continue-on-error: true
+        env:
+          BAZEL_DIFF_CLIPPY_TARGETS_QUERY: 'attr("tags", "clippy_macos", //...)'
       - name: Check for workflow file changes
         id: workflow_check
-        run: |
-          ./ci/files_changed.sh '^(\.github/workflows/ios\.yaml|MODULE\.bazel|MODULE\.bazel\.lock|ci/ios_app_size_report\.sh|ci/parse_ios_app_thinning_report\.py|ci/capture_ios_binary_size\.sh|ci/check_ios_xcframework_archive_members\.sh|ci/extract_embedded_profile_plist\.py)$'
-        continue-on-error: true
+        uses: ./.github/actions/files-changed
+        with:
+          files: |
+            .github/workflows/ios.yaml
+            ci/ios_app_size_report.sh
+            ci/parse_ios_app_thinning_report.py
+            ci/capture_ios_binary_size.sh
+            ci/check_ios_xcframework_archive_members.sh
+            ci/extract_embedded_profile_plist.py
+      - name: Check for Clippy configuration changes
+        id: clippy_config_check
+        uses: ./.github/actions/check-clippy-config
+      - name: Upload affected Clippy targets
+        if: ${{ steps.bazel_check.outputs.has_affected_clippy_targets == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-affected-clippy-targets
+          path: /tmp/impacted_clippy_targets.txt
+          if-no-files-found: error
       - name: Determine if tests should run
         id: check_changes_separate
         run: |
-          bazel_status="${{ steps.bazel_check.outputs.check_result }}"
-          workflow_status="${{ steps.workflow_check.outputs.check_result }}"
+          bazel_changed="${{ steps.bazel_check.outputs.changed }}"
+          workflow_changed="${{ steps.workflow_check.outputs.changed }}"
+          clippy_config_changed="${{ steps.clippy_config_check.outputs.changed }}"
 
-          # Log the values of bazel_status and workflow_status for diagnostics
-          echo "bazel_status: $bazel_status"
-          echo "workflow_status: $workflow_status"
-          # Check if any status indicates a relevant change or error
-          if [[ "$bazel_status" == "1" || "$workflow_status" == "1" ]]; then
-            echo "An unexpected issue occurred during checks."
-            exit 1
-          elif [[ "$bazel_status" == "0" || "$workflow_status" == "0" ]]; then
+          if [[ "$bazel_changed" == "true" || "$workflow_changed" == "true" || "$clippy_config_changed" == "true" ]]; then
             echo "Changes detected in one or more checks. Running tests."
             echo "run_tests=true" >> $GITHUB_ENV
-          elif [[ "$bazel_status" == "2" && "$workflow_status" == "2" ]]; then
+          else
             echo "No relevant changes found."
             echo "run_tests=false" >> $GITHUB_ENV
-          else
-            echo "Unknown issue."
-            exit 1
           fi
         shell: bash
 
@@ -126,9 +137,26 @@ jobs:
 
       - name: "Install dependencies"
         run: ./ci/mac_ci_setup.sh
+
+      - name: Download affected Clippy targets
+        if: ${{ github.event_name == 'pull_request' && needs.pre_check.outputs.has_affected_clippy_targets == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-affected-clippy-targets
+          path: /tmp
+
       - name: Run iOS tests
-        # Bypass rules_apple's hardcoded 60s simulator boot and 150s test-launch timeouts,
-        run: env -u ANDROID_NDK_HOME ./bazelw test $(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)') --test_tag_filters=macos_only --test_output=errors --config ci --remote_download_minimal --test_env=REUSE_GLOBAL_SIMULATOR=1 --test_env=STARTUP_TIMEOUT_SEC=300
+        uses: ./.github/actions/run-bazel-tests
+        with:
+          slice: macos_runner
+          mode: full
+      - name: Run Clippy
+        if: ${{ github.event_name == 'push' || needs.pre_check.outputs.has_affected_clippy_targets == 'true' || needs.pre_check.outputs.workflow_changed == 'true' || needs.pre_check.outputs.clippy_config_changed == 'true' }}
+        uses: ./.github/actions/run-clippy
+        with:
+          slice: macos_runner
+          mode: ${{ (github.event_name == 'push' || needs.pre_check.outputs.workflow_changed == 'true' || needs.pre_check.outputs.clippy_config_changed == 'true') && 'full' || 'affected' }}
+          affected-targets-path: /tmp/impacted_clippy_targets.txt
       - name: Upload iOS test failure artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -34,16 +34,22 @@ jobs:
         id: bazel_check
         run: ./ci/check_bazel.sh //platform/... //test/...
         env:
-          BAZEL_DIFF_ARGS: --config ci --config nomacos --config libunwind
-        continue-on-error: true
+          BAZEL_DIFF_ARGS: --config ci --config libunwind
+          BAZEL_DIFF_TEST_TARGETS_QUERY: 'kind(".*_test rule", (//platform/... union //test/...) except attr("tags", "macos_only", //platform/... union //test/...))'
+          BAZEL_DIFF_CLIPPY_TARGETS_QUERY: '((attr("tags", "clippy", //...) except attr("tags", "macos_only", //...)) except attr("tags", "manual", //...)) union //platform/shared:build_script_'
 
       - name: Check for workflow file changes
         id: workflow_check
-        run: ./ci/files_changed.sh .github/workflows/linux_tests.yaml
-        continue-on-error: true
+        uses: ./.github/actions/files-changed
+        with:
+          files: .github/workflows/linux_tests.yaml
+
+      - name: Check for Clippy configuration changes
+        id: clippy_config_check
+        uses: ./.github/actions/check-clippy-config
 
       - name: Attempt to free up runner disk space
-        if: ${{ steps.bazel_check.outputs.check_result != '2' || steps.workflow_check.outputs.check_result != '2' }}
+        if: ${{ github.event_name == 'push' || steps.bazel_check.outputs.changed == 'true' || steps.workflow_check.outputs.changed == 'true' || steps.clippy_config_check.outputs.changed == 'true' }}
         run: |
           echo "Disk space BEFORE cleanup:"
           echo "================================"
@@ -64,27 +70,45 @@ jobs:
           echo "Disk space AFTER cleanup:"
           df -h /
 
-      - name: test
+      - name: Determine test mode
+        id: test_mode
         run: |
-          bazel_status="${{ steps.bazel_check.outputs.check_result }}"
-          workflow_status="${{ steps.workflow_check.outputs.check_result }}"
+          bazel_changed="${{ steps.bazel_check.outputs.changed }}"
+          workflow_changed="${{ steps.workflow_check.outputs.changed }}"
+          clippy_config_changed="${{ steps.clippy_config_check.outputs.changed }}"
 
-          if [[ $bazel_status == "2" && $workflow_status == "2" ]]; then
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          elif [[ $bazel_changed == "false" && $workflow_changed == "false" && $clippy_config_changed == "false" ]]; then
             echo "No changes detected, skipping"
-            exit 0
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
+          elif ./ci/version_only_change.sh; then
+            echo "No changes detected in the version-only change script. Skipping tests."
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
+          elif [[ "$workflow_changed" == "true" || "$clippy_config_changed" == "true" ]]; then
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ steps.bazel_check.outputs.has_affected_test_targets }}" == "true" ]]; then
+            echo "mode=affected" >> "$GITHUB_OUTPUT"
+          else
+            echo "No affected Linux test targets; skipping tests."
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
           fi
 
-          # ulimit -c unlimited
-          set +e
-          ./ci/version_only_change.sh
-          res="$?"
-          echo "Script completed with exit code: $res"
-          if [[ $res -ne 0 ]]; then
-            set -e
-            ./bazelw test //platform/... //test/... --config ci --config nomacos --config libunwind --remote_download_minimal --test_output=errors --test_env=RUST_LOG=debug
-          else
-              echo "No changes detected in the version-only change script. Skipping tests."
-          fi
+      - name: Run Linux tests
+        if: ${{ steps.test_mode.outputs.mode != 'skip' }}
+        uses: ./.github/actions/run-bazel-tests
+        with:
+          slice: linux_runner
+          mode: ${{ steps.test_mode.outputs.mode }}
+          affected-targets-path: /tmp/impacted_test_targets.txt
+
+      - name: Run Clippy
+        if: ${{ github.event_name == 'push' || steps.bazel_check.outputs.has_affected_clippy_targets == 'true' || steps.workflow_check.outputs.changed == 'true' || steps.clippy_config_check.outputs.changed == 'true' }}
+        uses: ./.github/actions/run-clippy
+        with:
+          slice: linux_runner
+          mode: ${{ (github.event_name == 'push' || steps.workflow_check.outputs.changed == 'true' || steps.clippy_config_check.outputs.changed == 'true') && 'full' || 'affected' }}
+          affected-targets-path: /tmp/impacted_clippy_targets.txt
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }} # Run only if something went wrong
         with:

--- a/bazel/bitdrift_build_system.bzl
+++ b/bazel/bitdrift_build_system.bzl
@@ -5,7 +5,7 @@ load("@rules_rs//rs:rust_shared_library.bzl", "rust_shared_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
 load("@rules_rust//rust:defs.bzl", "rust_clippy")
 
-def bitdrift_rust_binary(name, srcs = None, deps = [], proc_macro_deps = [], **args):
+def bitdrift_rust_binary(name, srcs = None, deps = [], proc_macro_deps = [], tags = [], **args):
     rust_binary(
         name = name,
         srcs = srcs if srcs else native.glob(["src/**/*.rs"]),
@@ -14,6 +14,7 @@ def bitdrift_rust_binary(name, srcs = None, deps = [], proc_macro_deps = [], **a
         aliases = _crate_aliases(),
         edition = "2024",
         rustc_flags = _rustc_flags(),
+        tags = _clippy_tags(tags),
         **args
     )
 
@@ -28,7 +29,7 @@ def bitdrift_rust_binary(name, srcs = None, deps = [], proc_macro_deps = [], **a
         ],
     )
 
-def bitdrift_rust_shared_library(name, srcs = None, deps = [], proc_macro_deps = [], rustc_flags = [], **args):
+def bitdrift_rust_shared_library(name, srcs = None, deps = [], proc_macro_deps = [], rustc_flags = [], tags = [], **args):
     rust_shared_library(
         name = name,
         srcs = srcs if srcs else native.glob(["src/**/*.rs"]),
@@ -37,6 +38,7 @@ def bitdrift_rust_shared_library(name, srcs = None, deps = [], proc_macro_deps =
         aliases = _crate_aliases(),
         edition = "2024",
         rustc_flags = rustc_flags + _rustc_flags(),
+        tags = _clippy_tags(tags),
         **args
     )
 
@@ -51,7 +53,7 @@ def bitdrift_rust_shared_library(name, srcs = None, deps = [], proc_macro_deps =
         ],
     )
 
-def bitdrift_rust_test(name, deps = [], proc_macro_deps = [], **args):
+def bitdrift_rust_test(name, deps = [], proc_macro_deps = [], tags = [], **args):
     rust_test(
         name = name,
         rustc_flags = _rustc_flags(),
@@ -59,6 +61,7 @@ def bitdrift_rust_test(name, deps = [], proc_macro_deps = [], **args):
         deps = all_crate_deps(normal = True, normal_dev = True, cargo_only = True) + deps,
         proc_macro_deps = proc_macro_deps,
         aliases = _crate_aliases(),
+        tags = _clippy_tags(tags),
         **args
     )
 
@@ -71,7 +74,7 @@ def bitdrift_rust_integration_test(name, **args):
         **args
     )
 
-def bitdrift_rust_library_only(name, srcs, deps = []):
+def bitdrift_rust_library_only(name, srcs, deps = [], tags = []):
     rust_library(
         name = name,
         srcs = srcs,
@@ -80,6 +83,7 @@ def bitdrift_rust_library_only(name, srcs, deps = []):
         aliases = _crate_aliases(),
         rustc_flags = _rustc_flags(),
         edition = "2024",
+        tags = _clippy_tags(tags),
     )
 
 def bitdrift_rust_library(
@@ -97,6 +101,8 @@ def bitdrift_rust_library(
     if test_crate_aliases == None:
         test_crate_aliases = _crate_aliases()
 
+    clippy_tags = _clippy_tags(tags)
+
     rust_library(
         name = name,
         deps = deps + all_crate_deps(normal = True, cargo_only = True),
@@ -105,7 +111,7 @@ def bitdrift_rust_library(
         aliases = crate_aliases,
         rustc_flags = _rustc_flags(),
         edition = "2024",
-        tags = tags,
+        tags = clippy_tags,
         data = data,
         **args
     )
@@ -113,7 +119,7 @@ def bitdrift_rust_library(
     rust_test(
         name = "{}_test".format(name),
         crate = name,
-        tags = tags,
+        tags = clippy_tags,
         rustc_flags = _rustc_flags(),
         aliases = test_crate_aliases,
         data = data,
@@ -134,6 +140,12 @@ def bitdrift_rust_library(
             "manual",
         ],
     )
+
+def _clippy_tags(tags):
+    result = tags + ["clippy"]
+    if "macos_only" in tags:
+        result.append("clippy_macos")
+    return result
 
 def _rustc_flags():
     return [

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 #
 # Usage ./ci/check_bazel.sh <list of targets to check for in the changeset>
 
-# Trap to handle unexpected errors and log them
-trap 'echo "An unexpected error occurred during Bazel check."; echo "check_result=1" >> "$GITHUB_OUTPUT"; exit 1' ERR
+# Trap to handle unexpected errors and log them.
+trap 'echo "An unexpected error occurred during Bazel check."; exit 1' ERR
 
 # Check if GITHUB_BASE_REF is set (i.e., you're in a pull request)
 if [ -n "$GITHUB_BASE_REF" ]; then
@@ -41,8 +41,11 @@ fi
 # If the only file that changed was .sdk_version, we don't need to run bazel-diff and just mark it as no changes detected.
 if ./ci/version_only_change.sh; then
   echo "Only change was platform/shared/.sdk-version, no Bazel changes detected."
-  echo "check_result=2" >> "$GITHUB_OUTPUT"
-  exit 1
+  echo "has_affected_targets=false" >> "$GITHUB_OUTPUT"
+  echo "has_affected_test_targets=false" >> "$GITHUB_OUTPUT"
+  echo "has_affected_clippy_targets=false" >> "$GITHUB_OUTPUT"
+  echo "changed=false" >> "$GITHUB_OUTPUT"
+  exit 0
 fi
 
 starting_hashes_json="/tmp/starting_hashes.json"
@@ -108,6 +111,48 @@ formatted_impacted_targets="$(IFS=$'\n'; echo "${impacted_targets[*]}")"
 # and grep the file to avoid this.
 echo "$formatted_impacted_targets" | tee /tmp/impacted_targets.txt
 
+if [[ ${#impacted_targets[@]} -gt 0 ]]; then
+  echo "has_affected_targets=true" >> "$GITHUB_OUTPUT"
+else
+  echo "has_affected_targets=false" >> "$GITHUB_OUTPUT"
+fi
+
+# A caller can request the subset of impacted labels that are runnable tests.
+# This keeps `bazel test` from receiving libraries or source files from the
+# general impacted-targets list.
+impacted_test_targets_path="/tmp/impacted_test_targets.txt"
+if [[ -n "${BAZEL_DIFF_TEST_TARGETS_QUERY:-}" ]]; then
+  all_test_targets_path="/tmp/all_test_targets.txt"
+  "$bazel_path" query "$BAZEL_DIFF_TEST_TARGETS_QUERY" --output=label | LC_ALL=C sort > "$all_test_targets_path"
+  LC_ALL=C sort "$impacted_targets_path" | comm -12 - "$all_test_targets_path" > "$impacted_test_targets_path"
+
+  if [[ -s "$impacted_test_targets_path" ]]; then
+    echo "has_affected_test_targets=true" >> "$GITHUB_OUTPUT"
+  else
+    echo "has_affected_test_targets=false" >> "$GITHUB_OUTPUT"
+  fi
+else
+  echo "has_affected_test_targets=false" >> "$GITHUB_OUTPUT"
+fi
+
+# Clippy invocations receive explicit labels through --target_pattern_file, so
+# Bazel's tag filters do not trim their target set. Intersect the Bazel Diff
+# labels with the runner-specific Clippy query before handing them to Clippy.
+impacted_clippy_targets_path="/tmp/impacted_clippy_targets.txt"
+if [[ -n "${BAZEL_DIFF_CLIPPY_TARGETS_QUERY:-}" ]]; then
+  all_clippy_targets_path="/tmp/all_clippy_targets.txt"
+  "$bazel_path" query "$BAZEL_DIFF_CLIPPY_TARGETS_QUERY" --output=label | LC_ALL=C sort > "$all_clippy_targets_path"
+  LC_ALL=C sort "$impacted_targets_path" | comm -12 - "$all_clippy_targets_path" > "$impacted_clippy_targets_path"
+
+  if [[ -s "$impacted_clippy_targets_path" ]]; then
+    echo "has_affected_clippy_targets=true" >> "$GITHUB_OUTPUT"
+  else
+    echo "has_affected_clippy_targets=false" >> "$GITHUB_OUTPUT"
+  fi
+else
+  echo "has_affected_clippy_targets=false" >> "$GITHUB_OUTPUT"
+fi
+
 # Look for the patterns provided as arguments to this script. $formatted_impacted_targets contains
 # a list of all the Bazel targets impacted by the changes between the two branches, so we just
 # check to see if any of the provided patterns appear in the list of targets.
@@ -127,15 +172,20 @@ do
   fi
 done
 
-# Exit code based on whether changes were detected
+# Report whether the caller's target patterns changed. A no-change result is a
+# successful check; only a failure to perform the comparison exits non-zero.
 if [ "$changes_detected" = true ]; then
   if [[ ${#bazel_diff_args[@]} -gt 0 ]]; then
-    "$bazel_path" build --nobuild --build_tests_only "${bazel_diff_args[@]}" "$@"
+    if [[ -n "${BAZEL_DIFF_TEST_TARGETS_QUERY:-}" ]]; then
+      if [[ -s "$impacted_test_targets_path" ]]; then
+        "$bazel_path" build --nobuild --build_tests_only "${bazel_diff_args[@]}" --target_pattern_file="$impacted_test_targets_path"
+      fi
+    else
+      "$bazel_path" build --nobuild --build_tests_only "${bazel_diff_args[@]}" "$@"
+    fi
   fi
-  echo "check_result=0" >> "$GITHUB_OUTPUT"
-  exit 0  # Changes found
+  echo "changed=true" >> "$GITHUB_OUTPUT"
 else
   echo "No changes detected."
-  echo "check_result=2" >> "$GITHUB_OUTPUT"
-  exit 1
+  echo "changed=false" >> "$GITHUB_OUTPUT"
 fi

--- a/ci/check_clippy_config.sh
+++ b/ci/check_clippy_config.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Changes to these files can alter which Clippy checks run without changing an
+# ordinary Bazel target hash, so callers must run their full Clippy slice.
+exec ./ci/files_changed.sh --files \
+  .bazelrc \
+  .clippy.toml \
+  bazel/bitdrift_build_system.bzl \
+  ci/check_bazel.sh \
+  ci/check_clippy_config.sh \
+  ci/files_changed.sh \
+  ci/run_clippy.sh \
+  ci/run_bazel_tests.sh \
+  MODULE.bazel \
+  MODULE.bazel.lock \
+  .github/actions/check-clippy-config/action.yaml \
+  .github/actions/files-changed/action.yaml \
+  .github/actions/run-clippy/action.yaml \
+  .github/actions/run-bazel-tests/action.yaml

--- a/ci/files_changed.sh
+++ b/ci/files_changed.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 # Checks whether the files in provided regex via the command line has changed when comparing the HEAD ref and
-# $GITHUB_BASE_REF, i.e. the target branch (usually main). Returns true if the current branch is main.
+# $GITHUB_BASE_REF, i.e. the target branch (usually main). Writes a `changed`
+# boolean to $GITHUB_OUTPUT; a non-zero exit indicates an actual error.
 #
 # Usage: ./ci/files_changed.sh <regex>
+#        ./ci/files_changed.sh --files <path> [<path> ...]
 
 set -euo pipefail
 
-# Trap to handle unexpected errors and log them
-trap 'echo "An unexpected error occurred during file change check."; echo "check_result=1" >> "$GITHUB_OUTPUT"; exit 1' ERR
+# Trap to handle unexpected errors and log them.
+trap 'echo "An unexpected error occurred during file change check."; exit 1' ERR
 
 # Determine the base ref or fallback to HEAD~1 when running on main
 if [[ -z "${GITHUB_BASE_REF:-}" ]]; then
@@ -20,19 +22,32 @@ fi
 
 if git rev-parse --abbrev-ref HEAD | grep -q ^main$ ; then
   echo "Relevant file changes detected!"
-  echo "check_result=0" >> "$GITHUB_OUTPUT"
+  echo "changed=true" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
 # Run git diff and store output
 diff_output=$(git diff --name-only "$base_ref" || exit 1)  # Ensure git diff failures are caught
 
-# Check for relevant file changes
-if echo "$diff_output" | grep -E "$1" ; then
+# Check for relevant file changes. Exact-file mode prevents callers from
+# maintaining large, escape-heavy regular expressions.
+if [[ "$1" == "--files" ]]; then
+  shift
+  if [[ $# -eq 0 ]]; then
+    echo "--files requires at least one path."
+    exit 2
+  fi
+  change_matches=$(printf '%s\n' "$diff_output" | grep -F -x -f <(printf '%s\n' "$@") || true)
+else
+  change_matches=$(printf '%s\n' "$diff_output" | grep -E "$1" || true)
+fi
+
+if [[ -n "$change_matches" ]]; then
+  echo "$change_matches"
   echo "Relevant file changes detected!"
-  echo "check_result=0" >> "$GITHUB_OUTPUT"
+  echo "changed=true" >> "$GITHUB_OUTPUT"
   exit 0
 else
   echo "No relevant changes found."
-  echo "check_result=2" >> "$GITHUB_OUTPUT"
+  echo "changed=false" >> "$GITHUB_OUTPUT"
 fi

--- a/ci/run_bazel_tests.sh
+++ b/ci/run_bazel_tests.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# These names partition CI work by runner capability. "linux_runner" covers
+# every test that can run on Linux, including Android host tests;
+# "macos_runner" contains the iOS XCTest suite. "all" runs the complete test
+# set in one Bazel invocation on a local macOS machine.
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <all|linux_runner|macos_runner> <full|affected> <affected-targets-path>"
+  exit 2
+fi
+
+slice="$1"
+mode="$2"
+affected_targets_path="$3"
+
+case "$mode" in
+  full|affected)
+    ;;
+  *)
+    echo "Unsupported test mode: $mode"
+    exit 2
+    ;;
+esac
+
+run_bazel_tests() {
+  local use_ios_test_environment="$1"
+  local include_libunwind="$2"
+  local test_tag_filters="$3"
+  local build_tag_filters="$4"
+  shift 4
+
+  local bazel_args=(test --config ci --remote_download_minimal --test_output=errors --test_env=RUST_LOG=debug)
+  if [[ -n "$test_tag_filters" ]]; then
+    bazel_args+=(--test_tag_filters="$test_tag_filters")
+  fi
+  if [[ -n "$build_tag_filters" ]]; then
+    bazel_args+=(--build_tag_filters="$build_tag_filters")
+  fi
+  if [[ "$include_libunwind" == "true" ]]; then
+    bazel_args+=(--config libunwind)
+  fi
+  if [[ "$use_ios_test_environment" == "true" ]]; then
+    bazel_args+=(--test_env=REUSE_GLOBAL_SIMULATOR=1 --test_env=STARTUP_TIMEOUT_SEC=300)
+    env -u ANDROID_NDK_HOME ./bazelw "${bazel_args[@]}" "$@"
+  else
+    ./bazelw "${bazel_args[@]}" "$@"
+  fi
+}
+
+run_linux_runner() {
+  if [[ "$mode" == "full" ]]; then
+    run_bazel_tests false true -macos_only -macos_only //platform/... //test/...
+  elif [[ -s "$affected_targets_path" ]]; then
+    run_bazel_tests false true -macos_only -macos_only --target_pattern_file="$affected_targets_path"
+  else
+    echo "No affected Linux-runner test targets; skipping tests."
+  fi
+}
+
+run_macos_runner() {
+  # Keep the established full XCTest suite even when the Bazel Diff selection
+  # is affected-only. The affected targets still drive the Clippy invocation.
+  echo "Running the full iOS test suite for $mode mode."
+  local ios_test_targets=($(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)'))
+  run_bazel_tests true false macos_only '' "${ios_test_targets[@]}"
+}
+
+case "$slice" in
+  linux_runner)
+    run_linux_runner
+    ;;
+  macos_runner)
+    run_macos_runner
+    ;;
+  all)
+    if [[ "$mode" != "full" ]]; then
+      echo "The all slice only supports full mode."
+      exit 2
+    fi
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+      echo "The all slice is only supported on macOS."
+      exit 2
+    fi
+    run_bazel_tests true false '' '' //platform/... //test/...
+    ;;
+  *)
+    echo "Unsupported test slice: $slice"
+    exit 2
+    ;;
+esac

--- a/ci/run_clippy.sh
+++ b/ci/run_clippy.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# These names partition CI work by runner capability. "linux_runner" covers
+# every lint target that can run on Linux, including Android host targets;
+# "macos_runner" covers the macOS/iOS-only targets. "all" runs both slices on
+# a local macOS machine in one Bazel invocation.
+if [[ $# -ne 3 ]]; then
+  echo "Usage: $0 <all|linux_runner|macos_runner> <affected|full> <affected-targets-path>"
+  exit 2
+fi
+
+slice="$1"
+mode="$2"
+affected_targets_path="$3"
+
+case "$mode" in
+  full|affected)
+    ;;
+  *)
+    echo "Unsupported Clippy mode: $mode"
+    exit 2
+    ;;
+esac
+
+run_clippy() {
+  local build_tag_filters="$1"
+  shift
+  ./bazelw build --config ci --config clippy --build_tag_filters="$build_tag_filters" "$@"
+}
+
+run_linux_runner() {
+  local targets=()
+  if [[ "$mode" == "full" ]]; then
+    targets=(//... //platform/shared:build_script_)
+  elif [[ -s "$affected_targets_path" ]]; then
+    targets=(--target_pattern_file="$affected_targets_path")
+  else
+    echo "No affected Linux-runner Clippy targets; skipping."
+    return 0
+  fi
+
+  run_clippy clippy,-macos_only "${targets[@]}"
+}
+
+run_macos_runner() {
+  local targets=()
+  if [[ "$mode" == "full" ]]; then
+    targets=(//...)
+  elif [[ -s "$affected_targets_path" ]]; then
+    targets=(--target_pattern_file="$affected_targets_path")
+  else
+    echo "No affected macOS-runner Clippy targets; skipping."
+    return 0
+  fi
+
+  run_clippy clippy_macos "${targets[@]}"
+}
+
+case "$slice" in
+  linux_runner)
+    run_linux_runner
+    ;;
+  macos_runner)
+    run_macos_runner
+    ;;
+  all)
+    if [[ "$mode" != "full" ]]; then
+      echo "The all slice only supports full mode."
+      exit 2
+    fi
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+      echo "The all slice is only supported on macOS."
+      exit 2
+    fi
+    run_clippy clippy //... //platform/shared:build_script_
+    ;;
+  *)
+    echo "Unsupported Clippy slice: $slice"
+    exit 2
+    ;;
+esac

--- a/platform/shared/BUILD
+++ b/platform/shared/BUILD
@@ -19,6 +19,7 @@ cargo_build_script(
     srcs = ["build.rs"],
     data = [":sdk_version"],
     edition = "2024",
+    tags = ["clippy"],
 )
 
 filegroup(

--- a/platform/shared/version_codegen/main.rs
+++ b/platform/shared/version_codegen/main.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 pub fn main() {
   let version_path = args().nth_back(0).unwrap();
-  eprintln!("version_path: {}", &version_path);
+  eprintln!("version_path: {version_path}");
   let version = read_to_string(Path::new(&version_path)).unwrap();
 
   println!(

--- a/platform/swift/source/src/bridge_tests.rs
+++ b/platform/swift/source/src/bridge_tests.rs
@@ -5,6 +5,8 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+#![allow(clippy::unwrap_used)]
+
 use crate::bridge::{State, StreamWriter, SwiftNetworkStream};
 use bd_api::PlatformNetworkStream;
 use bd_runtime::runtime::FeatureFlag;

--- a/platform/swift/source/src/crash_report.rs
+++ b/platform/swift/source/src/crash_report.rs
@@ -1002,6 +1002,7 @@ fn write_summary_bridge_out(summary_out: *mut *const Object, summary: Enrichment
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
   use super::*;
   use std::io::Write;


### PR DESCRIPTION
Runs Clippy as a sequential step in the existing Linux and iOS Bazel test jobs.

On pull requests, the iOS pre-check passes its affected Bazel target file to the macOS test job, while Linux derives its affected test subset locally. Both jobs lint only the affected Clippy targets; configuration and wiring changes conservatively run the full platform slice. Pushes to main run the full Linux and macOS suites.

This preserves platform-specific coverage without a dedicated workflow or extra runners. It also fixes the newly exposed lint issue in version_codegen and scopes existing test-only unwrap/expect allowances to their test modules.

This additionally configures PRs to run only tests affected by the build instead of a wider //...-style target: this reduces the amount of Bazel targets that need configuring, which should help speed up PR builds. On PR pushes (e.g. to main) we run the whole suite. 

---

- [ ] CHANGELOG.md Unreleased section has been updated, if applicable.