### PR TITLE
andr; flush logger on window focus lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,7 @@
 
 **Added**
 
-- Flush the logger when the app's window loses focus, so buffered logs are made durable before the
-  app can be swiped away from the app switcher — a case where the `ON_STOP` lifecycle flush never
-  fires. Controlled by the `client_feature.android.logger_flushing_on_window_focus_loss` kill switch.
+- Flush the logger when the app's window loses focus to improve metrics reliability during forece quits.
 
 **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@
 
 **Added**
 
-- Nothing yet!
+- Flush the logger when the app's window loses focus, so buffered logs are made durable before the
+  app can be swiped away from the app switcher — a case where the `ON_STOP` lifecycle flush never
+  fires. Controlled by the `client_feature.android.logger_flushing_on_window_focus_loss` kill switch.
 
 **Changed**
 

--- a/bazel/android/build.bzl
+++ b/bazel/android/build.bzl
@@ -34,17 +34,26 @@ def bitdrift_kt_android_local_test(name, deps = [], jvm_flags = [], **kwargs):
     lib_deps = native.glob(["src/test/**/*.kt"], exclude = ["src/test/**/*Test.kt"], allow_empty = True)
 
     if len(lib_deps) != 0:
+        lib_name = "_{}_lib".format(name)
+        associates = kwargs.pop("associates", [])
+
         # We want the tests below to be able to depend on non-test files defined within this package,
         # so generate a lib target containing everything that doesn't look like a test and depend on that.
         # This means we get no cross-test file dependency, but test files depend on non-test files.
+        # The lib takes the same associates as the tests so helpers (fakes, utils) can implement
+        # `internal` declarations of the library under test.
         kt_android_library(
-            name = "_{}_lib".format(name),
+            name = lib_name,
             srcs = native.glob(["src/test/**/*.kt"], exclude = ["**/*Test.kt"]),
             deps = deps,
+            associates = associates,
             testonly = True,
         )
 
-        deps = [":_{}_lib".format(name)]
+        # Associating (rather than plain-depending) on the lib keeps the tests in the same Kotlin
+        # module as the helpers, so `internal` helpers are visible from test files.
+        kwargs["associates"] = associates + [":" + lib_name]
+        deps = []
 
     java_test_files = native.glob(["src/test/**/*.java"], allow_empty = True)
 

--- a/platform/jvm/capture/BUILD.bazel
+++ b/platform/jvm/capture/BUILD.bazel
@@ -105,7 +105,6 @@ bitdrift_kt_android_local_test(
         "-Djava.library.path=test/platform/jvm",
     ],
     deps = [
-        "//platform/jvm/capture:capture_logger_lib",
         artifact("junit:junit"),
         artifact("org.robolectric:robolectric"),
         "@rules_robolectric//bazel:android-all",

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -757,10 +757,6 @@ internal class LoggerImpl(
         }
     }
 
-    /**
-     * Flushes the logger when the app's window loses focus, which is the only observable signal for
-     * the app switcher — `ProcessLifecycleOwner`'s `ON_STOP` never fires while the overview is open.
-     */
     private fun addWindowFocusFlushTarget(
         context: Context,
         windowManager: IWindowManager,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -28,8 +28,8 @@ import io.bitdrift.capture.events.common.PowerMonitor
 import io.bitdrift.capture.events.device.DeviceStateListenerLogger
 import io.bitdrift.capture.events.lifecycle.AppExitLogger
 import io.bitdrift.capture.events.lifecycle.AppLifecycleListenerLogger
-import io.bitdrift.capture.events.lifecycle.WindowFocusFlushLogger
 import io.bitdrift.capture.events.lifecycle.EventsListenerTarget
+import io.bitdrift.capture.events.lifecycle.WindowFocusFlushLogger
 import io.bitdrift.capture.events.performance.BatteryMonitor
 import io.bitdrift.capture.events.performance.DiskUsageMonitor
 import io.bitdrift.capture.events.performance.JankStatsMonitor

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -28,6 +28,7 @@ import io.bitdrift.capture.events.common.PowerMonitor
 import io.bitdrift.capture.events.device.DeviceStateListenerLogger
 import io.bitdrift.capture.events.lifecycle.AppExitLogger
 import io.bitdrift.capture.events.lifecycle.AppLifecycleListenerLogger
+import io.bitdrift.capture.events.lifecycle.WindowFocusFlushLogger
 import io.bitdrift.capture.events.lifecycle.EventsListenerTarget
 import io.bitdrift.capture.events.performance.BatteryMonitor
 import io.bitdrift.capture.events.performance.DiskUsageMonitor
@@ -292,6 +293,8 @@ internal class LoggerImpl(
         )
 
         addJankStatsMonitorTarget(windowManager, context)
+
+        addWindowFocusFlushTarget(context, windowManager)
 
         appExitLogger =
             AppExitLogger(
@@ -751,6 +754,28 @@ internal class LoggerImpl(
             if (result is CaptureResult.Success) {
                 Log.i("capture", "Temporary device code: ${result.value}")
             }
+        }
+    }
+
+    /**
+     * Flushes the logger when the app's window loses focus, which is the only observable signal for
+     * the app switcher — `ProcessLifecycleOwner`'s `ON_STOP` never fires while the overview is open.
+     */
+    private fun addWindowFocusFlushTarget(
+        context: Context,
+        windowManager: IWindowManager,
+    ) {
+        if (context is Application) {
+            eventsListenerTarget.add(
+                WindowFocusFlushLogger(
+                    context,
+                    this,
+                    runtime,
+                    windowManager,
+                ),
+            )
+        } else {
+            errorHandler.handleError("Couldn't start WindowFocusFlushLogger. Invalid application provided")
         }
     }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/IWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/IWindowFocusRegistrar.kt
@@ -10,35 +10,22 @@ package io.bitdrift.capture.events.lifecycle
 import android.app.Activity
 
 /**
- * Observes window focus for an [Activity].
- *
- * Exists as an interface for two reasons. It keeps the *mechanism* of observing focus separate from
- * the *reaction* to losing it, so the reacting logger can be unit tested by driving focus changes
- * directly instead of standing up a real `Window` and `ViewTreeObserver`. And it leaves room for a
- * different mechanism later without touching the caller.
+ * Observes window focus for an [Activity], decoupling the focus mechanism from the reaction to it
+ * so the latter can be unit tested by driving focus changes directly.
  */
 internal interface IWindowFocusRegistrar {
     /**
-     * Starts observing focus for [activity], invoking [onFocusChanged] with the new focus state.
-     *
-     * Implementations must tolerate being called more than once for the same [activity] without
-     * registering duplicate observers, because activity callbacks can legitimately repeat.
+     * Starts observing focus for [activity]. Must be idempotent per activity — lifecycle callbacks
+     * can repeat.
      */
     fun register(
         activity: Activity,
         onFocusChanged: (hasFocus: Boolean) -> Unit,
     )
 
-    /**
-     * Stops observing focus for [activity]. Must be safe to call for an activity that was never
-     * registered, or whose window has already been torn down.
-     */
+    /** Stops observing focus for [activity]. Safe to call for an activity that was never registered. */
     fun unregister(activity: Activity)
 
-    /**
-     * Stops observing focus for every activity currently registered. Needed when the owning event
-     * listener stops: once its lifecycle callbacks are unregistered, per-activity unregistration can
-     * never happen again, so anything still registered would keep firing.
-     */
+    /** Stops observing focus for every registered activity. */
     fun unregisterAll()
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/IWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/IWindowFocusRegistrar.kt
@@ -34,4 +34,11 @@ internal interface IWindowFocusRegistrar {
      * registered, or whose window has already been torn down.
      */
     fun unregister(activity: Activity)
+
+    /**
+     * Stops observing focus for every activity currently registered. Needed when the owning event
+     * listener stops: once its lifecycle callbacks are unregistered, per-activity unregistration can
+     * never happen again, so anything still registered would keep firing.
+     */
+    fun unregisterAll()
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/IWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/IWindowFocusRegistrar.kt
@@ -1,0 +1,37 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.lifecycle
+
+import android.app.Activity
+
+/**
+ * Observes window focus for an [Activity].
+ *
+ * Exists as an interface for two reasons. It keeps the *mechanism* of observing focus separate from
+ * the *reaction* to losing it, so the reacting logger can be unit tested by driving focus changes
+ * directly instead of standing up a real `Window` and `ViewTreeObserver`. And it leaves room for a
+ * different mechanism later without touching the caller.
+ */
+internal interface IWindowFocusRegistrar {
+    /**
+     * Starts observing focus for [activity], invoking [onFocusChanged] with the new focus state.
+     *
+     * Implementations must tolerate being called more than once for the same [activity] without
+     * registering duplicate observers, because activity callbacks can legitimately repeat.
+     */
+    fun register(
+        activity: Activity,
+        onFocusChanged: (hasFocus: Boolean) -> Unit,
+    )
+
+    /**
+     * Stops observing focus for [activity]. Must be safe to call for an activity that was never
+     * registered, or whose window has already been torn down.
+     */
+    fun unregister(activity: Activity)
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
@@ -1,0 +1,65 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.lifecycle
+
+import android.app.Activity
+import android.view.ViewTreeObserver
+import androidx.annotation.UiThread
+import java.util.WeakHashMap
+
+/**
+ * [IWindowFocusRegistrar] backed by [ViewTreeObserver.OnWindowFocusChangeListener].
+ *
+ * `Application.ActivityLifecycleCallbacks` has no focus callback and `Activity.onWindowFocusChanged`
+ * requires subclassing, so neither is usable from inside an SDK. The window's `ViewTreeObserver` is,
+ * and it has been available since API 18 — comfortably below this SDK's minSdk — so no version gating
+ * is needed.
+ *
+ * The listener bookkeeping here is modelled on square/papa's `ViewTreeObservers`: hold the wrapper so
+ * it can actually be removed later, and check [ViewTreeObserver.isAlive] on both add and remove,
+ * because a dead observer throws on mutation. Papa reaches for `curtains` to find windows; this SDK
+ * already discovers activities via `ActivityLifecycleCallbacks`, so that dependency is not needed.
+ */
+internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
+    /**
+     * Weak keys so a leaked or forgotten activity cannot be retained by this map. The listener is the
+     * value because [ViewTreeObserver.removeOnWindowFocusChangeListener] needs the same instance that
+     * was added — keeping it is the only way to unregister rather than leak.
+     */
+    private val listeners = WeakHashMap<Activity, ViewTreeObserver.OnWindowFocusChangeListener>()
+
+    @UiThread
+    override fun register(
+        activity: Activity,
+        onFocusChanged: (Boolean) -> Unit,
+    ) {
+        // Activity callbacks can repeat for the same instance; registering twice would double every
+        // subsequent flush.
+        if (listeners.containsKey(activity)) {
+            return
+        }
+        val observer = activity.window?.decorView?.viewTreeObserver ?: return
+        if (!observer.isAlive) {
+            return
+        }
+        val listener = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus -> onFocusChanged(hasFocus) }
+        observer.addOnWindowFocusChangeListener(listener)
+        listeners[activity] = listener
+    }
+
+    @UiThread
+    override fun unregister(activity: Activity) {
+        val listener = listeners.remove(activity) ?: return
+        // peekDecorView avoids forcing a new decor view into existence purely to tear one down, and
+        // the observer is commonly already dead by the time an activity is destroyed.
+        val observer = activity.window?.peekDecorView()?.viewTreeObserver ?: return
+        if (observer.isAlive) {
+            observer.removeOnWindowFocusChangeListener(listener)
+        }
+    }
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
@@ -55,6 +55,22 @@ internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
     @UiThread
     override fun unregister(activity: Activity) {
         val listener = listeners.remove(activity) ?: return
+        removeListener(activity, listener)
+    }
+
+    @UiThread
+    override fun unregisterAll() {
+        // Copy first: WeakHashMap iteration is not safe against concurrent structural changes, and
+        // clearing up front keeps the map consistent even if a removal throws.
+        val snapshot = listeners.entries.map { it.key to it.value }
+        listeners.clear()
+        snapshot.forEach { (activity, listener) -> removeListener(activity, listener) }
+    }
+
+    private fun removeListener(
+        activity: Activity,
+        listener: ViewTreeObserver.OnWindowFocusChangeListener,
+    ) {
         // peekDecorView avoids forcing a new decor view into existence purely to tear one down, and
         // the observer is commonly already dead by the time an activity is destroyed.
         val observer = activity.window?.peekDecorView()?.viewTreeObserver ?: return

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
@@ -31,11 +31,12 @@ internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
         if (listeners.containsKey(activity)) {
             return
         }
-        val observer = activity.window?.decorView?.viewTreeObserver ?: return
-        if (!observer.isAlive) {
-            return
-        }
-        val listener = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus -> onFocusChanged(hasFocus) }
+        val observer =
+            activity.window
+                ?.decorView
+                ?.viewTreeObserver
+                ?.takeIf { it.isAlive } ?: return
+        val listener = ViewTreeObserver.OnWindowFocusChangeListener(onFocusChanged)
         observer.addOnWindowFocusChangeListener(listener)
         listeners[activity] = listener
     }
@@ -43,25 +44,18 @@ internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
     @UiThread
     override fun unregister(activity: Activity) {
         val listener = listeners.remove(activity) ?: return
-        removeListener(activity, listener)
+        // peekDecorView: don't create a decor view just to tear one down.
+        activity.window
+            ?.peekDecorView()
+            ?.viewTreeObserver
+            ?.takeIf { it.isAlive }
+            ?.removeOnWindowFocusChangeListener(listener)
     }
 
     @UiThread
     override fun unregisterAll() {
-        // Snapshot first: WeakHashMap iteration is not safe against structural changes.
-        val snapshot = listeners.entries.map { it.key to it.value }
-        listeners.clear()
-        snapshot.forEach { (activity, listener) -> removeListener(activity, listener) }
-    }
-
-    private fun removeListener(
-        activity: Activity,
-        listener: ViewTreeObserver.OnWindowFocusChangeListener,
-    ) {
-        // peekDecorView: don't create a decor view just to tear one down.
-        val observer = activity.window?.peekDecorView()?.viewTreeObserver ?: return
-        if (observer.isAlive) {
-            observer.removeOnWindowFocusChangeListener(listener)
-        }
+        // toList snapshots the keys: unregister mutates the map, and WeakHashMap iterators are not
+        // structurally safe.
+        listeners.keys.toList().forEach(::unregister)
     }
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrar.kt
@@ -13,24 +13,13 @@ import androidx.annotation.UiThread
 import java.util.WeakHashMap
 
 /**
- * [IWindowFocusRegistrar] backed by [ViewTreeObserver.OnWindowFocusChangeListener].
- *
- * `Application.ActivityLifecycleCallbacks` has no focus callback and `Activity.onWindowFocusChanged`
- * requires subclassing, so neither is usable from inside an SDK. The window's `ViewTreeObserver` is,
- * and it has been available since API 18 — comfortably below this SDK's minSdk — so no version gating
- * is needed.
- *
- * The listener bookkeeping here is modelled on square/papa's `ViewTreeObservers`: hold the wrapper so
- * it can actually be removed later, and check [ViewTreeObserver.isAlive] on both add and remove,
- * because a dead observer throws on mutation. Papa reaches for `curtains` to find windows; this SDK
- * already discovers activities via `ActivityLifecycleCallbacks`, so that dependency is not needed.
+ * [IWindowFocusRegistrar] backed by [ViewTreeObserver.OnWindowFocusChangeListener] (API 18) — the
+ * only focus signal observable from an SDK without subclassing activities. Bookkeeping follows
+ * square/papa's `ViewTreeObservers`: keep the listener instance so it can be removed, and check
+ * [ViewTreeObserver.isAlive] before mutating, since a dead observer throws.
  */
 internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
-    /**
-     * Weak keys so a leaked or forgotten activity cannot be retained by this map. The listener is the
-     * value because [ViewTreeObserver.removeOnWindowFocusChangeListener] needs the same instance that
-     * was added — keeping it is the only way to unregister rather than leak.
-     */
+    // Weak keys so the map never retains an activity.
     private val listeners = WeakHashMap<Activity, ViewTreeObserver.OnWindowFocusChangeListener>()
 
     @UiThread
@@ -38,8 +27,7 @@ internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
         activity: Activity,
         onFocusChanged: (Boolean) -> Unit,
     ) {
-        // Activity callbacks can repeat for the same instance; registering twice would double every
-        // subsequent flush.
+        // Registering twice would double every flush.
         if (listeners.containsKey(activity)) {
             return
         }
@@ -60,8 +48,7 @@ internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
 
     @UiThread
     override fun unregisterAll() {
-        // Copy first: WeakHashMap iteration is not safe against concurrent structural changes, and
-        // clearing up front keeps the map consistent even if a removal throws.
+        // Snapshot first: WeakHashMap iteration is not safe against structural changes.
         val snapshot = listeners.entries.map { it.key to it.value }
         listeners.clear()
         snapshot.forEach { (activity, listener) -> removeListener(activity, listener) }
@@ -71,8 +58,7 @@ internal class ViewTreeWindowFocusRegistrar : IWindowFocusRegistrar {
         activity: Activity,
         listener: ViewTreeObserver.OnWindowFocusChangeListener,
     ) {
-        // peekDecorView avoids forcing a new decor view into existence purely to tear one down, and
-        // the observer is commonly already dead by the time an activity is destroyed.
+        // peekDecorView: don't create a decor view just to tear one down.
         val observer = activity.window?.peekDecorView()?.viewTreeObserver ?: return
         if (observer.isAlive) {
             observer.removeOnWindowFocusChangeListener(listener)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
@@ -1,0 +1,116 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.lifecycle
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import io.bitdrift.capture.IInternalLogger
+import io.bitdrift.capture.common.IWindowManager
+import io.bitdrift.capture.common.MainThreadHandler
+import io.bitdrift.capture.common.Runtime
+import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.events.IEventListenerLogger
+
+/**
+ * Makes buffered data durable when the app's window loses focus.
+ *
+ * The gap this closes: the SDK's backgrounding flush hangs off `ProcessLifecycleOwner`'s `ON_STOP`,
+ * and `ON_STOP` never fires for the app switcher — while the overview is showing, the recents
+ * carousel renders a live tile of the activity, so the OS still reports it visible and the process is
+ * genuinely not backgrounded. An app swiped away from the overview therefore loses whatever had not
+ * yet reached disk. Window focus *does* drop in that case, which makes it the only observable signal.
+ *
+ * Focus loss is deliberately a broader signal than backgrounding. It also fires for an Activity
+ * transition, rotation, the IME, a permission dialog and the notification shade. That is acceptable
+ * because the flush is non-blocking and shared-core already gates what it costs: the stats upload sits
+ * behind a minimum-interval floor and disk writes behind a debounce window. Over-calling is cheap;
+ * missing the swipe-away is not.
+ *
+ * Note the asymmetry that follows from that: this flushes on focus *loss* only. Regaining focus needs
+ * no durability action, and flushing on it would double the work for no benefit.
+ *
+ * Disabled remotely via [RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS]. The flag is re-read on
+ * every callback rather than cached at [start], so a kill switch takes effect without a restart.
+ */
+internal class WindowFocusFlushLogger(
+    private val application: Application,
+    private val logger: IInternalLogger,
+    private val runtime: Runtime,
+    private val windowManager: IWindowManager,
+    private val focusRegistrar: IWindowFocusRegistrar = ViewTreeWindowFocusRegistrar(),
+    private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
+) : IEventListenerLogger,
+    Application.ActivityLifecycleCallbacks {
+    override fun start() {
+        mainThreadHandler.run {
+            application.registerActivityLifecycleCallbacks(this)
+            // An activity already started before the SDK initialised will never see
+            // onActivityStarted, so it would never get a listener and its focus loss would be
+            // missed entirely. Found by testing: the same scenario flushed when the SDK happened to
+            // start first and silently did nothing when it did not.
+            windowManager.findFirstValidActivity()?.let(::registerFocusObserver)
+        }
+    }
+
+    override fun stop() {
+        mainThreadHandler.run {
+            application.unregisterActivityLifecycleCallbacks(this)
+        }
+    }
+
+    /**
+     * Registered from `onActivityStarted` rather than `onActivityCreated`: the decor view is
+     * guaranteed to exist by then, and an activity that is created but never started cannot lose
+     * focus, so there is nothing to observe yet.
+     */
+    override fun onActivityStarted(activity: Activity) {
+        registerFocusObserver(activity)
+    }
+
+    private fun registerFocusObserver(activity: Activity) {
+        focusRegistrar.register(activity) { hasFocus ->
+            if (!hasFocus) {
+                onWindowFocusLost()
+            }
+        }
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        focusRegistrar.unregister(activity)
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // Defensive: a stopped activity is already unregistered, but an activity destroyed without a
+        // matching stop would otherwise keep a listener alive on a dead window.
+        focusRegistrar.unregister(activity)
+    }
+
+    private fun onWindowFocusLost() {
+        if (!runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
+            return
+        }
+        // Non-blocking: this runs on the main thread, so waiting on the flush would risk an ANR at
+        // exactly the moment the user is navigating away.
+        logger.flush(blocking = false)
+    }
+
+    override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?,
+    ) = Unit
+
+    override fun onActivityResumed(activity: Activity) = Unit
+
+    override fun onActivityPaused(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle,
+    ) = Unit
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
@@ -18,25 +18,13 @@ import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.events.IEventListenerLogger
 
 /**
- * Makes buffered data durable when the app's window loses focus.
+ * Flushes the logger when the app's window loses focus — the only signal that fires for the app
+ * switcher, where `ON_STOP` never does because the activity stays visible. Focus loss also fires for
+ * transient cases (IME, dialogs, transitions); over-calling is fine since flushes are debounced
+ * downstream.
  *
- * The gap this closes: the SDK's backgrounding flush hangs off `ProcessLifecycleOwner`'s `ON_STOP`,
- * and `ON_STOP` never fires for the app switcher — while the overview is showing, the recents
- * carousel renders a live tile of the activity, so the OS still reports it visible and the process is
- * genuinely not backgrounded. An app swiped away from the overview therefore loses whatever had not
- * yet reached disk. Window focus *does* drop in that case, which makes it the only observable signal.
- *
- * Focus loss is deliberately a broader signal than backgrounding. It also fires for an Activity
- * transition, rotation, the IME, a permission dialog and the notification shade. That is acceptable
- * because the flush is non-blocking and shared-core already gates what it costs: the stats upload sits
- * behind a minimum-interval floor and disk writes behind a debounce window. Over-calling is cheap;
- * missing the swipe-away is not.
- *
- * Note the asymmetry that follows from that: this flushes on focus *loss* only. Regaining focus needs
- * no durability action, and flushing on it would double the work for no benefit.
- *
- * Disabled remotely via [RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS]. The flag is re-read on
- * every callback rather than cached at [start], so a kill switch takes effect without a restart.
+ * This will be a no-op when the `client_feature.android.logger_flushing_on_window_focus_loss` kill
+ * switch is disabled.
  */
 internal class WindowFocusFlushLogger(
     private val application: Application,
@@ -47,22 +35,14 @@ internal class WindowFocusFlushLogger(
     private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
 ) : IEventListenerLogger,
     Application.ActivityLifecycleCallbacks {
-    /**
-     * Main-thread confined, like everything else in this class: [start] and [stop] mutate it inside
-     * [mainThreadHandler], and the focus callback that reads it is dispatched on the main thread.
-     * Without it, a focus listener registered before [stop] would keep flushing a logger that is
-     * being torn down — the runtime kill switch is independent of this listener's own lifecycle.
-     */
+    // Main-thread confined. Gates flushes from focus listeners that outlive stop().
     private var isStarted = false
 
     override fun start() {
         mainThreadHandler.run {
             isStarted = true
             application.registerActivityLifecycleCallbacks(this)
-            // An activity already started before the SDK initialised will never see
-            // onActivityStarted, so it would never get a listener and its focus loss would be
-            // missed entirely. Found by testing: the same scenario flushed when the SDK happened to
-            // start first and silently did nothing when it did not.
+            // An activity started before the SDK never sees onActivityStarted; pick it up here.
             windowManager.findFirstValidActivity()?.let(::registerFocusObserver)
         }
     }
@@ -71,17 +51,12 @@ internal class WindowFocusFlushLogger(
         mainThreadHandler.run {
             isStarted = false
             application.unregisterActivityLifecycleCallbacks(this)
-            // The per-activity unregistrations ride on the callbacks just removed, so anything still
-            // registered here would otherwise stay registered for the lifetime of its window.
+            // Per-activity unregistration rides on the callbacks just removed.
             focusRegistrar.unregisterAll()
         }
     }
 
-    /**
-     * Registered from `onActivityStarted` rather than `onActivityCreated`: the decor view is
-     * guaranteed to exist by then, and an activity that is created but never started cannot lose
-     * focus, so there is nothing to observe yet.
-     */
+    // Registered on start rather than create: the decor view is guaranteed to exist by then.
     override fun onActivityStarted(activity: Activity) {
         registerFocusObserver(activity)
     }
@@ -99,8 +74,7 @@ internal class WindowFocusFlushLogger(
     }
 
     override fun onActivityDestroyed(activity: Activity) {
-        // Defensive: a stopped activity is already unregistered, but an activity destroyed without a
-        // matching stop would otherwise keep a listener alive on a dead window.
+        // Defensive: covers an activity destroyed without a matching stop.
         focusRegistrar.unregister(activity)
     }
 
@@ -108,8 +82,7 @@ internal class WindowFocusFlushLogger(
         if (!isStarted || !runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
             return
         }
-        // Non-blocking: this runs on the main thread, so waiting on the flush would risk an ANR at
-        // exactly the moment the user is navigating away.
+        // Non-blocking: this runs on the main thread.
         logger.flush(blocking = false)
     }
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
@@ -63,8 +63,9 @@ internal class WindowFocusFlushLogger(
 
     private fun registerFocusObserver(activity: Activity) {
         focusRegistrar.register(activity) { hasFocus ->
-            if (!hasFocus) {
-                onWindowFocusLost()
+            if (!hasFocus && isStarted && runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
+                // Focus callbacks are dispatched on the main thread; a blocking flush would stall it.
+                logger.flush(blocking = false)
             }
         }
     }
@@ -76,14 +77,6 @@ internal class WindowFocusFlushLogger(
     override fun onActivityDestroyed(activity: Activity) {
         // Defensive: covers an activity destroyed without a matching stop.
         focusRegistrar.unregister(activity)
-    }
-
-    private fun onWindowFocusLost() {
-        if (!isStarted || !runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
-            return
-        }
-        // Focus callbacks are dispatched on the main thread; a blocking flush would stall it.
-        logger.flush(blocking = false)
     }
 
     override fun onActivityCreated(

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
@@ -47,8 +47,17 @@ internal class WindowFocusFlushLogger(
     private val mainThreadHandler: MainThreadHandler = MainThreadHandler(),
 ) : IEventListenerLogger,
     Application.ActivityLifecycleCallbacks {
+    /**
+     * Main-thread confined, like everything else in this class: [start] and [stop] mutate it inside
+     * [mainThreadHandler], and the focus callback that reads it is dispatched on the main thread.
+     * Without it, a focus listener registered before [stop] would keep flushing a logger that is
+     * being torn down — the runtime kill switch is independent of this listener's own lifecycle.
+     */
+    private var isStarted = false
+
     override fun start() {
         mainThreadHandler.run {
+            isStarted = true
             application.registerActivityLifecycleCallbacks(this)
             // An activity already started before the SDK initialised will never see
             // onActivityStarted, so it would never get a listener and its focus loss would be
@@ -60,7 +69,11 @@ internal class WindowFocusFlushLogger(
 
     override fun stop() {
         mainThreadHandler.run {
+            isStarted = false
             application.unregisterActivityLifecycleCallbacks(this)
+            // The per-activity unregistrations ride on the callbacks just removed, so anything still
+            // registered here would otherwise stay registered for the lifetime of its window.
+            focusRegistrar.unregisterAll()
         }
     }
 
@@ -92,7 +105,7 @@ internal class WindowFocusFlushLogger(
     }
 
     private fun onWindowFocusLost() {
-        if (!runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
+        if (!isStarted || !runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
             return
         }
         // Non-blocking: this runs on the main thread, so waiting on the flush would risk an ANR at

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLogger.kt
@@ -82,7 +82,7 @@ internal class WindowFocusFlushLogger(
         if (!isStarted || !runtime.isEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS)) {
             return
         }
-        // Non-blocking: this runs on the main thread.
+        // Focus callbacks are dispatched on the main thread; a blocking flush would stall it.
         logger.flush(blocking = false)
     }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrarTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrarTest.kt
@@ -1,0 +1,101 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.lifecycle
+
+import android.app.Activity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Exercises [ViewTreeWindowFocusRegistrar] against a real Robolectric [Activity], so a real decor
+ * view and a real `ViewTreeObserver` are in play. Focus changes are driven through
+ * `ViewTreeObserver.dispatchOnWindowFocusChange`, the same entry point the framework uses.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class ViewTreeWindowFocusRegistrarTest {
+    private val registrar = ViewTreeWindowFocusRegistrar()
+    private val receivedFocusChanges = mutableListOf<Boolean>()
+
+    private lateinit var activity: Activity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+    }
+
+    private fun dispatchFocusChange(hasFocus: Boolean) {
+        // dispatchOnWindowFocusChange is what ViewRootImpl calls on a real window focus change, but
+        // it is package-private and hidden from the SDK stubs — under Robolectric the real framework
+        // class runs, so reflection reaches it.
+        val observer = activity.window.decorView.viewTreeObserver
+        observer.javaClass
+            .getDeclaredMethod("dispatchOnWindowFocusChange", Boolean::class.javaPrimitiveType)
+            .apply { isAccessible = true }
+            .invoke(observer, hasFocus)
+    }
+
+    @Test
+    fun deliversFocusChangesForARegisteredActivity() {
+        registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
+
+        dispatchFocusChange(false)
+        dispatchFocusChange(true)
+
+        assertThat(receivedFocusChanges).containsExactly(false, true)
+    }
+
+    @Test
+    fun repeatRegistrationDoesNotDuplicateDelivery() {
+        // Activity callbacks legitimately repeat (stop/start cycles); a duplicate observer would
+        // double every subsequent flush.
+        registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
+        registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
+
+        dispatchFocusChange(false)
+
+        assertThat(receivedFocusChanges).containsExactly(false)
+    }
+
+    @Test
+    fun unregisterStopsDelivery() {
+        registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
+
+        registrar.unregister(activity)
+        dispatchFocusChange(false)
+
+        assertThat(receivedFocusChanges).isEmpty()
+    }
+
+    @Test
+    fun unregisterForANeverRegisteredActivityIsANoOp() {
+        registrar.unregister(activity)
+
+        dispatchFocusChange(false)
+
+        assertThat(receivedFocusChanges).isEmpty()
+    }
+
+    @Test
+    fun registrationSurvivesAStopStartCycle() {
+        // The flush logger unregisters on stop and re-registers on start; the registrar must come
+        // back to a working state on the same activity instance.
+        registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
+        registrar.unregister(activity)
+        registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
+
+        dispatchFocusChange(false)
+
+        assertThat(receivedFocusChanges).containsExactly(false)
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrarTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/ViewTreeWindowFocusRegistrarTest.kt
@@ -17,9 +17,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Exercises [ViewTreeWindowFocusRegistrar] against a real Robolectric [Activity], so a real decor
- * view and a real `ViewTreeObserver` are in play. Focus changes are driven through
- * `ViewTreeObserver.dispatchOnWindowFocusChange`, the same entry point the framework uses.
+ * Exercises [ViewTreeWindowFocusRegistrar] against a real Robolectric [Activity] and its
+ * [android.view.ViewTreeObserver].
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
@@ -35,9 +34,8 @@ class ViewTreeWindowFocusRegistrarTest {
     }
 
     private fun dispatchFocusChange(hasFocus: Boolean) {
-        // dispatchOnWindowFocusChange is what ViewRootImpl calls on a real window focus change, but
-        // it is package-private and hidden from the SDK stubs — under Robolectric the real framework
-        // class runs, so reflection reaches it.
+        // dispatchOnWindowFocusChange is what ViewRootImpl calls on a focus change, but it is hidden
+        // from the SDK stubs; the real class runs under Robolectric, so reflection reaches it.
         val observer = activity.window.decorView.viewTreeObserver
         observer.javaClass
             .getDeclaredMethod("dispatchOnWindowFocusChange", Boolean::class.javaPrimitiveType)
@@ -57,8 +55,6 @@ class ViewTreeWindowFocusRegistrarTest {
 
     @Test
     fun repeatRegistrationDoesNotDuplicateDelivery() {
-        // Activity callbacks legitimately repeat (stop/start cycles); a duplicate observer would
-        // double every subsequent flush.
         registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
         registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
 
@@ -88,8 +84,6 @@ class ViewTreeWindowFocusRegistrarTest {
 
     @Test
     fun registrationSurvivesAStopStartCycle() {
-        // The flush logger unregisters on stop and re-registers on start; the registrar must come
-        // back to a working state on the same activity instance.
         registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }
         registrar.unregister(activity)
         registrar.register(activity) { hasFocus -> receivedFocusChanges.add(hasFocus) }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
@@ -139,9 +139,6 @@ class WindowFocusFlushLoggerTest {
         assertThat(focusRegistrar.registeredActivities).isEmpty()
     }
 
-    // The tests below mirror the on-device scenario matrix (recents is the plain focus-loss case
-    // covered above).
-
     @Test
     fun home_flushesOnFocusLossAndUnregistersOnTheStopThatFollows() {
         windowFocusFlushLogger.start()

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
@@ -138,4 +138,61 @@ class WindowFocusFlushLoggerTest {
 
         assertThat(focusRegistrar.registeredActivities).isEmpty()
     }
+
+    // The tests below mirror the on-device scenario matrix (recents is the plain focus-loss case
+    // covered above).
+
+    @Test
+    fun home_flushesOnFocusLossAndUnregistersOnTheStopThatFollows() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+        windowFocusFlushLogger.onActivityStopped(activity)
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+
+        verify(logger, times(1)).flush(false)
+        assertThat(focusRegistrar.registeredActivities).isEmpty()
+    }
+
+    @Test
+    fun activityTransition_flushesForTheLeavingActivityAndKeepsObservingTheNewOne() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        windowFocusFlushLogger.onActivityStarted(secondActivity)
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+        windowFocusFlushLogger.onActivityStopped(activity)
+        focusRegistrar.changeFocus(secondActivity, hasFocus = false)
+
+        verify(logger, times(2)).flush(false)
+        assertThat(focusRegistrar.registeredActivities).containsExactly(secondActivity)
+    }
+
+    @Test
+    fun rotation_recreationWithoutFocusLossDoesNotFlush() {
+        // Measured on device: rotation destroys and recreates the activity but never reports a
+        // focus loss on the old window.
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        windowFocusFlushLogger.onActivityStopped(activity)
+        windowFocusFlushLogger.onActivityDestroyed(activity)
+        windowFocusFlushLogger.onActivityStarted(secondActivity)
+
+        verify(logger, never()).flush(false)
+        assertThat(focusRegistrar.registeredActivities).containsExactly(secondActivity)
+    }
+
+    @Test
+    fun imeOrPermissionDialog_flushesOncePerFocusLossAndIgnoresTheRegain() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+        focusRegistrar.changeFocus(activity, hasFocus = true)
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+
+        verify(logger, times(2)).flush(false)
+    }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
@@ -24,9 +24,8 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * Drives [WindowFocusFlushLogger] through [FakeWindowFocusRegistrar], so window-focus changes are
- * plain function calls — no `Window`, no `ViewTreeObserver`. The real focus mechanism is covered
- * separately by `ViewTreeWindowFocusRegistrarTest`.
+ * Drives [WindowFocusFlushLogger] through [FakeWindowFocusRegistrar]; the real focus mechanism is
+ * covered by [ViewTreeWindowFocusRegistrarTest].
  */
 class WindowFocusFlushLoggerTest {
     private val application: Application = mock()
@@ -99,8 +98,6 @@ class WindowFocusFlushLoggerTest {
 
     @Test
     fun registersAnActivityThatWasAlreadyStartedBeforeTheSdk() {
-        // The launcher activity can be started before the events listener target starts; it never
-        // gets an onActivityStarted, so start() must pick it up from the window manager.
         windowManager.firstValidActivity = activity
 
         windowFocusFlushLogger.start()
@@ -120,9 +117,7 @@ class WindowFocusFlushLoggerTest {
 
     @Test
     fun stopPreventsAnyFurtherFlushes() {
-        // The kill switch stays enabled: stopping the listener itself must be enough. A listener
-        // that was registered before stop() keeps receiving platform focus callbacks (nothing
-        // removed it), and those must not reach a logger that is being torn down.
+        // The kill switch stays enabled: stopping the listener must be enough on its own.
         windowFocusFlushLogger.start()
         windowFocusFlushLogger.onActivityStarted(activity)
 
@@ -134,9 +129,7 @@ class WindowFocusFlushLoggerTest {
 
     @Test
     fun stopUnregistersEveryRemainingFocusObserver() {
-        // After stop() the lifecycle callbacks are gone, so the per-activity unregistration in
-        // onActivityStopped/onActivityDestroyed can never run again — stop() itself is the last
-        // chance to tear these down.
+        // stop() removes the lifecycle callbacks, so it is the last chance to tear these down.
         windowFocusFlushLogger.start()
         windowFocusFlushLogger.onActivityStarted(activity)
         windowFocusFlushLogger.onActivityStarted(secondActivity)

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/lifecycle/WindowFocusFlushLoggerTest.kt
@@ -1,0 +1,148 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.events.lifecycle
+
+import android.app.Activity
+import android.app.Application
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import io.bitdrift.capture.IInternalLogger
+import io.bitdrift.capture.Mocks
+import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.fakes.FakeRuntime
+import io.bitdrift.capture.fakes.FakeWindowFocusRegistrar
+import io.bitdrift.capture.fakes.FakeWindowManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Drives [WindowFocusFlushLogger] through [FakeWindowFocusRegistrar], so window-focus changes are
+ * plain function calls — no `Window`, no `ViewTreeObserver`. The real focus mechanism is covered
+ * separately by `ViewTreeWindowFocusRegistrarTest`.
+ */
+class WindowFocusFlushLoggerTest {
+    private val application: Application = mock()
+    private val logger: IInternalLogger = mock()
+    private val runtime = FakeRuntime()
+    private val windowManager = FakeWindowManager()
+    private val focusRegistrar = FakeWindowFocusRegistrar()
+    private val mainThreadHandler = Mocks.sameThreadHandler
+
+    private val activity: Activity = mock()
+    private val secondActivity: Activity = mock()
+
+    private lateinit var windowFocusFlushLogger: WindowFocusFlushLogger
+
+    @Before
+    fun setUp() {
+        windowFocusFlushLogger =
+            WindowFocusFlushLogger(
+                application,
+                logger,
+                runtime,
+                windowManager,
+                focusRegistrar,
+                mainThreadHandler,
+            )
+    }
+
+    @Test
+    fun flushesNonBlockingWhenAStartedActivityLosesFocus() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+
+        verify(logger).flush(false)
+    }
+
+    @Test
+    fun doesNotFlushWhenFocusIsGained() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        focusRegistrar.changeFocus(activity, hasFocus = true)
+
+        verify(logger, never()).flush(false)
+    }
+
+    @Test
+    fun doesNotFlushWhenTheKillSwitchIsDisabled() {
+        runtime.setEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS, false)
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+
+        verify(logger, never()).flush(false)
+    }
+
+    @Test
+    fun rereadsTheKillSwitchOnEveryFocusLossWithoutARestart() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+        runtime.setEnabled(RuntimeFeature.LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS, false)
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+
+        verify(logger, times(1)).flush(false)
+    }
+
+    @Test
+    fun registersAnActivityThatWasAlreadyStartedBeforeTheSdk() {
+        // The launcher activity can be started before the events listener target starts; it never
+        // gets an onActivityStarted, so start() must pick it up from the window manager.
+        windowManager.firstValidActivity = activity
+
+        windowFocusFlushLogger.start()
+
+        assertThat(focusRegistrar.registeredActivities).containsExactly(activity)
+    }
+
+    @Test
+    fun unregistersAnActivityWhenItStops() {
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        windowFocusFlushLogger.onActivityStopped(activity)
+
+        assertThat(focusRegistrar.registeredActivities).isEmpty()
+    }
+
+    @Test
+    fun stopPreventsAnyFurtherFlushes() {
+        // The kill switch stays enabled: stopping the listener itself must be enough. A listener
+        // that was registered before stop() keeps receiving platform focus callbacks (nothing
+        // removed it), and those must not reach a logger that is being torn down.
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+
+        windowFocusFlushLogger.stop()
+        focusRegistrar.changeFocus(activity, hasFocus = false)
+
+        verify(logger, never()).flush(false)
+    }
+
+    @Test
+    fun stopUnregistersEveryRemainingFocusObserver() {
+        // After stop() the lifecycle callbacks are gone, so the per-activity unregistration in
+        // onActivityStopped/onActivityDestroyed can never run again — stop() itself is the last
+        // chance to tear these down.
+        windowFocusFlushLogger.start()
+        windowFocusFlushLogger.onActivityStarted(activity)
+        windowFocusFlushLogger.onActivityStarted(secondActivity)
+
+        windowFocusFlushLogger.stop()
+
+        assertThat(focusRegistrar.registeredActivities).isEmpty()
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeRuntime.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeRuntime.kt
@@ -1,0 +1,34 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.fakes
+
+import io.bitdrift.capture.common.Runtime
+import io.bitdrift.capture.common.RuntimeConfig
+import io.bitdrift.capture.common.RuntimeFeature
+import io.bitdrift.capture.common.RuntimeStringConfig
+
+/**
+ * [Runtime] fake that answers with each flag's declared default unless a test overrides it, which
+ * mirrors production more closely than a mock: a test only has to state what it changes.
+ */
+internal class FakeRuntime : Runtime {
+    private val overrides = mutableMapOf<RuntimeFeature, Boolean>()
+
+    fun setEnabled(
+        feature: RuntimeFeature,
+        enabled: Boolean,
+    ) {
+        overrides[feature] = enabled
+    }
+
+    override fun isEnabled(feature: RuntimeFeature): Boolean = overrides[feature] ?: feature.defaultValue
+
+    override fun getConfigValue(config: RuntimeConfig): Int = config.defaultValue
+
+    override fun getConfigValue(config: RuntimeStringConfig): String = config.defaultValue
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeRuntime.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeRuntime.kt
@@ -12,10 +12,7 @@ import io.bitdrift.capture.common.RuntimeConfig
 import io.bitdrift.capture.common.RuntimeFeature
 import io.bitdrift.capture.common.RuntimeStringConfig
 
-/**
- * [Runtime] fake that answers with each flag's declared default unless a test overrides it, which
- * mirrors production more closely than a mock: a test only has to state what it changes.
- */
+/** [Runtime] fake that answers with each flag's declared default unless a test overrides it. */
 internal class FakeRuntime : Runtime {
     private val overrides = mutableMapOf<RuntimeFeature, Boolean>()
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowFocusRegistrar.kt
@@ -1,0 +1,56 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.fakes
+
+import android.app.Activity
+import io.bitdrift.capture.events.lifecycle.IWindowFocusRegistrar
+
+/**
+ * [IWindowFocusRegistrar] fake that lets a test drive window-focus changes directly and observe
+ * exactly which activities currently have a focus observer.
+ *
+ * One behaviour is deliberately mirrored from the real `ViewTreeObserver`: a callback that was
+ * registered and never unregistered keeps receiving focus changes — including after the component
+ * that registered it has "stopped". That is what makes missing-teardown bugs observable here.
+ */
+internal class FakeWindowFocusRegistrar : IWindowFocusRegistrar {
+    private val callbacks = LinkedHashMap<Activity, (hasFocus: Boolean) -> Unit>()
+
+    /** The activities that currently have a focus observer registered. */
+    val registeredActivities: Set<Activity>
+        get() = callbacks.keys
+
+    override fun register(
+        activity: Activity,
+        onFocusChanged: (hasFocus: Boolean) -> Unit,
+    ) {
+        // Mirrors the real registrar's contract: repeat registration must not duplicate observers.
+        if (callbacks.containsKey(activity)) {
+            return
+        }
+        callbacks[activity] = onFocusChanged
+    }
+
+    override fun unregister(activity: Activity) {
+        callbacks.remove(activity)
+    }
+
+    // Not part of IWindowFocusRegistrar (yet): the production teardown that would need it does not
+    // exist either. When stop()-time teardown lands in the interface this becomes an `override`.
+    fun unregisterAll() {
+        callbacks.clear()
+    }
+
+    /** Simulates the platform dispatching a window-focus change for [activity]'s window. */
+    fun changeFocus(
+        activity: Activity,
+        hasFocus: Boolean,
+    ) {
+        callbacks[activity]?.invoke(hasFocus)
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowFocusRegistrar.kt
@@ -40,9 +40,7 @@ internal class FakeWindowFocusRegistrar : IWindowFocusRegistrar {
         callbacks.remove(activity)
     }
 
-    // Not part of IWindowFocusRegistrar (yet): the production teardown that would need it does not
-    // exist either. When stop()-time teardown lands in the interface this becomes an `override`.
-    fun unregisterAll() {
+    override fun unregisterAll() {
         callbacks.clear()
     }
 

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowFocusRegistrar.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowFocusRegistrar.kt
@@ -11,12 +11,8 @@ import android.app.Activity
 import io.bitdrift.capture.events.lifecycle.IWindowFocusRegistrar
 
 /**
- * [IWindowFocusRegistrar] fake that lets a test drive window-focus changes directly and observe
- * exactly which activities currently have a focus observer.
- *
- * One behaviour is deliberately mirrored from the real `ViewTreeObserver`: a callback that was
- * registered and never unregistered keeps receiving focus changes — including after the component
- * that registered it has "stopped". That is what makes missing-teardown bugs observable here.
+ * [IWindowFocusRegistrar] fake that lets tests drive focus changes directly. Like a real
+ * `ViewTreeObserver`, a never-unregistered callback keeps receiving changes.
  */
 internal class FakeWindowFocusRegistrar : IWindowFocusRegistrar {
     private val callbacks = LinkedHashMap<Activity, (hasFocus: Boolean) -> Unit>()
@@ -29,7 +25,6 @@ internal class FakeWindowFocusRegistrar : IWindowFocusRegistrar {
         activity: Activity,
         onFocusChanged: (hasFocus: Boolean) -> Unit,
     ) {
-        // Mirrors the real registrar's contract: repeat registration must not duplicate observers.
         if (callbacks.containsKey(activity)) {
             return
         }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowManager.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowManager.kt
@@ -11,10 +11,7 @@ import android.app.Activity
 import android.view.View
 import io.bitdrift.capture.common.IWindowManager
 
-/**
- * [IWindowManager] fake. Tests that need an "activity was already started before the SDK" state
- * assign [firstValidActivity]; everything else reads as an app with no windows.
- */
+/** [IWindowManager] fake; set [firstValidActivity] to simulate an already-started activity. */
 internal class FakeWindowManager(
     var firstValidActivity: Activity? = null,
 ) : IWindowManager {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowManager.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeWindowManager.kt
@@ -1,0 +1,26 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.fakes
+
+import android.app.Activity
+import android.view.View
+import io.bitdrift.capture.common.IWindowManager
+
+/**
+ * [IWindowManager] fake. Tests that need an "activity was already started before the SDK" state
+ * assign [firstValidActivity]; everything else reads as an app with no windows.
+ */
+internal class FakeWindowManager(
+    var firstValidActivity: Activity? = null,
+) : IWindowManager {
+    override fun getBottomMostRootView(): View? = null
+
+    override fun getAllRootViews(): List<View> = emptyList()
+
+    override fun findFirstValidActivity(): Activity? = firstValidActivity
+}

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -59,6 +59,18 @@ sealed class RuntimeFeature(
     data object LOGGER_FLUSHING_ON_CRASH : RuntimeFeature("client_feature.android.logger_flushing_on_force_quit", defaultValue = true)
 
     /**
+     * Whether the logger should be flushed when the app's window loses focus.
+     *
+     * Window focus is lost on the app switcher, an Activity transition, rotation, the IME appearing,
+     * a permission dialog, and the notification shade. Some of those are transient and none of them
+     * imply the process is going away, so this is a best-effort durability hint rather than a
+     * lifecycle signal: it makes buffered data durable at moments the process *might* not survive.
+     * It complements the ON_STOP flush, which never fires for the app switcher at all.
+     */
+    data object LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS :
+        RuntimeFeature("client_feature.android.logger_flushing_on_window_focus_loss", defaultValue = true)
+
+    /**
      * Whether Dropped Frames reporting is enabled
      */
     data object DROPPED_EVENTS_MONITORING : RuntimeFeature("client_feature.android.dropped_frames_reporting", defaultValue = true)

--- a/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
+++ b/platform/jvm/common/src/main/kotlin/io/bitdrift/capture/common/Runtime.kt
@@ -60,12 +60,6 @@ sealed class RuntimeFeature(
 
     /**
      * Whether the logger should be flushed when the app's window loses focus.
-     *
-     * Window focus is lost on the app switcher, an Activity transition, rotation, the IME appearing,
-     * a permission dialog, and the notification shade. Some of those are transient and none of them
-     * imply the process is going away, so this is a best-effort durability hint rather than a
-     * lifecycle signal: it makes buffered data durable at moments the process *might* not survive.
-     * It complements the ON_STOP flush, which never fires for the app switcher at all.
      */
     data object LOGGER_FLUSHING_ON_WINDOW_FOCUS_LOSS :
         RuntimeFeature("client_feature.android.logger_flushing_on_window_focus_loss", defaultValue = true)

--- a/platform/jvm/gradle-test-app/src/main/AndroidManifest.xml
+++ b/platform/jvm/gradle-test-app/src/main/AndroidManifest.xml
@@ -34,6 +34,13 @@
                 />
         </provider>
 
+        <!-- Exists to exercise every route to window-focus loss (IME, permission dialog, rotation,
+             Activity transition). Exported so scenarios can `am start -n` it without driving the UI. -->
+        <activity
+            android:name=".ui.activities.FocusMatrixActivity"
+            android:exported="true"
+            android:label="@string/focus_matrix" />
+
         <activity
             android:name=".ui.activities.MainActivity"
             android:exported="true"

--- a/platform/jvm/gradle-test-app/src/main/AndroidManifest.xml
+++ b/platform/jvm/gradle-test-app/src/main/AndroidManifest.xml
@@ -34,8 +34,7 @@
                 />
         </provider>
 
-        <!-- Exists to exercise every route to window-focus loss (IME, permission dialog, rotation,
-             Activity transition). Exported so scenarios can `am start -n` it without driving the UI. -->
+        <!-- Exercises window-focus-loss cases; exported so tests can start it via adb. -->
         <activity
             android:name=".ui.activities.FocusMatrixActivity"
             android:exported="true"

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -102,6 +102,10 @@ sealed class NavigationAction : AppAction {
 
     object NavigateToStressTest : NavigationAction()
 
+    /** Starts [io.bitdrift.gradletestapp.ui.activities.FocusMatrixActivity] — a real Activity
+     * transition, which is itself one of the window-focus-loss cases under test. */
+    object NavigateToFocusMatrix : NavigationAction()
+
     object InvokeService : NavigationAction()
 }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -102,8 +102,6 @@ sealed class NavigationAction : AppAction {
 
     object NavigateToStressTest : NavigationAction()
 
-    /** Starts [io.bitdrift.gradletestapp.ui.activities.FocusMatrixActivity] — a real Activity
-     * transition, which is itself one of the window-focus-loss cases under test. */
     object NavigateToFocusMatrix : NavigationAction()
 
     object InvokeService : NavigationAction()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/activities/FocusMatrixActivity.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/activities/FocusMatrixActivity.kt
@@ -1,0 +1,109 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.gradletestapp.ui.activities
+
+import android.Manifest
+import android.os.Bundle
+import android.view.Gravity
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import io.bitdrift.gradletestapp.R
+import io.bitdrift.gradletestapp.diagnostics.lifecycle.LifecycleEventLogger
+import timber.log.Timber
+
+/**
+ * A second Activity that exists purely to exercise every way an app window can lose focus, so the
+ * SDK's flush-on-focus-loss can be verified end to end.
+ *
+ * Reaching it is itself one of the cases under test (an Activity transition drops focus on the
+ * activity being left). The rest are driven from here:
+ *
+ *  - **IME** — focusing the text field raises the keyboard, which takes window focus.
+ *  - **Permission dialog** — a system dialog takes focus without the activity stopping. Uses
+ *    READ_PHONE_STATE, which the app already declares: adding a permission purely for this would
+ *    drag in a `uses-feature` hardware declaration and the lint that enforces it, for no benefit.
+ *    Revoke it first so the dialog actually appears on repeat runs:
+ *    `adb shell pm revoke io.bitdrift.gradletestapp android.permission.READ_PHONE_STATE`
+ *  - **Rotation** — `adb shell settings put system user_rotation 1` recreates the activity.
+ *  - **Recents / home / kill** — driven entirely over adb, no UI needed.
+ *
+ * Built with views rather than Compose on purpose: the point is to observe `ViewTreeObserver` window
+ * focus with as little between the harness and the platform as possible, and this app already mixes
+ * both so it is not out of place.
+ *
+ * Focus changes go through the same [LifecycleEventLogger] helper `MainActivity` uses, so a focus
+ * change and the SDK's resulting flush interleave in one capture on the device clock. That is what
+ * makes the assertion "focus dropped, then a flush happened" possible at all.
+ */
+class FocusMatrixActivity : AppCompatActivity() {
+    private val requestPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            Timber.i("focus-matrix permission result granted=%s", granted)
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val root =
+            LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.CENTER
+                setPadding(PADDING_PX, PADDING_PX, PADDING_PX, PADDING_PX)
+                layoutParams =
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+            }
+
+        root.addView(
+            TextView(this).apply {
+                setText(R.string.focus_matrix_instructions)
+            },
+        )
+
+        // Tapping this raises the IME, which takes window focus without stopping the activity.
+        root.addView(
+            EditText(this).apply {
+                id = ID_INPUT
+                setHint(R.string.focus_matrix_input_hint)
+            },
+        )
+
+        // A system permission dialog also takes focus without an activity stop. Already-granted
+        // permissions return instantly with no dialog and therefore no focus loss, so revoke it
+        // before testing (see the class doc).
+        root.addView(
+            Button(this).apply {
+                id = ID_REQUEST_PERMISSION
+                setText(R.string.focus_matrix_request_permission)
+                setOnClickListener { requestPermission.launch(Manifest.permission.READ_PHONE_STATE) }
+            },
+        )
+
+        setContentView(root)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        // Same helper MainActivity uses, so both activities emit one consistent focus line that the
+        // logcat harness already parses.
+        LifecycleEventLogger.onWindowFocusChanged(this, hasFocus)
+    }
+
+    private companion object {
+        const val PADDING_PX = 48
+        const val ID_INPUT = 1_001
+        const val ID_REQUEST_PERMISSION = 1_002
+    }
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/activities/FocusMatrixActivity.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/activities/FocusMatrixActivity.kt
@@ -22,28 +22,9 @@ import io.bitdrift.gradletestapp.diagnostics.lifecycle.LifecycleEventLogger
 import timber.log.Timber
 
 /**
- * A second Activity that exists purely to exercise every way an app window can lose focus, so the
- * SDK's flush-on-focus-loss can be verified end to end.
- *
- * Reaching it is itself one of the cases under test (an Activity transition drops focus on the
- * activity being left). The rest are driven from here:
- *
- *  - **IME** — focusing the text field raises the keyboard, which takes window focus.
- *  - **Permission dialog** — a system dialog takes focus without the activity stopping. Uses
- *    READ_PHONE_STATE, which the app already declares: adding a permission purely for this would
- *    drag in a `uses-feature` hardware declaration and the lint that enforces it, for no benefit.
- *    Revoke it first so the dialog actually appears on repeat runs:
- *    `adb shell pm revoke io.bitdrift.gradletestapp android.permission.READ_PHONE_STATE`
- *  - **Rotation** — `adb shell settings put system user_rotation 1` recreates the activity.
- *  - **Recents / home / kill** — driven entirely over adb, no UI needed.
- *
- * Built with views rather than Compose on purpose: the point is to observe `ViewTreeObserver` window
- * focus with as little between the harness and the platform as possible, and this app already mixes
- * both so it is not out of place.
- *
- * Focus changes go through the same [LifecycleEventLogger] helper `MainActivity` uses, so a focus
- * change and the SDK's resulting flush interleave in one capture on the device clock. That is what
- * makes the assertion "focus dropped, then a flush happened" possible at all.
+ * Exercises window-focus-loss cases for verifying the SDK's flush-on-focus-loss: reaching it is an
+ * Activity transition, the text field raises the IME, and the button opens a permission dialog.
+ * Recents/home/rotation are driven over adb.
  */
 class FocusMatrixActivity : AppCompatActivity() {
     private val requestPermission =
@@ -72,7 +53,6 @@ class FocusMatrixActivity : AppCompatActivity() {
             },
         )
 
-        // Tapping this raises the IME, which takes window focus without stopping the activity.
         root.addView(
             EditText(this).apply {
                 id = ID_INPUT
@@ -80,9 +60,8 @@ class FocusMatrixActivity : AppCompatActivity() {
             },
         )
 
-        // A system permission dialog also takes focus without an activity stop. Already-granted
-        // permissions return instantly with no dialog and therefore no focus loss, so revoke it
-        // before testing (see the class doc).
+        // An already-granted permission shows no dialog (and so no focus loss); revoke first:
+        // `adb shell pm revoke io.bitdrift.gradletestapp android.permission.READ_PHONE_STATE`
         root.addView(
             Button(this).apply {
                 id = ID_REQUEST_PERMISSION
@@ -96,8 +75,6 @@ class FocusMatrixActivity : AppCompatActivity() {
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        // Same helper MainActivity uses, so both activities emit one consistent focus line that the
-        // logcat harness already parses.
         LifecycleEventLogger.onWindowFocusChanged(this, hasFocus)
     }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NavigationCard.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NavigationCard.kt
@@ -55,6 +55,11 @@ fun NavigationCard(onAction: (AppAction) -> Unit) {
                 ) { Text(stringResource(id = R.string.navigate_second), maxLines = 1, softWrap = false) }
 
                 OutlinedButton(
+                    onClick = { onAction(NavigationAction.NavigateToFocusMatrix) },
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = BitdriftColors.TextPrimary),
+                ) { Text(stringResource(id = R.string.focus_matrix), maxLines = 1, softWrap = false) }
+
+                OutlinedButton(
                     onClick = { onAction(NavigationAction.NavigateToXml) },
                     colors = ButtonDefaults.outlinedButtonColors(contentColor = BitdriftColors.TextPrimary),
                 ) { Text(stringResource(id = R.string.navigate_to_xml_view), maxLines = 1, softWrap = false) }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
@@ -29,11 +29,11 @@ import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.gradletestapp.R
 import io.bitdrift.gradletestapp.data.model.NavigationAction
-import io.bitdrift.gradletestapp.ui.activities.FocusMatrixActivity
 import io.bitdrift.gradletestapp.data.repository.AppExitRepository
 import io.bitdrift.gradletestapp.data.repository.NetworkTestingRepository
 import io.bitdrift.gradletestapp.data.repository.SdkRepository
 import io.bitdrift.gradletestapp.data.repository.StressTestRepository
+import io.bitdrift.gradletestapp.ui.activities.FocusMatrixActivity
 import io.bitdrift.gradletestapp.ui.compose.MainScreen
 import io.bitdrift.gradletestapp.ui.service.SendTelemetryService
 import io.bitdrift.gradletestapp.ui.viewmodel.MainViewModel

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/FirstFragment.kt
@@ -10,6 +10,7 @@ package io.bitdrift.gradletestapp.ui.fragments
 import android.app.Application
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -28,6 +29,7 @@ import io.bitdrift.capture.events.span.Span
 import io.bitdrift.capture.events.span.SpanResult
 import io.bitdrift.gradletestapp.R
 import io.bitdrift.gradletestapp.data.model.NavigationAction
+import io.bitdrift.gradletestapp.ui.activities.FocusMatrixActivity
 import io.bitdrift.gradletestapp.data.repository.AppExitRepository
 import io.bitdrift.gradletestapp.data.repository.NetworkTestingRepository
 import io.bitdrift.gradletestapp.data.repository.SdkRepository
@@ -105,6 +107,11 @@ class FirstFragment : Fragment() {
                                 is NavigationAction.NavigateToDialogAndModals -> {
                                     Logger.logScreenView("dialog_and_modals_fragment")
                                     findNavController().navigate(R.id.action_FirstFragment_to_DialogAndModalsFragment)
+                                }
+
+                                is NavigationAction.NavigateToFocusMatrix -> {
+                                    Logger.logScreenView("focus_matrix_activity")
+                                    startActivity(Intent(requireContext(), FocusMatrixActivity::class.java))
                                 }
 
                                 is NavigationAction.NavigateToStressTest -> {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -197,7 +197,6 @@ class MainViewModel(
             is NavigationAction.NavigateToXml -> {}
             is NavigationAction.NavigateToDialogAndModals -> {}
             is NavigationAction.NavigateToStressTest -> {}
-            // Navigation is performed by the Fragment; the ViewModel only needs to stay exhaustive.
             is NavigationAction.NavigateToFocusMatrix -> {}
             is NavigationAction.InvokeService -> {}
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -197,6 +197,8 @@ class MainViewModel(
             is NavigationAction.NavigateToXml -> {}
             is NavigationAction.NavigateToDialogAndModals -> {}
             is NavigationAction.NavigateToStressTest -> {}
+            // Navigation is performed by the Fragment; the ViewModel only needs to stay exhaustive.
+            is NavigationAction.NavigateToFocusMatrix -> {}
             is NavigationAction.InvokeService -> {}
 
         }

--- a/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
@@ -53,7 +53,6 @@
     <string name="restart_warning_summary">Click here to restart and apply your configuration changes</string>
     <string name="log_message_toast">Log message sent with level: %1$s</string>
     <string name="webview_testing">WebView Testing</string>
-    <!-- Debug-only focus-matrix harness strings; not translated. -->
     <string name="focus_matrix" translatable="false">Focus matrix</string>
     <string name="focus_matrix_instructions" translatable="false">Focus matrix\n\nTap the field to raise the IME.\nTap the button for a permission dialog.</string>
     <string name="focus_matrix_input_hint" translatable="false">tap me to raise the IME</string>

--- a/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
@@ -53,4 +53,10 @@
     <string name="restart_warning_summary">Click here to restart and apply your configuration changes</string>
     <string name="log_message_toast">Log message sent with level: %1$s</string>
     <string name="webview_testing">WebView Testing</string>
+    <!-- Diagnostic strings for the focus-matrix test screen. Not translated: this is a debug-only
+         harness for verifying flush-on-window-focus-loss, not user-facing product UI. -->
+    <string name="focus_matrix" translatable="false">Focus matrix</string>
+    <string name="focus_matrix_instructions" translatable="false">Focus matrix\n\nTap the field to raise the IME.\nTap the button for a permission dialog.</string>
+    <string name="focus_matrix_input_hint" translatable="false">tap me to raise the IME</string>
+    <string name="focus_matrix_request_permission" translatable="false">Request permission (focus loss)</string>
 </resources>

--- a/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
+++ b/platform/jvm/gradle-test-app/src/main/res/values/strings.xml
@@ -53,8 +53,7 @@
     <string name="restart_warning_summary">Click here to restart and apply your configuration changes</string>
     <string name="log_message_toast">Log message sent with level: %1$s</string>
     <string name="webview_testing">WebView Testing</string>
-    <!-- Diagnostic strings for the focus-matrix test screen. Not translated: this is a debug-only
-         harness for verifying flush-on-window-focus-loss, not user-facing product UI. -->
+    <!-- Debug-only focus-matrix harness strings; not translated. -->
     <string name="focus_matrix" translatable="false">Focus matrix</string>
     <string name="focus_matrix_instructions" translatable="false">Focus matrix\n\nTap the field to raise the IME.\nTap the button for a permission dialog.</string>
     <string name="focus_matrix_input_hint" translatable="false">tap me to raise the IME</string>


### PR DESCRIPTION
Flush the logger (non-blocking) when the app's window loses focus. The existing backgrounding
flush hangs off `ProcessLifecycleOwner`'s `ON_STOP`, which never fires while the recents overview
is showing — an app swiped away from there loses whatever hadn't reached disk. Window focus is the
only signal that fires in that case.

- `WindowFocusFlushLogger` (`IEventListenerLogger`) registers a `ViewTreeObserver.OnWindowFocusChangeListener`
  (API 18) per started activity via an injectable `IWindowFocusRegistrar`; over-firing (IME, dialogs,
  transitions) is fine — flushes are debounced downstream.
- Kill switch: `client_feature.android.logger_flushing_on_window_focus_loss` (default on, re-read per callback).
- Unit tests (explicit fakes) + Robolectric tests mirror the on-device scenario matrix.
- Test app: `FocusMatrixActivity` exercises the IME / permission-dialog / transition focus-loss cases.

Verified on a Pixel 10: recents, recents+kill, home, and activity-navigation all show
`focus=false` → flush within 1ms, upload acked before process death. Rotation drops no focus (measured).

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.