### PR TITLE
remove dependency on ndk from gradle

### DIFF
--- a/.github/actions/android-setup/action.yaml
+++ b/.github/actions/android-setup/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: Whether to set up the local Android SDK cache needed by Gradle
     required: false
     default: "false"
+  setup-gradle-cache:
+    description: Whether to restore Gradle's dependency cache
+    required: false
+    default: "false"
   java-version:
     description: JDK version to install
     required: false
@@ -53,7 +57,7 @@ runs:
       with:
         distribution: 'zulu'
         java-version: ${{ inputs.java-version }}
-        cache: gradle
+        cache: ${{ inputs.setup-gradle-cache == 'true' && 'gradle' || '' }}
 
     - name: Accept Android SDK licenses
       if: inputs.setup-emulator == 'true'

--- a/.github/actions/setup-android-emulator/action.yaml
+++ b/.github/actions/setup-android-emulator/action.yaml
@@ -5,6 +5,10 @@ inputs:
   buildbuddy-api-key:
     description: BuildBuddy API key.
     required: false
+  setup-gradle-cache:
+    description: Whether to restore Gradle's dependency cache
+    required: false
+    default: "false"
   api-level:
     description: Android API level for the emulator.
     required: true
@@ -42,6 +46,7 @@ runs:
       uses: ./.github/actions/android-setup
       with:
         buildbuddy-api-key: ${{ inputs.buildbuddy-api-key }}
+        setup-gradle-cache: ${{ inputs.setup-gradle-cache }}
         setup-emulator: "true"
         emulator-api-level: ${{ inputs.api-level }}
         emulator-target: ${{ inputs.target }}

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -303,6 +303,7 @@ jobs:
       uses: ./.github/actions/setup-android-emulator
       with:
         buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        setup-gradle-cache: "true"
         api-level: '23'
         target: default
         arch: x86_64
@@ -347,6 +348,7 @@ jobs:
         uses: ./.github/actions/setup-android-emulator
         with:
           buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          setup-gradle-cache: "true"
           api-level: '31'
           target: default
           arch: x86_64

--- a/.github/workflows/gradle_test_app_random_native_crashes.yaml
+++ b/.github/workflows/gradle_test_app_random_native_crashes.yaml
@@ -20,10 +20,11 @@ jobs:
       - name: Checkout project sources
         uses: actions/checkout@v4
 
-      - name: Setup Android cmd line tools + NDK
+      - name: Setup Android command-line tools
         uses: ./.github/actions/android-setup
         with:
           buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+          setup-gradle-cache: "true"
           setup-emulator: 'true'
           emulator-api-level: '31'
           emulator-target: google_apis

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -202,8 +202,8 @@ native_binary(
 # Android extensions
 ####################
 
-# Android SDK/NDK inputs are hermetic for Bazel. Gradle deliberately continues to use the
-# cached local SDK installed by tools/setup_android_sdk.sh.
+# Android SDK/NDK inputs are hermetic for Bazel. Gradle uses only the cached local SDK
+# installed by tools/setup_android_sdk.sh.
 android = use_extension("@hermetic_android_toolchains//:extensions.bzl", "android", dev_dependency = True)
 android.sdk(
     build_tools_version = SDK_BUILD_TOOLS_VERSION,

--- a/platform/jvm/BUILD.bazel
+++ b/platform/jvm/BUILD.bazel
@@ -35,11 +35,30 @@ bitdrift_rust_shared_library(
             "-Clink-args=-Wl,-framework,Security",
         ],
         "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        # Gradle selects this define for variants that previously used
+        # debugSymbolLevel = "SYMBOL_TABLE". Keep the symbol table while
+        # stripping debug information without requiring Gradle's NDK tools.
+        ":strip_debug_info": ["-Cstrip=debuginfo"],
+        # Gradle selects this define for variants that previously used
+        # debugSymbolLevel = "FULL".
+        ":strip_none": ["-Cstrip=none"],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = [
         "//platform/jvm/core:capture_core",
     ],
+)
+
+config_setting(
+    name = "strip_debug_info",
+    values = {"define": "capture_rust_strip_level=debuginfo"},
+)
+
+config_setting(
+    name = "strip_none",
+    values = {"define": "capture_rust_strip_level=none"},
 )
 
 # Concatenate the proguard files from the capture and replay libraries

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -65,6 +65,14 @@ android {
         }
     }
 
+    packaging {
+        jniLibs {
+            // Bazel already selects libcapture's strip level for each build type. Preserve the
+            // generated library so Android Gradle Plugin does not invoke an NDK strip tool.
+            keepDebugSymbols += "**/libcapture.so"
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -55,11 +55,8 @@ android {
 
     defaultConfig {
         minSdk = 23
-        ndkVersion = "27.2.12479018"
         consumerProguardFiles("consumer-rules.pro")
     }
-
-    ndkVersion = "27.2.12479018"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -112,6 +112,26 @@ android {
 val bazelWorkspace = file("../../..")
 val bazelCaptureLibrary = "//platform/jvm:capture_shared"
 
+/**
+ * Controls the Rust debug information included in a Bazel-built JNI library.
+ *
+ * Gradle does not strip the library because that requires an NDK installation. Instead, this
+ * value selects the equivalent Rust linker behavior in Bazel.
+ */
+enum class BazelRustStripLevel(
+    /** The value supplied to Bazel's `capture_rust_strip_level` define, when one is needed. */
+    val bazelDefineValue: String?,
+) {
+    /** Use Bazel's default stripping behavior for the selected build configuration. */
+    DEFAULT(null),
+
+    /** Strip DWARF debug information while retaining the symbol table. */
+    DEBUG_INFO("debuginfo"),
+
+    /** Preserve all debug information and symbols. */
+    NONE("none"),
+}
+
 // Keep Gradle's historical cargo-ndk target names so existing local and CI invocations select
 // the corresponding Bazel platform and APK JNI directory together.
 data class BazelAndroidTarget(
@@ -129,7 +149,11 @@ val bazelAndroidTarget =
         else -> throw GradleException("Unsupported Rust Android target: $rustTarget")
     }
 
-fun registerBazelRustBuild(buildType: String, release: Boolean, stripLevel: String? = null) =
+fun registerBazelRustBuild(
+    buildType: String,
+    release: Boolean,
+    stripLevel: BazelRustStripLevel = BazelRustStripLevel.DEFAULT,
+) =
     tasks.register<Exec>("buildBazel${buildType.replaceFirstChar(Char::uppercase)}Rust") {
         description = "Build the $buildType Android Rust library with Bazel"
         workingDir = bazelWorkspace
@@ -142,10 +166,10 @@ fun registerBazelRustBuild(buildType: String, release: Boolean, stripLevel: Stri
         if (release) {
             args("--config=release-android")
         }
-        if (stripLevel != null) {
+        if (stripLevel.bazelDefineValue != null) {
             // Preserve the Gradle variant's debugSymbolLevel through Bazel, which owns the
             // Rust linker and does not require Gradle to install the NDK.
-            args("--define=capture_rust_strip_level=$stripLevel")
+            args("--define=capture_rust_strip_level=${stripLevel.bazelDefineValue}")
         }
     }
 
@@ -177,9 +201,11 @@ fun registerBazelRustCopy(buildType: String, buildTask: TaskProvider<out Task>) 
         }
     }
 
-val buildBazelDebugRust = registerBazelRustBuild("debug", release = false, stripLevel = "debuginfo")
+val buildBazelDebugRust =
+    registerBazelRustBuild("debug", release = false, stripLevel = BazelRustStripLevel.DEBUG_INFO)
 val buildBazelReleaseRust = registerBazelRustBuild("release", release = true)
-val buildBazelProfileableRust = registerBazelRustBuild("profileable", release = true, stripLevel = "none")
+val buildBazelProfileableRust =
+    registerBazelRustBuild("profileable", release = true, stripLevel = BazelRustStripLevel.NONE)
 val copyBazelDebugRust = registerBazelRustCopy("debug", buildBazelDebugRust)
 val copyBazelReleaseRust = registerBazelRustCopy("release", buildBazelReleaseRust)
 val copyBazelProfileableRust = registerBazelRustCopy("profileable", buildBazelProfileableRust)

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -58,6 +58,13 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    buildTypes {
+        create("profileable") {
+            initWith(getByName("release"))
+            matchingFallbacks += listOf("release")
+        }
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -114,7 +121,7 @@ val bazelAndroidTarget =
         else -> throw GradleException("Unsupported Rust Android target: $rustTarget")
     }
 
-fun registerBazelRustBuild(buildType: String, release: Boolean) =
+fun registerBazelRustBuild(buildType: String, release: Boolean, stripLevel: String? = null) =
     tasks.register<Exec>("buildBazel${buildType.replaceFirstChar(Char::uppercase)}Rust") {
         description = "Build the $buildType Android Rust library with Bazel"
         workingDir = bazelWorkspace
@@ -126,6 +133,11 @@ fun registerBazelRustBuild(buildType: String, release: Boolean) =
         )
         if (release) {
             args("--config=release-android")
+        }
+        if (stripLevel != null) {
+            // Preserve the Gradle variant's debugSymbolLevel through Bazel, which owns the
+            // Rust linker and does not require Gradle to install the NDK.
+            args("--define=capture_rust_strip_level=$stripLevel")
         }
     }
 
@@ -157,14 +169,17 @@ fun registerBazelRustCopy(buildType: String, buildTask: TaskProvider<out Task>) 
         }
     }
 
-val buildBazelDebugRust = registerBazelRustBuild("debug", release = false)
+val buildBazelDebugRust = registerBazelRustBuild("debug", release = false, stripLevel = "debuginfo")
 val buildBazelReleaseRust = registerBazelRustBuild("release", release = true)
+val buildBazelProfileableRust = registerBazelRustBuild("profileable", release = true, stripLevel = "none")
 val copyBazelDebugRust = registerBazelRustCopy("debug", buildBazelDebugRust)
 val copyBazelReleaseRust = registerBazelRustCopy("release", buildBazelReleaseRust)
+val copyBazelProfileableRust = registerBazelRustCopy("profileable", buildBazelProfileableRust)
 
 android.sourceSets {
     getByName("debug").jniLibs.srcDir(layout.buildDirectory.dir("generated/jniLibs/debug"))
     getByName("release").jniLibs.srcDir(layout.buildDirectory.dir("generated/jniLibs/release"))
+    getByName("profileable").jniLibs.srcDir(layout.buildDirectory.dir("generated/jniLibs/profileable"))
 }
 
 tasks.matching { it.name == "mergeDebugJniLibFolders" }.configureEach {
@@ -173,6 +188,10 @@ tasks.matching { it.name == "mergeDebugJniLibFolders" }.configureEach {
 
 tasks.matching { it.name == "mergeReleaseJniLibFolders" }.configureEach {
     dependsOn(copyBazelReleaseRust)
+}
+
+tasks.matching { it.name == "mergeProfileableJniLibFolders" }.configureEach {
+    dependsOn(copyBazelProfileableRust)
 }
 
 // Task to build the test JNI library (combines production + test code)

--- a/platform/jvm/gradle-test-app/build.gradle.kts
+++ b/platform/jvm/gradle-test-app/build.gradle.kts
@@ -121,8 +121,13 @@ android {
         )
     }
 
-    // This needs to be set to access the strip tools to strip the shared libraries.
-    ndkVersion = "27.2.12479018"
+    packaging {
+        jniLibs {
+            // Gradle must preserve the JNI libraries so it does not require the NDK's strip tool.
+            // Bazel controls libcapture stripping through --config=release-android.
+            keepDebugSymbols += "**/*.so"
+        }
+    }
 
     // Run lint checks on every build
     applicationVariants.configureEach {
@@ -150,10 +155,6 @@ android {
 
     buildTypes {
         debug {
-            // This can be enable to test proguard rules while debugging
-            ndk {
-                debugSymbolLevel = "SYMBOL_TABLE" // Using this to reduce output .so size
-            }
             isMinifyEnabled = false
             isShrinkResources = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
@@ -169,14 +170,6 @@ android {
         create("profileable") {
             initWith(getByName("release"))
             matchingFallbacks += listOf("release")
-            ndk {
-                debugSymbolLevel = "FULL"
-            }
-            packaging {
-                jniLibs {
-                    keepDebugSymbols += "**/*.so"
-                }
-            }
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             proguardFiles("profileable-rules.pro")
         }

--- a/tools/android_sdk_wrapper.sh
+++ b/tools/android_sdk_wrapper.sh
@@ -5,18 +5,13 @@ set -euo pipefail
 script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly script_root
 readonly android_sdk_version="4333796"
-# shellcheck source=tools/android_toolchain_versions.sh
-source "$script_root/android_toolchain_versions.sh"
-readonly ndk_version="$android_ndk_version"
 readonly softlink_root_dir="/tmp/bitdrift-android-sdk"
 readonly custom_android_home="$softlink_root_dir/android-sdk-$android_sdk_version-unarchived"
-readonly custom_android_ndk_home="$custom_android_home/ndk/$ndk_version/"
 
 "$script_root/setup_android_sdk.sh"
 
 unset ANDROID_SDK_ROOT
 
 ANDROID_HOME=$custom_android_home \
-  ANDROID_NDK_HOME=$custom_android_ndk_home \
   PATH="$custom_android_home/tools/bin:$custom_android_home/platform-tools:$PATH" \
   "$@"

--- a/tools/android_toolchain_versions.sh
+++ b/tools/android_toolchain_versions.sh
@@ -2,12 +2,11 @@
 
 # shellcheck disable=SC2034
 
-# Versions used by the local Android SDK cache for Gradle and emulator workflows.
-# MODULE.bazel carries the corresponding Bazel configuration; keep the two in sync with
+# Versions shared by the local Android SDK cache and Bazel. Bazel alone owns the NDK
+# configuration; keep these values in sync with MODULE.bazel through
 # tools/check_android_toolchain_versions.sh.
 
 readonly android_sdk_api_level="36"
 readonly android_build_tools_version="36.1.0"
-readonly android_ndk_version="27.2.12479018"
 readonly android_ndk_alias="r27c"
 readonly android_ndk_api_level="21"

--- a/tools/check_android_toolchain_versions.sh
+++ b/tools/check_android_toolchain_versions.sh
@@ -31,16 +31,8 @@ fi
 if ! grep -Fq "build-tools;\$android_build_tools_version" "$script_root/setup_android_sdk.sh"; then
   fail "the Gradle SDK setup does not install the configured build-tools"
 fi
-if ! grep -Fq "ndk;\$ndk_version" "$script_root/setup_android_sdk.sh"; then
-  fail "the Gradle SDK setup does not install the configured NDK"
-fi
-
 while IFS= read -r gradle_sdk_api; do
   [[ "$gradle_sdk_api" == "$android_sdk_api_level" ]] || fail "a Gradle project compiles against API $gradle_sdk_api, expected $android_sdk_api_level"
 done < <(find "$repo_root/platform/jvm" "$repo_root/gradle" -type f \( -name '*.gradle' -o -name '*.gradle.kts' \) -exec grep -hE 'compileSdk[[:space:]]*(=[[:space:]]*)?[0-9]+' {} + | sed -nE 's/.*compileSdk[[:space:]]*(=[[:space:]]*)?([0-9]+).*/\2/p' | sort -u)
 
-while IFS= read -r gradle_ndk_version; do
-  [[ "$gradle_ndk_version" == "$android_ndk_version" ]] || fail "a Gradle project uses NDK $gradle_ndk_version, expected $android_ndk_version"
-done < <(find "$repo_root/platform/jvm" "$repo_root/gradle" -type f \( -name '*.gradle' -o -name '*.gradle.kts' \) -exec grep -hE 'ndkVersion[[:space:]]*=[[:space:]]*"[0-9.]+"' {} + | sed -nE 's/.*ndkVersion[[:space:]]*=[[:space:]]*"([0-9.]+)".*/\1/p' | sort -u)
-
-echo "Android Bazel and Gradle toolchain versions are aligned."
+echo "Android Bazel toolchain and Gradle SDK versions are aligned."

--- a/tools/setup_android_sdk.sh
+++ b/tools/setup_android_sdk.sh
@@ -9,7 +9,6 @@ script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly script_root
 # shellcheck source=tools/android_toolchain_versions.sh
 source "$script_root/android_toolchain_versions.sh"
-readonly ndk_version="$android_ndk_version"
 repo_root="$(cd "$script_root/.." && pwd)"
 readonly repo_root
 readonly android_sdk_root_dir="$HOME/.androidbin/bitdrift-android-sdk"
@@ -37,7 +36,6 @@ readonly install_android_sdk_packages_command=(
   "$android_sdk_unarchived_dir/cmdline-tools/$cmdline_tools_version/bin/sdkmanager"
   "--install"
   "platform-tools"
-  "ndk;$ndk_version"
   "platforms;android-$android_sdk_api_level"
   "build-tools;$android_build_tools_version"
 )
@@ -67,7 +65,6 @@ function provision_android_sdk_packages() {
   local -r cached_sdkmanager="$android_sdk_unarchived_dir/cmdline-tools/latest/bin/sdkmanager"
   local -r packages_installed=(
     "$android_sdk_unarchived_dir/platform-tools"
-    "$android_sdk_unarchived_dir/ndk/$ndk_version"
     "$android_sdk_unarchived_dir/platforms/android-$android_sdk_api_level"
     "$android_sdk_unarchived_dir/build-tools/$android_build_tools_version"
   )
@@ -84,7 +81,7 @@ function provision_android_sdk_packages() {
 
     if [[ -x "$cached_sdkmanager" ]]; then
       ANDROID_HOME="$android_sdk_unarchived_dir" "$repo_root/ci/jdk_wrapper.sh" "$cached_sdkmanager" "--install" \
-        "platform-tools" "ndk;$ndk_version" "platforms;android-$android_sdk_api_level" "build-tools;$android_build_tools_version" | (grep -v = || true)
+        "platform-tools" "platforms;android-$android_sdk_api_level" "build-tools;$android_build_tools_version" | (grep -v = || true)
     else
       ANDROID_HOME="$android_sdk_unarchived_dir" "$repo_root/ci/jdk_wrapper.sh" "${install_android_cmd_line_tools[@]}" | (grep -v = || true)
       ANDROID_HOME="$android_sdk_unarchived_dir" "$repo_root/ci/jdk_wrapper.sh" "${install_android_sdk_packages_command[@]}" | (grep -v = || true)
@@ -117,13 +114,9 @@ expose_latest_cmdline_tools
 if [[ -n "${ANDROID_HOME_ENV_FILE:-}" ]]; then
   echo "$softlink_unarchived_dir" > "$ANDROID_HOME_ENV_FILE"
 fi
-if [[ -n "${ANDROID_NDK_HOME_ENV_FILE:-}" ]]; then
-  echo "$softlink_unarchived_dir/ndk/$ndk_version/" > "$ANDROID_NDK_HOME_ENV_FILE"
-fi
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   {
     echo "ANDROID_HOME=$softlink_unarchived_dir"
     echo "ANDROID_SDK_ROOT=$softlink_unarchived_dir"
-    echo "ANDROID_NDK_HOME=$softlink_unarchived_dir/ndk/$ndk_version/"
   } >> "$GITHUB_ENV"
 fi


### PR DESCRIPTION
We build the .so with Bazel so gradle doesn't need the NDK tooling

We preserve the binary stripping levels used by Gradle, allowing the level to be changed just through a Gradle config change