### PR TITLE
ci: run bazel-diff from native release binary

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -30,26 +30,6 @@ jobs:
         uses: ./.github/actions/android-setup
         with:
           buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
-      - name: Attempt to free up runner disk space
-        run: |
-          echo "Disk space BEFORE cleanup:"
-          echo "================================"
-          df -h /
-          echo "Cleaning up disk space:"
-          
-          # Remove large pre-installed packages we don't need
-          sudo rm -rf /usr/share/dotnet           # .NET runtime (~4GB)
-          sudo rm -rf /usr/local/lib/android      # Android SDK (~12GB)
-          sudo rm -rf /usr/share/swift            # Swift toolchain (~3GB)
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"     # GitHub Actions tool cache (~6GB)
-          
-          # Clean up apt packages
-          sudo apt-get autoremove -y
-          
-          echo "Disk space clean-up done."
-          echo "================================"
-          echo "Disk space AFTER cleanup:"
-          df -h /
       - name: Check for Bazel build file changes
         id: bazel_check
         run: ./ci/check_bazel.sh //platform/... //test/...
@@ -61,6 +41,28 @@ jobs:
         id: workflow_check
         run: ./ci/files_changed.sh .github/workflows/linux_tests.yaml
         continue-on-error: true
+
+      - name: Attempt to free up runner disk space
+        if: ${{ steps.bazel_check.outputs.check_result != '2' || steps.workflow_check.outputs.check_result != '2' }}
+        run: |
+          echo "Disk space BEFORE cleanup:"
+          echo "================================"
+          df -h /
+          echo "Cleaning up disk space:"
+
+          # Remove large pre-installed packages we don't need
+          sudo rm -rf /usr/share/dotnet           # .NET runtime (~4GB)
+          sudo rm -rf /usr/local/lib/android      # Android SDK (~12GB)
+          sudo rm -rf /usr/share/swift            # Swift toolchain (~3GB)
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"     # GitHub Actions tool cache (~6GB)
+
+          # Clean up apt packages
+          sudo apt-get autoremove -y
+
+          echo "Disk space clean-up done."
+          echo "================================"
+          echo "Disk space AFTER cleanup:"
+          df -h /
 
       - name: test
         run: |

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,4 @@
 load("@rules_apple//apple:apple.bzl", "apple_static_framework_import")
-load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_compiler_plugin", "kt_kotlinc_options")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_javac_options")
 load("@rules_multirun//:defs.bzl", "multirun")
@@ -312,10 +311,4 @@ xcodeproj(
             ),
         ),
     ],
-)
-
-java_binary(
-    name = "bazel-diff",
-    main_class = "com.bazel_diff.Main",
-    runtime_deps = ["@bazel_diff//jar"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,8 +53,6 @@ SDK_BUILD_TOOLS_VERSION = "36.1.0"
 # Bazel dependencies
 ####################
 
-http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
-
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
@@ -108,12 +106,6 @@ use_repo(
     "llvm-toolchain-minimal-22.1.7-linux-arm64",
     "llvm-toolchain-minimal-22.1.7-windows-amd64",
     "llvm-toolchain-minimal-22.1.7-windows-arm64",
-)
-
-http_jar(
-    name = "bazel_diff",
-    integrity = "sha256-Sn3WTHsfsSGbglE4xiwgbSrOdHCqXToHpVRTLnQEiJM=",
-    url = "https://github.com/Tinder/bazel-diff/releases/download/9.0.3/bazel-diff_deploy.jar",
 )
 
 new_git_repository(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -29,8 +29,6 @@ alias(
 
 exports_files([
     "pom_template.xml",
-    "run_fuzzer.sh",
-    "test_fuzzer.sh",
 ])
 
 config_setting(

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -130,7 +130,7 @@ done
 # Exit code based on whether changes were detected
 if [ "$changes_detected" = true ]; then
   if [[ ${#bazel_diff_args[@]} -gt 0 ]]; then
-    "$bazel_path" test --nobuild "${bazel_diff_args[@]}" "$@"
+    "$bazel_path" build --nobuild --build_tests_only "${bazel_diff_args[@]}" "$@"
   fi
   echo "check_result=0" >> "$GITHUB_OUTPUT"
   exit 0  # Changes found

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -31,9 +31,8 @@ workspace_path=$(pwd)
 # Path to your Bazel executable
 bazel_path=$(pwd)/bazelw
 
-# Optional Bazel command options for building bazel-diff. Linux CI uses this
-# to leave Bazel's server configured identically to the test command that
-# follows.
+# Linux CI uses these options to warm the exact Bazel test configuration that
+# follows a positive affected-targets result.
 bazel_diff_args=()
 if [[ -n "${BAZEL_DIFF_ARGS:-}" ]]; then
   read -r -a bazel_diff_args <<< "$BAZEL_DIFF_ARGS"
@@ -49,19 +48,55 @@ fi
 starting_hashes_json="/tmp/starting_hashes.json"
 final_hashes_json="/tmp/final_hashes.json"
 impacted_targets_path="/tmp/impacted_targets.txt"
-bazel_diff="/tmp/bazel_diff"
 
-"$bazel_path" run "${bazel_diff_args[@]}" :bazel-diff --script_path="$bazel_diff"
+# Keep Bazel out of the launcher path: `generate-hashes` still invokes Bazel for
+# each revision, but downloading the native CLI avoids a third Bazel analysis
+# just to materialize a bazel-diff wrapper.
+bazel_diff_version="v42.0.0"
+bazel_diff_dir="${RUNNER_TEMP:-/tmp}/bazel-diff-$bazel_diff_version"
+mkdir -p "$bazel_diff_dir"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    bazel_diff_asset="bazel-diff-rust-linux-amd64"
+    bazel_diff_sha256="d7bf5c6f74b582fa54b6a6da5b23f7d0e816a4c71af984645ec2d71aa8c37631"
+    bazel_diff_command=("$bazel_diff_dir/$bazel_diff_asset")
+    ;;
+  Darwin-arm64)
+    bazel_diff_asset="bazel-diff-rust-macos-arm64"
+    bazel_diff_sha256="f32b8db587cd42eae59da2bb3055bfead9b650cfc0b4565677db10a7770b19c1"
+    bazel_diff_command=("$bazel_diff_dir/$bazel_diff_asset")
+    ;;
+  *)
+    # The deploy JAR keeps local use working on hosts without a published
+    # native binary, such as Intel macOS.
+    bazel_diff_asset="bazel-diff_deploy.jar"
+    bazel_diff_sha256="0170b70fe2f24477ab056c11f5c3240d8b45a1dca5ab73ad252c096679c5500c"
+    bazel_diff_command=(java -jar "$bazel_diff_dir/$bazel_diff_asset")
+    ;;
+esac
+
+bazel_diff_path="$bazel_diff_dir/$bazel_diff_asset"
+if [[ ! -f "$bazel_diff_path" ]] || [[ "$(shasum -a 256 "$bazel_diff_path" | awk '{print $1}')" != "$bazel_diff_sha256" ]]; then
+  curl --fail --location --retry 3 --retry-all-errors --output "$bazel_diff_path" \
+    "https://github.com/Tinder/bazel-diff/releases/download/$bazel_diff_version/$bazel_diff_asset"
+fi
+
+if [[ "$(shasum -a 256 "$bazel_diff_path" | awk '{print $1}')" != "$bazel_diff_sha256" ]]; then
+  echo "bazel-diff checksum verification failed."
+  exit 1
+fi
+chmod +x "$bazel_diff_path"
 
 git -C "$workspace_path" checkout "$previous_revision" --quiet
 
-$bazel_diff generate-hashes -w "$workspace_path" -b "$bazel_path" $starting_hashes_json --excludeExternalTargets
+"${bazel_diff_command[@]}" generate-hashes -w "$workspace_path" -b "$bazel_path" $starting_hashes_json --excludeExternalTargets
 
 git -C "$workspace_path" checkout "$final_revision" --quiet
 
-$bazel_diff generate-hashes -w "$workspace_path" -b "$bazel_path" $final_hashes_json --excludeExternalTargets
+"${bazel_diff_command[@]}" generate-hashes -w "$workspace_path" -b "$bazel_path" $final_hashes_json --excludeExternalTargets
 
-$bazel_diff get-impacted-targets -sh $starting_hashes_json -fh $final_hashes_json -o $impacted_targets_path
+"${bazel_diff_command[@]}" get-impacted-targets -w "$workspace_path" -sh $starting_hashes_json -fh $final_hashes_json -o $impacted_targets_path
 
 # First pretty print the targets for debugging
 
@@ -94,6 +129,9 @@ done
 
 # Exit code based on whether changes were detected
 if [ "$changes_detected" = true ]; then
+  if [[ ${#bazel_diff_args[@]} -gt 0 ]]; then
+    "$bazel_path" test --nobuild "${bazel_diff_args[@]}" "$@"
+  fi
   echo "check_result=0" >> "$GITHUB_OUTPUT"
   exit 0  # Changes found
 else


### PR DESCRIPTION
Replaces the Bazel-built `bazel-diff` launcher with the pinned v42 native release binary. This removes a full Bazel analysis from each `ci/check_bazel.sh` invocation while preserving the required `generate-hashes` Bazel calls.

Linux x86_64 and macOS arm64 use platform-native assets with SHA-256 verification; unsupported developer hosts fall back to the verified deploy JAR. The obsolete `http_jar` and `java_binary` launcher are removed.

When Linux CI detects relevant Bazel changes, `BAZEL_DIFF_ARGS` now warms the same tests-only target graph using a no-build Bazel invocation. Disk reclamation runs only after the Bazel and workflow checks show that work is needed.

Removes stale exports for the absent `run_fuzzer.sh` and `test_fuzzer.sh` scripts, eliminating their Bazel warnings.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.