### PR TITLE
use hermetic android toolchain via bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,8 @@
 common --enable_bzlmod
 common --incompatible_disable_native_android_rules
+# Accepted licenses for the pinned hermetic Android SDK and NDK in MODULE.bazel.
+common --repo_env=ACCEPTED_ANDROID_SDK_LICENSE_VERSION=36
+common --repo_env=ACCEPTED_ANDROID_NDK_LICENSE_VERSION=r27c
 
 mobile-install --config=android
 

--- a/.github/actions/android-setup/action.yaml
+++ b/.github/actions/android-setup/action.yaml
@@ -5,6 +5,10 @@ inputs:
   buildbuddy-api-key:
     description: BuildBuddy API key.
     required: false
+  setup-local-android-sdk:
+    description: Whether to set up the local Android SDK cache needed by Gradle
+    required: false
+    default: "false"
   java-version:
     description: JDK version to install
     required: false
@@ -29,10 +33,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Bazel and Android SDK
+    - name: Set up Bazel and optional local Android SDK
       uses: ./.github/actions/setup
       with:
         buildbuddy-api-key: ${{ inputs.buildbuddy-api-key }}
+        setup-local-android-sdk: ${{ inputs.setup-local-android-sdk == 'true' || inputs.setup-emulator == 'true' || inputs.emulator-api-level != '' }}
 
     - name: Enable KVM group perms
       if: inputs.setup-emulator == 'true'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,10 +1,14 @@
 name: Setup
-description: Restores the Bazelisk launcher and Android SDK used by bazelw
+description: Restores the Bazelisk launcher and verifies Android toolchain configuration
 
 inputs:
   buildbuddy-api-key:
     description: BuildBuddy API key.
     required: false
+  setup-local-android-sdk:
+    description: Whether to restore the local Android SDK cache used by Gradle and emulator jobs
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -32,25 +36,32 @@ runs:
         path: ${{ github.workspace }}/tmp/bazel
         key: ${{ runner.os }}-${{ runner.arch }}-bazelisk-${{ hashFiles('bazelw') }}
 
-    - name: Restore Android SDK cache
+    - name: Check Android Bazel and Gradle toolchain versions
+      shell: bash
+      run: ./tools/check_android_toolchain_versions.sh
+
+    - name: Restore local Android SDK cache for Gradle
+      if: inputs.setup-local-android-sdk == 'true'
       id: android-sdk-cache
       uses: actions/cache/restore@v4
       with:
         path: ~/.androidbin/bitdrift-android-sdk/android-sdk-4333796-unarchived
         key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('tools/setup_android_sdk.sh') }}
 
-    - name: Set up Android SDK
+    - name: Set up local Android SDK for Gradle
+      if: inputs.setup-local-android-sdk == 'true'
       shell: bash
       run: ./tools/setup_android_sdk.sh
 
-    - name: Save Android SDK cache
-      if: github.ref == 'refs/heads/main' && steps.android-sdk-cache.outputs.cache-hit != 'true'
+    - name: Save local Android SDK cache for Gradle
+      if: github.ref == 'refs/heads/main' && inputs.setup-local-android-sdk == 'true' && steps.android-sdk-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ~/.androidbin/bitdrift-android-sdk/android-sdk-4333796-unarchived
         key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('tools/setup_android_sdk.sh') }}
 
-    - name: Add Android SDK tools to PATH
+    - name: Add local Android SDK tools to PATH
+      if: inputs.setup-local-android-sdk == 'true'
       shell: bash
       run: |
         echo "$ANDROID_HOME/cmdline-tools/6.0/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -46,7 +46,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.androidbin/bitdrift-android-sdk/android-sdk-4333796-unarchived
-        key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('tools/setup_android_sdk.sh') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('tools/setup_android_sdk.sh', 'tools/android_toolchain_versions.sh') }}
 
     - name: Set up local Android SDK for Gradle
       if: inputs.setup-local-android-sdk == 'true'
@@ -58,7 +58,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ~/.androidbin/bitdrift-android-sdk/android-sdk-4333796-unarchived
-        key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('tools/setup_android_sdk.sh') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-android-sdk-${{ hashFiles('tools/setup_android_sdk.sh', 'tools/android_toolchain_versions.sh') }}
 
     - name: Add local Android SDK tools to PATH
       if: inputs.setup-local-android-sdk == 'true'

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -42,7 +42,7 @@ jobs:
         id: workflow_check
         uses: ./.github/actions/files-changed
         with:
-          regex: '^(\.github/workflows/android\.yaml|MODULE\.bazel|MODULE\.bazel\.lock)$'
+          regex: '^(\.bazelrc|MODULE\.bazel(\.lock)?|\.github/(workflows/android\.yaml|actions/(setup|android-setup)/.*)|tools/(android_sdk_wrapper|setup_android_sdk|android_toolchain_versions|check_android_toolchain_versions)\.sh)$'
 
       - name: Check for relevant Gradle changes
         id: gradle_check

--- a/.github/workflows/example_apps_android.yaml
+++ b/.github/workflows/example_apps_android.yaml
@@ -45,6 +45,7 @@ jobs:
       uses: ./.github/actions/android-setup
       with:
         buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        setup-local-android-sdk: "true"
     - name: Accept Android SDK licenses
       run: yes | $ANDROID_HOME/cmdline-tools/6.0/bin/sdkmanager --licenses
     - name: Install Rust target

--- a/.github/workflows/integrations_android.yaml
+++ b/.github/workflows/integrations_android.yaml
@@ -53,6 +53,8 @@ jobs:
         cache: gradle
     - name: Setup Android cmd line tools + NDK
       uses: ./.github/actions/android-setup
+      with:
+        setup-local-android-sdk: "true"
     - name: Accept Android SDK licenses
       run: yes | $ANDROID_HOME/cmdline-tools/6.0/bin/sdkmanager --licenses
     - name: Install Rust target

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,6 +69,9 @@ bazel_dep(name = "rules_cc", version = "0.2.22")
 bazel_dep(name = "rules_java", version = "9.7.1")
 bazel_dep(name = "rules_android", version = "0.7.3")
 bazel_dep(name = "rules_android_ndk", version = "0.1.5")
+
+bazel_dep(name = "hermetic_android_toolchains", version = "0.0.0", dev_dependency = True)
+
 bazel_dep(name = "rules_jvm_external", version = "7.1")
 bazel_dep(name = "rules_detekt", version = "0.8.1.13")
 bazel_dep(name = "flatbuffers", version = "25.9.23")
@@ -184,17 +187,39 @@ native_binary(
 # Android extensions
 ####################
 
-android_sdk_repository_extension = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
-android_sdk_repository_extension.configure(
-    api_level = SDK_API_LEVEL,
+# Android SDK/NDK inputs are hermetic for Bazel. Gradle deliberately continues to use the
+# cached local SDK installed by tools/setup_android_sdk.sh.
+android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
+android.sdk(
     build_tools_version = SDK_BUILD_TOOLS_VERSION,
+    version = str(SDK_API_LEVEL),
 )
+android.ndk(
+    api_level = NDK_API_LEVEL,
+    version = "r27c",
+)
+use_repo(android, "androidndk", "androidsdk")
 
-android_ndk_repository_extension = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_repository_extension")
-android_ndk_repository_extension.configure(api_level = NDK_API_LEVEL)
-use_repo(android_ndk_repository_extension, "androidndk")
+# Redirect the repositories normally created by rules_android and rules_android_ndk to
+# the hermetic repositories above.
+rules_android_sdk = use_extension("@rules_android//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
 
-register_toolchains("@androidndk//:all")
+override_repo(rules_android_sdk, "androidsdk")
+
+rules_android_ndk = use_extension("@rules_android_ndk//:extension.bzl", "android_ndk_repository_extension")
+
+override_repo(rules_android_ndk, "androidndk")
+
+register_toolchains("@androidndk//:all", "@androidsdk//:all")
+
+# The upstream module publishes as 0.0.0. Pin its source archive so toolchain metadata
+# changes only when this override is intentionally updated.
+archive_override(
+    module_name = "hermetic_android_toolchains",
+    integrity = "sha256-9/R5xpQHfZoXUG/JdNnZHg80qaObDYTH49DlunSkAww=",
+    strip_prefix = "hermetic_android_toolchains-9ac990099a55fa9045605666a42d42426da3f099",
+    urls = ["https://github.com/keith/hermetic_android_toolchains/archive/9ac990099a55fa9045605666a42d42426da3f099.tar.gz"],
+)
 
 register_toolchains("//:kotlin_toolchain")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1138,16 +1138,12 @@
     "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "qHbR00gVzVzkxX+PRtv4UGcUFMtBz7TK9CNYUWH8nIE=",
-        "usagesDigest": "jeJzq9685LSfO0zzSX6WTzoyQQlewzAxPwtBY3ZNGHk=",
+        "usagesDigest": "41RGyCJ0zUZD5UkH51J/8z6riXa19M5AqghQOa1vBG4=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "androidsdk": {
             "repoRuleId": "@@rules_android+//rules/android_sdk_repository:rule.bzl%_android_sdk_repository",
-            "attributes": {
-              "api_level": 36,
-              "build_tools_version": "36.1.0",
-              "path": ""
-            }
+            "attributes": {}
           }
         }
       }
@@ -1155,15 +1151,12 @@
     "@@rules_android_ndk+//:extension.bzl%android_ndk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "j+NMXk5/a1vnDypModKL+ToEo/4o7DJeXSFhTfbJ7rI=",
-        "usagesDigest": "tXdb/y2hCK73f5fVH7UOcgb8cfmb/BAIT98U7wb39Ak=",
+        "usagesDigest": "vKYK9OxiQRvmSeKRcy5Qj4oO+xcgUJlW0CtmEajKweU=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "androidndk": {
             "repoRuleId": "@@rules_android_ndk+//:rules.bzl%android_ndk_repository",
-            "attributes": {
-              "api_level": 21,
-              "path": ""
-            }
+            "attributes": {}
           }
         }
       }

--- a/bazelw
+++ b/bazelw
@@ -61,4 +61,4 @@ if [[ ! -x "$bazelisk" ]]; then
   fi
 fi
 
-exec ./tools/android_sdk_wrapper.sh "$bazelisk" "$@"
+exec "$bazelisk" "$@"

--- a/ci/check_bazel.sh
+++ b/ci/check_bazel.sh
@@ -41,10 +41,12 @@ fi
 # If the only file that changed was .sdk_version, we don't need to run bazel-diff and just mark it as no changes detected.
 if ./ci/version_only_change.sh; then
   echo "Only change was platform/shared/.sdk-version, no Bazel changes detected."
-  echo "has_affected_targets=false" >> "$GITHUB_OUTPUT"
-  echo "has_affected_test_targets=false" >> "$GITHUB_OUTPUT"
-  echo "has_affected_clippy_targets=false" >> "$GITHUB_OUTPUT"
-  echo "changed=false" >> "$GITHUB_OUTPUT"
+  {
+    echo "has_affected_targets=false"
+    echo "has_affected_test_targets=false"
+    echo "has_affected_clippy_targets=false"
+    echo "changed=false"
+  } >> "$GITHUB_OUTPUT"
   exit 0
 fi
 

--- a/ci/run_bazel_tests.sh
+++ b/ci/run_bazel_tests.sh
@@ -63,7 +63,10 @@ run_macos_runner() {
   # Keep the established full XCTest suite even when the Bazel Diff selection
   # is affected-only. The affected targets still drive the Clippy invocation.
   echo "Running the full iOS test suite for $mode mode."
-  local ios_test_targets=($(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)'))
+  local ios_test_targets=()
+  while IFS= read -r target; do
+    ios_test_targets+=("$target")
+  done < <(./bazelw query 'kind(ios_unit_test, //test/platform/swift/unit_integration/...)')
   run_bazel_tests true false macos_only '' "${ios_test_targets[@]}"
 }
 

--- a/ci/setup_linux_format.sh
+++ b/ci/setup_linux_format.sh
@@ -7,7 +7,7 @@ formatter_dir="$(pwd)/formatters"
 readonly formatter_dir
 
 # buildifier is used for format .bzl / BUILD / WORKSPACE files.
-curl -LSs https://github.com/bazelbuild/buildtools/releases/download/6.0.1/buildifier-linux-amd64 --output "$formatter_dir/buildifier"
+curl -LSs https://github.com/bazelbuild/buildtools/releases/download/v8.5.1/buildifier-linux-amd64 --output "$formatter_dir/buildifier"
 chmod +x "$formatter_dir/buildifier"
 
 # The binaries above dynamically link a library provided by Swift, so download Swift + update the

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 
     defaultConfig {
         minSdk = 23
-        ndkVersion = "27"
+        ndkVersion = "27.2.12479018"
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/tools/android_sdk_wrapper.sh
+++ b/tools/android_sdk_wrapper.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly script_root
 readonly android_sdk_version="4333796"
-readonly ndk_version="27.2.12479018"
+# shellcheck source=tools/android_toolchain_versions.sh
+source "$script_root/android_toolchain_versions.sh"
+readonly ndk_version="$android_ndk_version"
 readonly softlink_root_dir="/tmp/bitdrift-android-sdk"
 readonly custom_android_home="$softlink_root_dir/android-sdk-$android_sdk_version-unarchived"
 readonly custom_android_ndk_home="$custom_android_home/ndk/$ndk_version/"

--- a/tools/android_toolchain_versions.sh
+++ b/tools/android_toolchain_versions.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# shellcheck disable=SC2034
+
+# Versions used by the local Android SDK cache for Gradle and emulator workflows.
+# MODULE.bazel carries the corresponding Bazel configuration; keep the two in sync with
+# tools/check_android_toolchain_versions.sh.
+
+readonly android_sdk_api_level="36"
+readonly android_build_tools_version="36.1.0"
+readonly android_ndk_version="27.2.12479018"
+readonly android_ndk_alias="r27c"
+readonly android_ndk_api_level="21"

--- a/tools/check_android_toolchain_versions.sh
+++ b/tools/check_android_toolchain_versions.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_root
+repo_root="$(cd "$script_root/.." && pwd)"
+readonly repo_root
+
+# shellcheck source=tools/android_toolchain_versions.sh
+source "$script_root/android_toolchain_versions.sh"
+
+fail() {
+  echo "Android toolchain version drift: $1" >&2
+  exit 1
+}
+
+module_sdk_api="$(sed -nE 's/^SDK_API_LEVEL = ([0-9]+)$/\1/p' "$repo_root/MODULE.bazel")"
+module_build_tools="$(sed -nE 's/^SDK_BUILD_TOOLS_VERSION = "([^"]+)"$/\1/p' "$repo_root/MODULE.bazel")"
+module_ndk_api="$(sed -nE 's/^NDK_API_LEVEL = ([0-9]+)$/\1/p' "$repo_root/MODULE.bazel")"
+module_ndk_alias="$(sed -nE '/^android\.ndk\(/,/^\)/ s/^    version = "([^"]+)",$/\1/p' "$repo_root/MODULE.bazel")"
+
+[[ "$module_sdk_api" == "$android_sdk_api_level" ]] || fail "MODULE.bazel SDK API is $module_sdk_api, expected $android_sdk_api_level"
+[[ "$module_build_tools" == "$android_build_tools_version" ]] || fail "MODULE.bazel build-tools is $module_build_tools, expected $android_build_tools_version"
+[[ "$module_ndk_api" == "$android_ndk_api_level" ]] || fail "MODULE.bazel NDK API is $module_ndk_api, expected $android_ndk_api_level"
+[[ "$module_ndk_alias" == "$android_ndk_alias" ]] || fail "MODULE.bazel NDK is $module_ndk_alias, expected $android_ndk_alias"
+
+if ! rg -Fq 'platforms;android-$android_sdk_api_level' "$script_root/setup_android_sdk.sh"; then
+  fail "the Gradle SDK setup does not install the configured platform API"
+fi
+if ! rg -Fq 'build-tools;$android_build_tools_version' "$script_root/setup_android_sdk.sh"; then
+  fail "the Gradle SDK setup does not install the configured build-tools"
+fi
+if ! rg -Fq 'ndk;$ndk_version' "$script_root/setup_android_sdk.sh"; then
+  fail "the Gradle SDK setup does not install the configured NDK"
+fi
+
+while IFS= read -r gradle_sdk_api; do
+  [[ "$gradle_sdk_api" == "$android_sdk_api_level" ]] || fail "a Gradle project compiles against API $gradle_sdk_api, expected $android_sdk_api_level"
+done < <(rg --no-filename -o --replace '$1' 'compileSdk\s*(?:=)?\s*([0-9]+)' "$repo_root/platform/jvm" "$repo_root/gradle" -g '*.gradle' -g '*.gradle.kts' | sort -u)
+
+while IFS= read -r gradle_ndk_version; do
+  [[ "$gradle_ndk_version" == "$android_ndk_version" ]] || fail "a Gradle project uses NDK $gradle_ndk_version, expected $android_ndk_version"
+done < <(rg --no-filename -o --replace '$1' 'ndkVersion\s*=\s*"([0-9.]+)"' "$repo_root/platform/jvm" "$repo_root/gradle" -g '*.gradle' -g '*.gradle.kts' | sort -u)
+
+echo "Android Bazel and Gradle toolchain versions are aligned."

--- a/tools/check_android_toolchain_versions.sh
+++ b/tools/check_android_toolchain_versions.sh
@@ -25,22 +25,22 @@ module_ndk_alias="$(sed -nE '/^android\.ndk\(/,/^\)/ s/^    version = "([^"]+)",
 [[ "$module_ndk_api" == "$android_ndk_api_level" ]] || fail "MODULE.bazel NDK API is $module_ndk_api, expected $android_ndk_api_level"
 [[ "$module_ndk_alias" == "$android_ndk_alias" ]] || fail "MODULE.bazel NDK is $module_ndk_alias, expected $android_ndk_alias"
 
-if ! rg -Fq 'platforms;android-$android_sdk_api_level' "$script_root/setup_android_sdk.sh"; then
+if ! grep -Fq "platforms;android-\$android_sdk_api_level" "$script_root/setup_android_sdk.sh"; then
   fail "the Gradle SDK setup does not install the configured platform API"
 fi
-if ! rg -Fq 'build-tools;$android_build_tools_version' "$script_root/setup_android_sdk.sh"; then
+if ! grep -Fq "build-tools;\$android_build_tools_version" "$script_root/setup_android_sdk.sh"; then
   fail "the Gradle SDK setup does not install the configured build-tools"
 fi
-if ! rg -Fq 'ndk;$ndk_version' "$script_root/setup_android_sdk.sh"; then
+if ! grep -Fq "ndk;\$ndk_version" "$script_root/setup_android_sdk.sh"; then
   fail "the Gradle SDK setup does not install the configured NDK"
 fi
 
 while IFS= read -r gradle_sdk_api; do
   [[ "$gradle_sdk_api" == "$android_sdk_api_level" ]] || fail "a Gradle project compiles against API $gradle_sdk_api, expected $android_sdk_api_level"
-done < <(rg --no-filename -o --replace '$1' 'compileSdk\s*(?:=)?\s*([0-9]+)' "$repo_root/platform/jvm" "$repo_root/gradle" -g '*.gradle' -g '*.gradle.kts' | sort -u)
+done < <(find "$repo_root/platform/jvm" "$repo_root/gradle" -type f \( -name '*.gradle' -o -name '*.gradle.kts' \) -exec grep -hE 'compileSdk[[:space:]]*(=[[:space:]]*)?[0-9]+' {} + | sed -nE 's/.*compileSdk[[:space:]]*(=[[:space:]]*)?([0-9]+).*/\2/p' | sort -u)
 
 while IFS= read -r gradle_ndk_version; do
   [[ "$gradle_ndk_version" == "$android_ndk_version" ]] || fail "a Gradle project uses NDK $gradle_ndk_version, expected $android_ndk_version"
-done < <(rg --no-filename -o --replace '$1' 'ndkVersion\s*=\s*"([0-9.]+)"' "$repo_root/platform/jvm" "$repo_root/gradle" -g '*.gradle' -g '*.gradle.kts' | sort -u)
+done < <(find "$repo_root/platform/jvm" "$repo_root/gradle" -type f \( -name '*.gradle' -o -name '*.gradle.kts' \) -exec grep -hE 'ndkVersion[[:space:]]*=[[:space:]]*"[0-9.]+"' {} + | sed -nE 's/.*ndkVersion[[:space:]]*=[[:space:]]*"([0-9.]+)".*/\1/p' | sort -u)
 
 echo "Android Bazel and Gradle toolchain versions are aligned."

--- a/tools/setup_android_sdk.sh
+++ b/tools/setup_android_sdk.sh
@@ -5,9 +5,11 @@ set -euo pipefail
 readonly android_sdk_version="4333796"
 readonly android_sdk_license_hash="24333f8a63b6825ea9c5514f83c2829b004d1fee"
 readonly cmdline_tools_version="6.0"
-readonly ndk_version="27.2.12479018"
 script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly script_root
+# shellcheck source=tools/android_toolchain_versions.sh
+source "$script_root/android_toolchain_versions.sh"
+readonly ndk_version="$android_ndk_version"
 repo_root="$(cd "$script_root/.." && pwd)"
 readonly repo_root
 readonly android_sdk_root_dir="$HOME/.androidbin/bitdrift-android-sdk"
@@ -36,8 +38,8 @@ readonly install_android_sdk_packages_command=(
   "--install"
   "platform-tools"
   "ndk;$ndk_version"
-  "platforms;android-36"
-  "build-tools;36.1.0"
+  "platforms;android-$android_sdk_api_level"
+  "build-tools;$android_build_tools_version"
 )
 
 function download_android_sdk() {
@@ -66,8 +68,8 @@ function provision_android_sdk_packages() {
   local -r packages_installed=(
     "$android_sdk_unarchived_dir/platform-tools"
     "$android_sdk_unarchived_dir/ndk/$ndk_version"
-    "$android_sdk_unarchived_dir/platforms/android-36"
-    "$android_sdk_unarchived_dir/build-tools/36.1.0"
+    "$android_sdk_unarchived_dir/platforms/android-$android_sdk_api_level"
+    "$android_sdk_unarchived_dir/build-tools/$android_build_tools_version"
   )
   local package_path
 
@@ -82,7 +84,7 @@ function provision_android_sdk_packages() {
 
     if [[ -x "$cached_sdkmanager" ]]; then
       ANDROID_HOME="$android_sdk_unarchived_dir" "$repo_root/ci/jdk_wrapper.sh" "$cached_sdkmanager" "--install" \
-        "platform-tools" "ndk;$ndk_version" "platforms;android-36" "build-tools;36.1.0" | (grep -v = || true)
+        "platform-tools" "ndk;$ndk_version" "platforms;android-$android_sdk_api_level" "build-tools;$android_build_tools_version" | (grep -v = || true)
     else
       ANDROID_HOME="$android_sdk_unarchived_dir" "$repo_root/ci/jdk_wrapper.sh" "${install_android_cmd_line_tools[@]}" | (grep -v = || true)
       ANDROID_HOME="$android_sdk_unarchived_dir" "$repo_root/ci/jdk_wrapper.sh" "${install_android_sdk_packages_command[@]}" | (grep -v = || true)


### PR DESCRIPTION
Uses the new https://github.com/keith/hermetic_android_toolchains to use a hermetic android toolchain instead of relying on configuring ANDROID_HOME outside of the bazel build.

This avoids having to restore the 1GB android home before doing any bazel task, which should speed up all non-gradle tasks including the pre_check.

This will also allow us to remove the NDK dep from the gradle cache which will decrease the size of the android home that needs to be restored for gradle. This is left for a followup.

## Toolchain version validation

tools/check_android_toolchain_versions.sh runs on every CI job that uses the shared .github/actions/setup action, before the optional local Android SDK cache is restored. It validates that the hermetic Bazel toolchain configuration and the Gradle/emulator SDK configuration remain aligned; the local SDK itself is restored only for Gradle or emulator jobs.

---

- [ ] CHANGELOG.md's "Unreleased" section has been updated, if applicable.