### PR TITLE
AGENTS.md: guard FFI ABI boundaries

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,0 @@
-# Copilot review instructions
-
-For any Swift C bridge or Android JNI change, apply the FFI and ABI safety requirements in the
-repository's `AGENTS.md`. Flag a mismatch between an export, its declaration, and its caller as
-release-blocking, even when the affected parameter is unused.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# Copilot review instructions
+
+## FFI and ABI boundary
+
+Treat all Swift C bridge and Android JNI changes as release-blocking ABI work. For every changed
+entry point, verify that the Rust export exactly matches its declaration and caller:
+
+- C ABI: `extern "C"` parameter count, order, nullability, and types must match
+  `CaptureRustBridge.h` and Swift call sites.
+- JNI: the Rust export parameters must match the Kotlin `external` declaration and its callers.
+  Never add unused trailing Rust parameters; they still change the ABI.
+- Swift Foundation values crossing the C header must use the corresponding Objective-C object type
+  (for example, nullable `NSString *` for `String?`), not `const void *`.
+- Public Swift/Objective-C/Kotlin/Java APIs must retain existing overloads and binary symbols when
+  adding an argument. Default arguments alone do not preserve JVM or Swift library-evolution ABI.
+
+Flag any mismatch immediately, even if the parameter is currently unused. Verify relevant Swift
+and Android bridge builds/tests after the implementation is complete.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,18 +1,5 @@
 # Copilot review instructions
 
-## FFI and ABI boundary
-
-Treat all Swift C bridge and Android JNI changes as release-blocking ABI work. For every changed
-entry point, verify that the Rust export exactly matches its declaration and caller:
-
-- C ABI: `extern "C"` parameter count, order, nullability, and types must match
-  `CaptureRustBridge.h` and Swift call sites.
-- JNI: the Rust export parameters must match the Kotlin `external` declaration and its callers.
-  Never add unused trailing Rust parameters; they still change the ABI.
-- Swift Foundation values crossing the C header must use the corresponding Objective-C object type
-  (for example, nullable `NSString *` for `String?`), not `const void *`.
-- Public Swift/Objective-C/Kotlin/Java APIs must retain existing overloads and binary symbols when
-  adding an argument. Default arguments alone do not preserve JVM or Swift library-evolution ABI.
-
-Flag any mismatch immediately, even if the parameter is currently unused. Verify relevant Swift
-and Android bridge builds/tests after the implementation is complete.
+For any Swift C bridge or Android JNI change, apply the FFI and ABI safety requirements in the
+repository's `AGENTS.md`. Flag a mismatch between an export, its declaration, and its caller as
+release-blocking, even when the affected parameter is unused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,23 @@ Test locations:
 - Android: JDK 17, NDK 27.2, minSdk 23
 - Rust: 1.95.0
 
+## FFI and ABI Safety
+
+Changes at the Swift C bridge or Android JNI boundary are release-critical. Treat a function
+signature as an ABI contract: its parameter count, order, nullability, and pointer types must
+match exactly across every declaration, generated binding, and Rust export. In particular, never
+add an unused trailing parameter to a Rust C/JNI export, and use Objective-C object types (such as
+nullable `NSString *`) rather than untyped pointers when Swift passes Foundation values.
+
+When changing an FFI entry point, inspect and update every layer together:
+
+- the Rust `extern "C"` or JNI export;
+- `CaptureRustBridge.h` and every Swift call site, or the Kotlin `external` declaration and callers;
+- compatibility overloads exposed to Swift, Objective-C, Kotlin, or Java.
+
+Run focused bridge compilation/tests for every FFI change. Do not rely on Rust-only compilation to
+validate Swift header imports or JNI call signatures.
+
 ## Key Dependencies
 
 Depends on [shared-core](https://github.com/bitdriftlabs/shared-core) for `bd-logger`, `bd-buffer`, `bd-api`, `bd-crash-handler`, `bd-runtime`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,4 +124,6 @@ Depends on [shared-core](https://github.com/bitdriftlabs/shared-core) for `bd-lo
 
 ## Changelog
 
-Update `CHANGELOG.md` under `### Both`, `### Android`, or `### iOS` with categories: **Added**, **Changed**, **Fixed**.
+Update `CHANGELOG.md` for every user-facing behavior change under `### Both`, `### Android`,
+or `### iOS` with categories: **Added**, **Changed**, **Fixed**. Do not add an entry for CI,
+build, tooling, test-only, documentation-only, or internal changes that do not affect SDK behavior.


### PR DESCRIPTION
- [x] `CHANGELOG.md` is not applicable; this changes only contributor and review guidance.