### PR TITLE
simplify populating reports with static metadata

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -13,7 +13,6 @@ import io.bitdrift.capture.network.ICaptureNetwork
 import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
 import io.bitdrift.capture.reports.IssueCallbackConfiguration
-import io.bitdrift.capture.reports.processor.IStreamingReportProcessor
 import io.bitdrift.capture.reports.processor.ReportProcessingSession
 import okio.IOException
 import java.io.InputStream
@@ -31,7 +30,7 @@ interface StackTraceProvider {
 }
 
 @Suppress("UndocumentedPublicClass")
-internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
+internal object CaptureJniLibrary : IBridge {
     /**
      * Loads the shared library. This is safe to call multiple times.
      */
@@ -424,9 +423,11 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
      * @param stream          The InputStream containing ANR details
      * @param timestampMillis The time at which the event took place
      * @param destinationPath Target file path to write the report
+     * @param attributes Client attributes used for dynamic report metadata
      */
     @Throws(IOException::class, IllegalArgumentException::class)
-    external override fun processAndPersistANR(
+    external fun processAndPersistANR(
+        loggerId: LoggerId,
         stream: InputStream?,
         timestampMillis: Long,
         destinationPath: String,
@@ -448,10 +449,11 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
      * @param debugId Debug id that will be used for de-minification
      * @param timestampMillis The time at which the event took place
      * @param destinationPath Target file path to write the report
-     * @param attributes Client attributes for metadata
+     * @param attributes Client attributes used for dynamic report metadata
      * @param sdkVersion bitdrift's React Native SDK version(e.g 8.1)
      */
-    external override fun processAndPersistJavaScriptError(
+    external fun processAndPersistJavaScriptError(
+        loggerId: LoggerId,
         errorName: String,
         errorMessage: String,
         stackTrace: String,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -741,6 +741,7 @@ internal class LoggerImpl(
         issueReporter?.init(
             sdkDirectory = sdkDirectory,
             clientAttributes = clientAttributes,
+            loggerId = loggerId,
             completedReportsProcessor = this,
         )
     }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IIssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IIssueReporter.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture.reports
 
+import io.bitdrift.capture.LoggerId
 import io.bitdrift.capture.attributes.IClientAttributes
 import io.bitdrift.capture.reports.processor.ICompletedReportsProcessor
 
@@ -21,6 +22,7 @@ interface IIssueReporter {
         sdkDirectory: String,
         clientAttributes: IClientAttributes,
         completedReportsProcessor: ICompletedReportsProcessor,
+        loggerId: LoggerId,
     )
 
     /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IssueReporter.kt
@@ -11,8 +11,8 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.bitdrift.capture.Capture.LOG_TAG
-import io.bitdrift.capture.CaptureJniLibrary
 import io.bitdrift.capture.IInternalLogger
+import io.bitdrift.capture.LoggerId
 import io.bitdrift.capture.attributes.IClientAttributes
 import io.bitdrift.capture.common.IBackgroundThreadHandler
 import io.bitdrift.capture.events.performance.IMemoryMetricsProvider
@@ -27,6 +27,7 @@ import io.bitdrift.capture.reports.persistence.IssueReporterStore
 import io.bitdrift.capture.reports.processor.ICompletedReportsProcessor
 import io.bitdrift.capture.reports.processor.IIssueReporterProcessor
 import io.bitdrift.capture.reports.processor.IssueReporterProcessor
+import io.bitdrift.capture.reports.processor.JniStreamingReportProcessor
 import io.bitdrift.capture.reports.processor.ReportProcessingSession
 import io.bitdrift.capture.threading.CaptureDispatchers
 import io.bitdrift.capture.utils.ConfigCache
@@ -66,6 +67,7 @@ internal class IssueReporter(
         sdkDirectory: String,
         clientAttributes: IClientAttributes,
         completedReportsProcessor: ICompletedReportsProcessor,
+        loggerId: LoggerId,
     ) {
         if (issueReporterState != NotInitialized) {
             Log.e(LOG_TAG, "Issue reporting already being initialized")
@@ -86,7 +88,14 @@ internal class IssueReporter(
 
         runCatching {
             issueReporterProcessor =
-                buildDefaultIssueReporterProcessor(sdkDirectory, clientAttributes, dateProvider, internalLogger, memoryMetricsProvider)
+                buildDefaultIssueReporterProcessor(
+                    sdkDirectory,
+                    clientAttributes,
+                    loggerId,
+                    dateProvider,
+                    internalLogger,
+                    memoryMetricsProvider,
+                )
             captureUncaughtExceptionHandler.install(this)
             processPriorReports(completedReportsProcessor)
         }.getOrElse {
@@ -200,6 +209,7 @@ internal class IssueReporter(
         fun buildDefaultIssueReporterProcessor(
             sdkDirectory: String,
             clientAttributes: IClientAttributes,
+            loggerId: LoggerId,
             dateProvider: DateProvider,
             internalLogger: IInternalLogger,
             memoryMetricsProvider: IMemoryMetricsProvider,
@@ -207,7 +217,7 @@ internal class IssueReporter(
             IssueReporterProcessor(
                 IssueReporterStore(sdkDirectory),
                 clientAttributes,
-                CaptureJniLibrary,
+                JniStreamingReportProcessor(loggerId, clientAttributes),
                 dateProvider,
                 internalLogger,
                 memoryMetricsProvider,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IStreamingReportProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IStreamingReportProcessor.kt
@@ -6,40 +6,43 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 package io.bitdrift.capture.reports.processor
 
-import io.bitdrift.capture.attributes.IClientAttributes
 import java.io.InputStream
+
+/** Immutable input for persisting an ANR report. */
+internal data class AnrReport(
+    val stream: InputStream?,
+    val timestampMillis: Long,
+    val destinationPath: String,
+    val runningState: String?,
+    val appExitDescription: String?,
+    val memoryPressureLevel: Int,
+    val isFileSizeOptimizationEnabled: Boolean,
+)
+
+/** Immutable input for persisting a JavaScript error report. */
+internal data class JavaScriptErrorReport(
+    val errorName: String,
+    val errorMessage: String,
+    val stackTrace: String,
+    val isFatal: Boolean,
+    val engine: String,
+    val debugId: String,
+    val timestampMillis: Long,
+    val destinationPath: String,
+    val sdkVersion: String,
+)
 
 /**
  * Process reports via streaming values
  */
-interface IStreamingReportProcessor {
+internal interface IStreamingReportProcessor {
     /**
      * Call to convert a trace input stream into a report file
      */
-    fun processAndPersistANR(
-        stream: InputStream?,
-        timestampMillis: Long,
-        destinationPath: String,
-        attributes: IClientAttributes,
-        runningState: String?,
-        appExitDescription: String?,
-        memoryPressureLevel: Int,
-        isFileSizeOptimizationEnabled: Boolean,
-    )
+    fun processAndPersistANR(report: AnrReport)
 
     /**
      * Call to convert a JS error trace into a fbs report file
      */
-    fun processAndPersistJavaScriptError(
-        errorName: String,
-        errorMessage: String,
-        stackTrace: String,
-        isFatal: Boolean,
-        engine: String,
-        debugId: String,
-        timestampMillis: Long,
-        destinationPath: String,
-        attributes: IClientAttributes,
-        sdkVersion: String,
-    )
+    fun processAndPersistJavaScriptError(report: JavaScriptErrorReport)
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessor.kt
@@ -84,16 +84,17 @@ internal class IssueReporterProcessor(
                 }
 
             streamingReportsProcessor.processAndPersistJavaScriptError(
-                errorName = errorName,
-                errorMessage = message,
-                stackTrace = stack,
-                isFatal = isFatalIssue,
-                engine = engine,
-                debugId = debugId,
-                timestampMillis = timestamp,
-                destinationPath = destinationPath,
-                attributes = clientAttributes,
-                sdkVersion = sdkVersion,
+                JavaScriptErrorReport(
+                    errorName = errorName,
+                    errorMessage = message,
+                    stackTrace = stack,
+                    isFatal = isFatalIssue,
+                    engine = engine,
+                    debugId = debugId,
+                    timestampMillis = timestamp,
+                    destinationPath = destinationPath,
+                    sdkVersion = sdkVersion,
+                ),
             )
         }.onFailure {
             internalLogger.logInternalError(
@@ -119,14 +120,15 @@ internal class IssueReporterProcessor(
         runCatching {
             if (fatalIssueType == ReportType.AppNotResponding) {
                 streamingReportsProcessor.processAndPersistANR(
-                    traceInputStream,
-                    timestamp,
-                    reporterIssueStore.generateFatalIssueFilePath(),
-                    clientAttributes,
-                    runningState,
-                    applicationExit.description,
-                    internalLogger.getPreviousRunMemoryPressureLevel().nativeValue,
-                    isFileSizeOptimizationEnabled,
+                    AnrReport(
+                        traceInputStream,
+                        timestamp,
+                        reporterIssueStore.generateFatalIssueFilePath(),
+                        runningState,
+                        applicationExit.description,
+                        internalLogger.getPreviousRunMemoryPressureLevel().nativeValue,
+                        isFileSizeOptimizationEnabled,
+                    ),
                 )
             } else if (fatalIssueType == ReportType.NativeCrash) {
                 val builder = FlatBufferBuilder(FBS_BUILDER_DEFAULT_SIZE)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/JniStreamingReportProcessor.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/processor/JniStreamingReportProcessor.kt
@@ -1,0 +1,47 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+package io.bitdrift.capture.reports.processor
+
+import io.bitdrift.capture.CaptureJniLibrary
+import io.bitdrift.capture.LoggerId
+import io.bitdrift.capture.attributes.IClientAttributes
+
+/** Binds JNI report persistence to the logger and dynamic client metadata used by every report. */
+internal class JniStreamingReportProcessor(
+    private val loggerId: LoggerId,
+    private val attributes: IClientAttributes,
+) : IStreamingReportProcessor {
+    override fun processAndPersistANR(report: AnrReport) {
+        CaptureJniLibrary.processAndPersistANR(
+            loggerId,
+            report.stream,
+            report.timestampMillis,
+            report.destinationPath,
+            attributes,
+            report.runningState,
+            report.appExitDescription,
+            report.memoryPressureLevel,
+            report.isFileSizeOptimizationEnabled,
+        )
+    }
+
+    override fun processAndPersistJavaScriptError(report: JavaScriptErrorReport) {
+        CaptureJniLibrary.processAndPersistJavaScriptError(
+            loggerId,
+            report.errorName,
+            report.errorMessage,
+            report.stackTrace,
+            report.isFatal,
+            report.engine,
+            report.debugId,
+            report.timestampMillis,
+            report.destinationPath,
+            attributes,
+            report.sdkVersion,
+        )
+    }
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeIssueReporter.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/fakes/FakeIssueReporter.kt
@@ -7,6 +7,7 @@
 
 package io.bitdrift.capture.fakes
 
+import io.bitdrift.capture.LoggerId
 import io.bitdrift.capture.attributes.IClientAttributes
 import io.bitdrift.capture.reports.IIssueReporter
 import io.bitdrift.capture.reports.IssueReporterState
@@ -19,6 +20,7 @@ class FakeIssueReporter(
         sdkDirectory: String,
         clientAttributes: IClientAttributes,
         completedReportsProcessor: ICompletedReportsProcessor,
+        loggerId: LoggerId,
     ) {
         // no-op
     }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/IssueReporterTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/IssueReporterTest.kt
@@ -266,6 +266,14 @@ class IssueReporterTest {
         assertThat(this).isInstanceOf(expectedType)
     }
 
+    private fun IssueReporter.init(
+        sdkDirectory: String,
+        clientAttributes: ClientAttributes,
+        completedReportsProcessor: ICompletedReportsProcessor,
+    ) {
+        init(sdkDirectory, clientAttributes, completedReportsProcessor, TEST_LOGGER_ID)
+    }
+
     private fun buildReporter(): IssueReporter =
         IssueReporter(
             internalLogger = internalLogger,
@@ -275,4 +283,8 @@ class IssueReporterTest {
             dateProvider = FakeDateProvider,
             memoryMetricsProvider = memoryMetricsProvider,
         )
+
+    private companion object {
+        const val TEST_LOGGER_ID = 1L
+    }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessorTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/reports/processor/IssueReporterProcessorTest.kt
@@ -15,7 +15,6 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -62,6 +61,8 @@ class IssueReporterProcessorTest {
     private val lifecycleOwner: LifecycleOwner = mock()
     private val issueReportCaptor = argumentCaptor<ByteArray>()
     private val reportTypeCaptor = argumentCaptor<Byte>()
+    private val anrReportCaptor = argumentCaptor<AnrReport>()
+    private val javascriptErrorReportCaptor = argumentCaptor<JavaScriptErrorReport>()
     private val throwableCaptor = argumentCaptor<Throwable>()
     private val logMessageCaptor = argumentCaptor<() -> String>()
 
@@ -275,16 +276,7 @@ class IssueReporterProcessorTest {
                 ),
         )
 
-        verify(streamingReportProcessor).processAndPersistANR(
-            eq(trace),
-            eq(FAKE_TIME_STAMP),
-            eq("/some/path/foo.cap"),
-            eq(attributes),
-            eq("foreground"),
-            isNull(),
-            any(),
-            eq(true),
-        )
+        assertAnrReport(trace, "foreground")
     }
 
     @Test
@@ -301,16 +293,7 @@ class IssueReporterProcessorTest {
                 ),
         )
 
-        verify(streamingReportProcessor).processAndPersistANR(
-            eq(trace),
-            eq(FAKE_TIME_STAMP),
-            eq("/some/path/foo.cap"),
-            eq(attributes),
-            eq("cached"),
-            isNull(),
-            any(),
-            eq(true),
-        )
+        assertAnrReport(trace, "cached")
     }
 
     @Test
@@ -327,16 +310,7 @@ class IssueReporterProcessorTest {
                 ),
         )
 
-        verify(streamingReportProcessor).processAndPersistANR(
-            eq(null),
-            eq(FAKE_TIME_STAMP),
-            eq("/some/path/foo.cap"),
-            eq(attributes),
-            eq("cached"),
-            isNull(),
-            any(),
-            eq(true),
-        )
+        assertAnrReport(null, "cached")
     }
 
     @Test
@@ -353,16 +327,7 @@ class IssueReporterProcessorTest {
                 ),
         )
 
-        verify(streamingReportProcessor).processAndPersistANR(
-            eq(trace),
-            eq(FAKE_TIME_STAMP),
-            eq("/some/path/foo.cap"),
-            eq(attributes),
-            eq("foreground_service"),
-            isNull(),
-            any(),
-            eq(true),
-        )
+        assertAnrReport(trace, "foreground_service")
     }
 
     @Test
@@ -631,7 +596,7 @@ class IssueReporterProcessorTest {
         doReturn(FAKE_FATAL_PATH).`when`(issueReporterStorage).generateFatalIssueFilePath()
         doThrow(RuntimeException("js persist failed"))
             .`when`(streamingReportProcessor)
-            .processAndPersistJavaScriptError(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+            .processAndPersistJavaScriptError(any())
 
         persistJavaScriptError(isFatalIssue = true)
 
@@ -649,16 +614,20 @@ class IssueReporterProcessorTest {
     private fun assertJavaScriptArguments(expectedFatalIssue: Boolean) {
         val expectedPath = if (expectedFatalIssue) FAKE_FATAL_PATH else FAKE_NON_FATAL_PATH
         verify(streamingReportProcessor).processAndPersistJavaScriptError(
-            errorName = eq(FAKE_ERROR_NAME),
-            errorMessage = eq(FAKE_ERROR_MESSAGE),
-            stackTrace = eq(FAKE_STACK_TRACE),
-            isFatal = eq(expectedFatalIssue),
-            engine = eq(FAKE_ENGINE_JSC),
-            debugId = eq(FAKE_DEBUG_ID),
-            timestampMillis = eq(DEFAULT_TEST_TIMESTAMP),
-            destinationPath = eq(expectedPath),
-            attributes = eq(attributes),
-            sdkVersion = eq(RN_BITDRIFT_VERSION),
+            javascriptErrorReportCaptor.capture(),
+        )
+        assertThat(javascriptErrorReportCaptor.firstValue).isEqualTo(
+            JavaScriptErrorReport(
+                FAKE_ERROR_NAME,
+                FAKE_ERROR_MESSAGE,
+                FAKE_STACK_TRACE,
+                expectedFatalIssue,
+                FAKE_ENGINE_JSC,
+                FAKE_DEBUG_ID,
+                DEFAULT_TEST_TIMESTAMP,
+                expectedPath,
+                RN_BITDRIFT_VERSION,
+            ),
         )
     }
 
@@ -703,16 +672,25 @@ class IssueReporterProcessorTest {
         doReturn("/some/path/foo.cap").`when`(issueReporterStorage).generateFatalIssueFilePath()
         doThrow(exception)
             .`when`(streamingReportProcessor)
-            .processAndPersistANR(
-                any(),
-                eq(FAKE_TIME_STAMP),
-                eq("/some/path/foo.cap"),
-                eq(attributes),
-                any(),
-                any(),
-                any(),
-                eq(true),
-            )
+            .processAndPersistANR(any())
+    }
+
+    private fun assertAnrReport(
+        stream: InputStream?,
+        runningState: String,
+    ) {
+        verify(streamingReportProcessor).processAndPersistANR(anrReportCaptor.capture())
+        assertThat(anrReportCaptor.firstValue).isEqualTo(
+            AnrReport(
+                stream,
+                FAKE_TIME_STAMP,
+                "/some/path/foo.cap",
+                runningState,
+                null,
+                MemoryPressureLevel.Warning.nativeValue,
+                true,
+            ),
+        )
     }
 
     private fun createApplicationExitInfo(

--- a/platform/jvm/core/src/jni.rs
+++ b/platform/jvm/core/src/jni.rs
@@ -847,14 +847,14 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
         device,
         store,
         network: network_manager,
-        static_metadata,
+        static_metadata: static_metadata.clone(),
         start_in_sleep_mode: start_in_sleep_mode == JNI_TRUE,
       })
       .with_internal_logger(true)
       .with_crash_report_hook(crash_report_hook)
       .build()
       .map(|(logger, _, future, _)| {
-        LoggerHolder::new(
+        LoggerHolder::new_with_static_metadata(
           logger,
           async move {
             handle_unexpected(
@@ -869,6 +869,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
             future.await
           }
           .boxed(),
+          Some(static_metadata),
         )
       })?;
 
@@ -1558,6 +1559,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processIssueRe
 pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPersistANR(
   mut env: JNIEnv<'_>,
   _class: JClass<'_>,
+  logger_id: LoggerId<'_>,
   stream: JObject<'_>,
   timestamp: jlong,
   destination: JString<'_>,
@@ -1598,17 +1600,28 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPers
     Some(&stream)
   };
 
-  match report_processing::persist_anr(
-    &mut env,
-    stream,
-    timestamp,
-    &destination,
-    &attributes,
-    running_state_str.as_deref(),
-    app_exit_description_str.as_deref(),
-    memory_pressure_level,
-    is_file_size_optimization_enabled == JNI_TRUE,
-  ) {
+  let result = logger_id
+    .static_metadata()
+    .ok_or_else(|| anyhow::anyhow!("missing static logger metadata"))
+    .and_then(|metadata| {
+      let mut context = report_processing::AndroidReportContext {
+        env: &mut env,
+        metadata,
+        attributes: &attributes,
+      };
+      let report = report_processing::AnrReport {
+        source_stream: stream,
+        timestamp_millis: timestamp,
+        destination: &destination,
+        running_state: running_state_str.as_deref(),
+        app_exit_description: app_exit_description_str.as_deref(),
+        memory_pressure_level,
+        is_file_size_optimization_enabled: is_file_size_optimization_enabled == JNI_TRUE,
+      };
+      report_processing::persist_anr(&mut context, &report)
+    });
+
+  match result {
     Ok(()) => {},
     Err(e) => {
       let message = format!("jni persist ANR: {e:#}");
@@ -1621,6 +1634,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPers
 pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPersistJavaScriptError(
   mut env: JNIEnv<'_>,
   _class: JClass<'_>,
+  logger_id: LoggerId<'_>,
   error_name: JString<'_>,
   error_message: JString<'_>,
   stack_trace: JString<'_>,
@@ -1663,19 +1677,26 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_processAndPers
         .to_string_lossy()
         .to_string();
 
-      report_processing::persist_javascript_error(
-        &mut env,
-        &error_name,
-        &error_message,
-        &stack_trace,
-        is_fatal != 0,
-        &engine,
-        &debugger_id,
-        timestamp,
-        &destination,
-        &attributes,
-        &sdk_version,
-      )?;
+      let metadata = logger_id
+        .static_metadata()
+        .ok_or_else(|| anyhow::anyhow!("missing static logger metadata"))?;
+      let mut context = report_processing::AndroidReportContext {
+        env: &mut env,
+        metadata,
+        attributes: &attributes,
+      };
+      let report = report_processing::JavaScriptErrorReport {
+        error_name: &error_name,
+        error_message: &error_message,
+        stack_trace: &stack_trace,
+        is_fatal: is_fatal != 0,
+        engine: &engine,
+        debugger_id: &debugger_id,
+        timestamp_millis: timestamp,
+        destination: &destination,
+        sdk_version: &sdk_version,
+      };
+      report_processing::persist_javascript_error(&mut context, &report)?;
       Ok(())
     },
     "jni persist JavaScript error",

--- a/platform/jvm/core/src/report_processing.rs
+++ b/platform/jvm/core/src/report_processing.rs
@@ -29,23 +29,58 @@ use platform_shared::javascript_error::{
   DeviceMetadata,
   persist_javascript_error_report,
 };
+use platform_shared::metadata::Mobile;
 use std::io::{Seek, Write};
 use std::sync::OnceLock;
 
 const BUFFER_SIZE: i32 = 8192;
 static INPUT_STREAM_READ: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_APP_ID: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_APP_VERSION: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_VERSIONCODE: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_MANUFACTURER: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_MODEL: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_OS_VERSION: OnceLock<CachedMethod> = OnceLock::new();
 static CLIENT_ATTRS_OS_BRAND: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_OS_API_LEVEL: OnceLock<CachedMethod> = OnceLock::new();
 static CLIENT_ATTRS_SUPPORTED_ABIS: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_ARCHITECTURE: OnceLock<CachedMethod> = OnceLock::new();
-static CLIENT_ATTRS_LOCALE: OnceLock<CachedMethod> = OnceLock::new();
 static CLIENT_ATTRS_LOCALE_COUNTRY_CODE: OnceLock<CachedMethod> = OnceLock::new();
+
+//
+// AndroidReportContext
+//
+
+/// Dependencies shared by Android report builders.
+pub(crate) struct AndroidReportContext<'a, 'env_local, 'metadata, 'attributes, 'object> {
+  pub env: &'a mut JNIEnv<'env_local>,
+  pub metadata: &'metadata Mobile,
+  pub attributes: &'attributes JObject<'object>,
+}
+
+//
+// AnrReport
+//
+
+/// Per-report input used to build an Android ANR report.
+pub(crate) struct AnrReport<'a, 'local> {
+  pub source_stream: Option<&'a JObject<'local>>,
+  pub timestamp_millis: jlong,
+  pub destination: &'a str,
+  pub running_state: Option<&'a str>,
+  pub app_exit_description: Option<&'a str>,
+  pub memory_pressure_level: jint,
+  pub is_file_size_optimization_enabled: bool,
+}
+
+//
+// JavaScriptErrorReport
+//
+
+/// Per-report input used to build an Android JavaScript error report.
+pub(crate) struct JavaScriptErrorReport<'a> {
+  pub error_name: &'a str,
+  pub error_message: &'a str,
+  pub stack_trace: &'a str,
+  pub is_fatal: bool,
+  pub engine: &'a str,
+  pub debugger_id: &'a str,
+  pub timestamp_millis: jlong,
+  pub destination: &'a str,
+  pub sdk_version: &'a str,
+}
 
 pub(crate) fn initialize(env: &mut JNIEnv<'_>) -> anyhow::Result<()> {
   initialize_method_handle(
@@ -59,54 +94,6 @@ pub(crate) fn initialize(env: &mut JNIEnv<'_>) -> anyhow::Result<()> {
   initialize_method_handle(
     env,
     "io/bitdrift/capture/attributes/IClientAttributes",
-    "getAppId",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_APP_ID,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getAppVersion",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_APP_VERSION,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getAppVersionCode",
-    "()J",
-    &CLIENT_ATTRS_VERSIONCODE,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getManufacturer",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_MANUFACTURER,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getModel",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_MODEL,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getOsVersion",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_OS_VERSION,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
     "getOsBrand",
     "()Ljava/lang/String;",
     &CLIENT_ATTRS_OS_BRAND,
@@ -115,33 +102,9 @@ pub(crate) fn initialize(env: &mut JNIEnv<'_>) -> anyhow::Result<()> {
   initialize_method_handle(
     env,
     "io/bitdrift/capture/attributes/IClientAttributes",
-    "getOsApiLevel",
-    "()I",
-    &CLIENT_ATTRS_OS_API_LEVEL,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
     "getSupportedAbis",
     "()Ljava/util/List;",
     &CLIENT_ATTRS_SUPPORTED_ABIS,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getArchitecture",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_ARCHITECTURE,
-  )?;
-
-  initialize_method_handle(
-    env,
-    "io/bitdrift/capture/attributes/IClientAttributes",
-    "getLocale",
-    "()Ljava/lang/String;",
-    &CLIENT_ATTRS_LOCALE,
   )?;
 
   initialize_method_handle(
@@ -156,19 +119,13 @@ pub(crate) fn initialize(env: &mut JNIEnv<'_>) -> anyhow::Result<()> {
 }
 
 pub(crate) fn persist_anr(
-  env: &mut JNIEnv<'_>,
-  source_stream: Option<&JObject<'_>>,
-  timestamp_millis: jlong,
-  destination: &str,
-  attributes: &JObject<'_>,
-  running_state: Option<&str>,
-  app_exit_description: Option<&str>,
-  memory_pressure_level: jint,
-  is_file_size_optimization_enabled: bool,
+  context: &mut AndroidReportContext<'_, '_, '_, '_, '_>,
+  report: &AnrReport<'_, '_>,
 ) -> anyhow::Result<()> {
   let mut builder = FlatBufferBuilder::new();
-  let source_file = source_stream
-    .map(|stream| read_stream_to_file(env, stream))
+  let source_file = report
+    .source_stream
+    .map(|stream| read_stream_to_file(context.env, stream))
     .transpose()?;
   let source_memmap = source_file
     .as_ref()
@@ -178,134 +135,126 @@ pub(crate) fn persist_anr(
     .as_ref()
     .map(bd_report_parsers::MemmapView::new);
   let timestamp = Timestamp::new(
-    u64::try_from(timestamp_millis / 1_000).unwrap_or_default(),
-    u32::try_from((timestamp_millis % 1_000) * 1_000).unwrap_or_default(),
+    u64::try_from(report.timestamp_millis / 1_000).unwrap_or_default(),
+    u32::try_from((report.timestamp_millis % 1_000) * 1_000).unwrap_or_default(),
   );
-  let mut device_info = build_device_metrics(env, &mut builder, attributes, &timestamp)?;
-  let mut app_info = build_app_metrics(
-    env,
-    &mut builder,
-    attributes,
-    running_state,
-    memory_pressure_level,
-  )?;
+  let mut device_info = build_device_metrics(context, &mut builder, &timestamp)?;
+  let mut app_info = build_app_metrics(context, &mut builder, report)?;
   let report_offset = bd_report_parsers::android::build_anr_from_app_exit(
     &mut builder,
     &mut app_info,
     &mut device_info,
     source_view,
-    app_exit_description,
-    is_file_size_optimization_enabled,
+    report.app_exit_description,
+    report.is_file_size_optimization_enabled,
   );
 
   builder.finish(report_offset, None);
-  std::fs::write(destination, builder.finished_data())?;
-  log::trace!("persisted report from {timestamp_millis}");
+  std::fs::write(report.destination, builder.finished_data())?;
+  log::trace!("persisted report from {}", report.timestamp_millis);
   Ok(())
 }
 
 pub(crate) fn persist_javascript_error(
-  env: &mut JNIEnv<'_>,
-  error_name: &str,
-  error_message: &str,
-  stack_trace: &str,
-  is_fatal: bool,
-  engine: &str,
-  debugger_id: &str,
-  timestamp_millis: jlong,
-  destination: &str,
-  attributes: &JObject<'_>,
-  sdk_version: &str,
+  context: &mut AndroidReportContext<'_, '_, '_, '_, '_>,
+  report: &JavaScriptErrorReport<'_>,
 ) -> anyhow::Result<()> {
-  let debug_id = if debugger_id.is_empty() {
+  let debug_id = if report.debugger_id.is_empty() {
     None
   } else {
-    Some(debugger_id)
+    Some(report.debugger_id)
   };
 
-  let timestamp_seconds = u64::try_from(timestamp_millis / 1_000).unwrap_or_default();
-  let timestamp_nanos = u32::try_from((timestamp_millis % 1_000) * 1_000).unwrap_or_default();
+  let timestamp_seconds = u64::try_from(report.timestamp_millis / 1_000).unwrap_or_default();
+  let timestamp_nanos =
+    u32::try_from((report.timestamp_millis % 1_000) * 1_000).unwrap_or_default();
 
-  let manufacturer = read_string(env, attributes, &CLIENT_ATTRS_MANUFACTURER).ok();
-  let model = read_string(env, attributes, &CLIENT_ATTRS_MODEL).ok();
-  let os_brand = read_string(env, attributes, &CLIENT_ATTRS_OS_BRAND).ok();
-  let os_version = read_string(env, attributes, &CLIENT_ATTRS_OS_VERSION).ok();
-  let architecture_str = read_string(env, attributes, &CLIENT_ATTRS_ARCHITECTURE).ok();
-  let architecture = architecture_str
-    .as_ref()
-    .map_or(Architecture::Unknown, |arch| match arch.as_str() {
-      "arm64" | "aarch64" => Architecture::arm64,
-      "x86_64" => Architecture::x86_64,
-      _ => Architecture::Unknown,
-    });
-  let cpu_abis = read_string_list(env, attributes, &CLIENT_ATTRS_SUPPORTED_ABIS).ok();
-
-  let app_id = read_string(env, attributes, &CLIENT_ATTRS_APP_ID).ok();
-  let app_version = read_string(env, attributes, &CLIENT_ATTRS_APP_VERSION).ok();
-  let version_code = CLIENT_ATTRS_VERSIONCODE
-    .get()
-    .ok_or(InvariantError::Invariant)?
-    .call_method(env, attributes, ReturnType::Primitive(Primitive::Long), &[])?
-    .j()
-    .ok();
+  let os_brand = read_string(context.env, context.attributes, &CLIENT_ATTRS_OS_BRAND).ok();
+  let architecture =
+    context
+      .metadata
+      .android_static_fields()
+      .map_or(Architecture::Unknown, |fields| {
+        match fields.architecture.as_str() {
+          "arm64" | "aarch64" => Architecture::arm64,
+          "x86_64" => Architecture::x86_64,
+          _ => Architecture::Unknown,
+        }
+      });
+  let cpu_abis = read_string_list(
+    context.env,
+    context.attributes,
+    &CLIENT_ATTRS_SUPPORTED_ABIS,
+  )
+  .ok();
 
   let device_metadata = DeviceMetadata {
-    manufacturer,
-    model,
-    os_version,
+    manufacturer: context
+      .metadata
+      .android_static_fields()
+      .map(|fields| fields.manufacturer.clone()),
+    model: Some(context.metadata.model.clone()),
+    os_version: context.metadata.os_version.clone(),
     os_brand,
     architecture: Some(architecture),
     cpu_abis,
   };
 
   let app_metadata = AppMetadata {
-    app_id,
-    app_version,
-    version_code,
+    app_id: context.metadata.app_id.clone(),
+    app_version: context.metadata.app_version.clone(),
+    version_code: context
+      .metadata
+      .android_static_fields()
+      .map(|fields| fields.app_version_code),
   };
 
   persist_javascript_error_report(
-    error_name,
-    error_message,
-    stack_trace,
-    is_fatal,
+    report.error_name,
+    report.error_message,
+    report.stack_trace,
+    report.is_fatal,
     debug_id,
     timestamp_seconds,
     timestamp_nanos,
     Platform::Android,
     "io.bitdrift.capture-android",
-    sdk_version,
-    destination,
+    report.sdk_version,
+    report.destination,
     device_metadata,
     app_metadata,
-    engine,
+    report.engine,
   )?;
 
   Ok(())
 }
 
 fn build_device_metrics<'fbb>(
-  env: &mut JNIEnv<'_>,
+  context: &mut AndroidReportContext<'_, '_, '_, '_, '_>,
   builder: &mut FlatBufferBuilder<'fbb>,
-  attributes: &JObject<'_>,
   timestamp: &'fbb Timestamp,
 ) -> anyhow::Result<DeviceMetricsArgs<'fbb>> {
-  let manufacturer = read_string(env, attributes, &CLIENT_ATTRS_MANUFACTURER)
-    .map_err(|e| anyhow::anyhow!("failed to parse manufacturer: {e}"))?;
-  let model = read_string(env, attributes, &CLIENT_ATTRS_MODEL)
-    .map_err(|e| anyhow::anyhow!("failed to parse model: {e}"))?;
-  let os_brand = read_string(env, attributes, &CLIENT_ATTRS_OS_BRAND)
+  let os_brand = read_string(context.env, context.attributes, &CLIENT_ATTRS_OS_BRAND)
     .map_err(|e| anyhow::anyhow!("failed to parse brand: {e}"))?;
-  let os_version = read_string(env, attributes, &CLIENT_ATTRS_OS_VERSION)
-    .map_err(|e| anyhow::anyhow!("failed to parse os version: {e}"))?;
+  let os_version = context
+    .metadata
+    .os_version
+    .as_deref()
+    .ok_or_else(|| anyhow::anyhow!("missing static os version"))?;
+  let manufacturer = context
+    .metadata
+    .android_static_fields()
+    .ok_or_else(|| anyhow::anyhow!("missing Android static metadata"))?
+    .manufacturer
+    .as_str();
   let os_build = OSBuildArgs {
     brand: Some(builder.create_string(&os_brand)),
-    version: Some(builder.create_string(&os_version)),
+    version: Some(builder.create_string(os_version)),
     ..Default::default()
   };
   Ok(DeviceMetricsArgs {
-    manufacturer: Some(builder.create_string(&manufacturer)),
-    model: Some(builder.create_string(&model)),
+    manufacturer: Some(builder.create_string(manufacturer)),
+    model: Some(builder.create_string(&context.metadata.model)),
     os_build: Some(OSBuild::create(builder, &os_build)),
     time: Some(timestamp),
     ..Default::default()
@@ -313,17 +262,15 @@ fn build_device_metrics<'fbb>(
 }
 
 fn build_app_metrics<'fbb>(
-  env: &mut JNIEnv<'_>,
+  context: &mut AndroidReportContext<'_, '_, '_, '_, '_>,
   builder: &mut FlatBufferBuilder<'fbb>,
-  attributes: &JObject<'_>,
-  running_state: Option<&str>,
-  memory_pressure_level: jint,
+  report: &AnrReport<'_, '_>,
 ) -> anyhow::Result<AppMetricsArgs<'fbb>> {
-  let version_code = CLIENT_ATTRS_VERSIONCODE
-    .get()
-    .ok_or(InvariantError::Invariant)?
-    .call_method(env, attributes, ReturnType::Primitive(Primitive::Long), &[])?
-    .j()?;
+  let version_code = context
+    .metadata
+    .android_static_fields()
+    .ok_or_else(|| anyhow::anyhow!("missing Android static metadata"))?
+    .app_version_code;
   let build_number = Some(AppBuildNumber::create(
     builder,
     &AppBuildNumberArgs {
@@ -331,19 +278,32 @@ fn build_app_metrics<'fbb>(
       ..Default::default()
     },
   ));
-  let app_id = read_string(env, attributes, &CLIENT_ATTRS_APP_ID)
-    .map_err(|e| anyhow::anyhow!("failed to parse app_id: {e}"))?;
-  let app_version = read_string(env, attributes, &CLIENT_ATTRS_APP_VERSION)
-    .map_err(|e| anyhow::anyhow!("failed to parse app_version: {e}"))?;
+  let app_id = context
+    .metadata
+    .app_id
+    .as_deref()
+    .ok_or_else(|| anyhow::anyhow!("missing static app id"))?;
+  let app_version = context
+    .metadata
+    .app_version
+    .as_deref()
+    .ok_or_else(|| anyhow::anyhow!("missing static app version"))?;
   // failable/optional value
-  let region_format = read_string(env, attributes, &CLIENT_ATTRS_LOCALE_COUNTRY_CODE).ok();
+  let region_format = read_string(
+    context.env,
+    context.attributes,
+    &CLIENT_ATTRS_LOCALE_COUNTRY_CODE,
+  )
+  .ok();
   Ok(AppMetricsArgs {
-    app_id: Some(builder.create_string(&app_id)),
-    version: Some(builder.create_string(&app_version)),
+    app_id: Some(builder.create_string(app_id)),
+    version: Some(builder.create_string(app_version)),
     build_number,
     region_format: region_format.map(|s| builder.create_string(&s)),
-    running_state: running_state.map(|s| builder.create_string(s)),
-    memory_pressure_level: MemoryPressureLevel(i8::try_from(memory_pressure_level).unwrap_or(0)),
+    running_state: report.running_state.map(|s| builder.create_string(s)),
+    memory_pressure_level: MemoryPressureLevel(
+      i8::try_from(report.memory_pressure_level).unwrap_or(0),
+    ),
     ..Default::default()
   })
 }

--- a/platform/shared/src/lib.rs
+++ b/platform/shared/src/lib.rs
@@ -128,6 +128,7 @@ pub struct LoggerHolder {
   handle: bd_logger::LoggerHandle,
   future: parking_lot::Mutex<Option<LoggerFuture>>,
   app_launch_tti_log: Once,
+  static_metadata: Option<Arc<metadata::Mobile>>,
 }
 
 impl Deref for LoggerHolder {
@@ -140,13 +141,29 @@ impl Deref for LoggerHolder {
 
 impl LoggerHolder {
   pub fn new(logger: bd_logger::Logger, future: LoggerFuture) -> Self {
+    Self::new_with_static_metadata(logger, future, None)
+  }
+
+  #[must_use]
+  pub fn new_with_static_metadata(
+    logger: bd_logger::Logger,
+    future: LoggerFuture,
+    static_metadata: Option<Arc<metadata::Mobile>>,
+  ) -> Self {
     let handle = logger.new_logger_handle();
     Self {
       logger,
       handle,
       future: parking_lot::Mutex::new(Some(future)),
       app_launch_tti_log: Once::new(),
+      static_metadata,
     }
+  }
+
+  /// Returns the immutable client metadata supplied while creating the logger.
+  #[must_use]
+  pub fn static_metadata(&self) -> Option<&metadata::Mobile> {
+    self.static_metadata.as_deref()
   }
 
   pub fn start(&self) {

--- a/platform/shared/src/metadata.rs
+++ b/platform/shared/src/metadata.rs
@@ -191,6 +191,15 @@ impl Mobile {
     fields.insert("model".into(), self.model.clone().into());
     fields
   }
+
+  /// Returns Android-specific immutable metadata when this is an Android client.
+  #[must_use]
+  pub const fn android_static_fields(&self) -> Option<&AndroidStaticFields> {
+    match &self.platform_static_fields {
+      PlatformStaticFields::Android(fields) => Some(fields),
+      PlatformStaticFields::Apple(_) | PlatformStaticFields::Electron => None,
+    }
+  }
 }
 
 impl bd_api::Metadata for Mobile {

--- a/platform/shared/src/metadata_test.rs
+++ b/platform/shared/src/metadata_test.rs
@@ -60,6 +60,17 @@ fn collect_inner_includes_os_version_and_android_manufacturer() {
 
   let collected = bd_api::Metadata::collect_inner(&metadata);
 
+  let android = metadata.android_static_fields();
+  assert_eq!(
+    android.map(|fields| fields.manufacturer.as_str()),
+    Some("Google")
+  );
+  assert_eq!(android.map(|fields| fields.app_version_code), Some(123));
+  assert_eq!(
+    android.map(|fields| fields.architecture.as_str()),
+    Some("arm64-v8a")
+  );
+
   assert_eq!(collected.get("os_version"), Some(&"14".to_string()));
   assert_eq!(collected.get("_manufacturer"), Some(&"Google".to_string()));
 
@@ -130,6 +141,8 @@ fn collect_inner_omits_manufacturer_for_non_android() {
   );
 
   let collected = bd_api::Metadata::collect_inner(&metadata);
+
+  assert!(metadata.android_static_fields().is_none());
 
   assert_eq!(collected.get("os_version"), Some(&"18.0".to_string()));
   assert!(!collected.contains_key("_manufacturer"));

--- a/platform/swift/source/src/bridge.rs
+++ b/platform/swift/source/src/bridge.rs
@@ -571,7 +571,7 @@ extern "C" fn capture_create_logger(
         network: network_manager,
         store,
         device,
-        static_metadata,
+        static_metadata: static_metadata.clone(),
         start_in_sleep_mode,
       })
       .with_crash_report_hook(
@@ -585,7 +585,9 @@ extern "C" fn capture_create_logger(
       )
       .with_internal_logger(true)
       .build()
-      .map(|(logger, _, future, _)| LoggerHolder::new(logger, future))?;
+      .map(|(logger, _, future, _)| {
+        LoggerHolder::new_with_static_metadata(logger, future, Some(static_metadata))
+      })?;
 
       Ok(logger.into_raw())
     },


### PR DESCRIPTION
Instead of passing ClientAttributes to the report builder and having to JNI out the values we can pull them straight from the metadata object. This avoids startup registration of these JNI handles and simplifies the code quite a bit.

The remaining values could also be moved into `Metadata` but I kept this light for now 