### PR TITLE
jni: remove new_global! macro

### DIFF
--- a/ci/run_clippy.sh
+++ b/ci/run_clippy.sh
@@ -27,7 +27,13 @@ esac
 run_clippy() {
   local build_tag_filters="$1"
   shift
-  ./bazelw build --config ci --config clippy --build_tag_filters="$build_tag_filters" "$@"
+
+  local bazel_configs=(--config clippy)
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    bazel_configs=(--config ci "${bazel_configs[@]}")
+  fi
+
+  ./bazelw build "${bazel_configs[@]}" --build_tag_filters="$build_tag_filters" "$@"
 }
 
 run_linux_runner() {

--- a/platform/jvm/core/src/executor.rs
+++ b/platform/jvm/core/src/executor.rs
@@ -94,12 +94,26 @@ impl std::fmt::Debug for ObjectHandle {
   }
 }
 
-/// Defines all Java object wrappers. All of these types are a phantom type tagged `ObjectWrapper`,
-/// which allows constructing them either as local or as global objects.
+/// Defines a wrapper around an `ObjectHandle` for a specific Java object type. This allows for the
+/// creation of a new global reference to the Java object, and provides deref implementations to
+/// allow for method calls to be made against the underlying `ObjectHandle`.
+///
+/// These wrappers are used to provide a type-safe way to interact with specific Java objects,
+/// ensuring that the correct methods are called on the correct object types. as well to provide a
+/// convenient way to implement traits.
 #[macro_export]
 macro_rules! define_object_wrapper {
   ($name:ident) => {
     pub struct $name(pub $crate::executor::ObjectHandle);
+
+    impl $name {
+      pub fn new_global(
+        env: &jni::JNIEnv<'_>,
+        object: jni::objects::JObject<'_>,
+      ) -> jni::errors::Result<Self> {
+        $crate::executor::ObjectHandle::new(env, object).map(|handle| Self(handle))
+      }
+    }
 
     impl std::ops::Deref for $name {
       type Target = $crate::executor::ObjectHandle;
@@ -114,12 +128,5 @@ macro_rules! define_object_wrapper {
         return &mut self.0;
       }
     }
-  };
-}
-
-#[macro_export]
-macro_rules! new_global {
-  ($object_type:ident, $env:expr, $object:expr) => {
-    $crate::executor::ObjectHandle::new($env, $object).map(|executor| $object_type(executor))
   };
 }

--- a/platform/jvm/core/src/jni.rs
+++ b/platform/jvm/core/src/jni.rs
@@ -15,7 +15,6 @@ use crate::{
   events,
   ffi,
   key_value_storage,
-  new_global,
   report_processing,
   resource_utilization,
   session,
@@ -480,7 +479,7 @@ impl bd_api::PlatformNetworkManager<bd_runtime::runtime::ConfigLoader> for Netwo
         )
         .and_then(|v| JValueGen::l(v).map_err(|e| anyhow!(e)))?;
 
-      Ok(Box::new(new_global!(StreamHandle, e, handle)?) as Box<dyn PlatformNetworkStream>)
+      Ok(Box::new(StreamHandle::new_global(e, handle)?) as Box<dyn PlatformNetworkStream>)
     });
 
     // At this point we should have allocated a new one but also deallocated the previous one. This
@@ -729,7 +728,7 @@ impl CrashReportHook for IssueCallbackConfigurationHandle {
 
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
-  mut env: JNIEnv<'_>,
+  env: JNIEnv<'_>,
   _class: JClass<'_>,
   directory: JString<'_>,
   api_key: JString<'_>,
@@ -760,17 +759,16 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
           .to_string(),
       );
       let network_manager = Box::new(Network {
-        handle: new_global!(NetworkHandle, &mut env, network)?,
+        handle: NetworkHandle::new_global(&env, network)?,
         active_streams: Arc::new(AtomicU32::new(0)),
       });
 
-      let preferences = new_global!(PreferencesHandle, &mut env, preferences)?;
+      let preferences = PreferencesHandle::new_global(&env, preferences)?;
       let store = Arc::new(bd_key_value::Store::new(Box::new(preferences)));
 
-      let session_strategy = Arc::new(new_global!(
-        SessionStrategyConfigurationHandle,
-        &mut env,
-        session_strategy
+      let session_strategy = Arc::new(SessionStrategyConfigurationHandle::new_global(
+        &env,
+        session_strategy,
       )?);
       let session = session_strategy.create(session_strategy.clone(), &sdk_directory)?;
 
@@ -792,7 +790,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
       ));
       let initial_ootb_fields = static_metadata.static_log_fields();
 
-      let error_reporter = Arc::new(new_global!(ErrorReporterHandle, &mut env, error_reporter)?);
+      let error_reporter = Arc::new(ErrorReporterHandle::new_global(&env, error_reporter)?);
       let error_reporter = MetadataErrorReporter::new(
         error_reporter,
         Arc::new(platform_shared::error::SessionProvider::new(
@@ -801,22 +799,19 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
         static_metadata.clone(),
       );
 
-      let resource_utilization_target = Box::new(new_global!(
-        ResourceUtilizationTargetHandler,
-        &mut env,
-        resource_utilization_target
+      let resource_utilization_target = Box::new(ResourceUtilizationTargetHandler::new_global(
+        &env,
+        resource_utilization_target,
       )?);
 
-      let session_replay_target = Box::new(new_global!(
-        SessionReplayTargetHandler,
-        &mut env,
-        session_replay_target
+      let session_replay_target = Box::new(SessionReplayTargetHandler::new_global(
+        &env,
+        session_replay_target,
       )?);
 
-      let events_listener_target = Box::new(new_global!(
-        EventsListenerTargetHandler,
-        &mut env,
-        events_listener_target
+      let events_listener_target = Box::new(EventsListenerTargetHandler::new_global(
+        &env,
+        events_listener_target,
       )?);
 
       // Errors emitted up until this point are not reported to bitdrift remote.
@@ -827,10 +822,9 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
       let crash_report_hook: Option<Arc<dyn CrashReportHook>> = if issue_report_callback.is_null() {
         None
       } else {
-        Some(Arc::new(new_global!(
-          IssueCallbackConfigurationHandle,
-          &mut env,
-          issue_report_callback
+        Some(Arc::new(IssueCallbackConfigurationHandle::new_global(
+          &env,
+          issue_report_callback,
         )?))
       };
 
@@ -839,7 +833,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
         sdk_directory,
         api_key: unsafe { env.get_string_unchecked(&api_key) }?.into(),
         session,
-        metadata_provider: Arc::new(new_global!(MetadataProvider, &mut env, metadata_provider)?),
+        metadata_provider: Arc::new(MetadataProvider::new_global(&env, metadata_provider)?),
         initial_ootb_fields,
         resource_utilization_target,
         session_replay_target,

--- a/test/platform/jvm/src/lib.rs
+++ b/test/platform/jvm/src/lib.rs
@@ -14,7 +14,6 @@ use capture_core::events::ListenerTargetHandler as EventsListenerTargetHandler;
 use capture_core::executor::ObjectHandle;
 use capture_core::jni::{ErrorReporterHandle, JValueWrapper};
 use capture_core::key_value_storage::PreferencesHandle;
-use capture_core::new_global;
 use capture_core::resource_utilization::TargetHandler as ResourceUtilizationTargetHandler;
 use capture_core::session_replay::TargetHandler as SessionReplayTargetHandler;
 use jni::JNIEnv;
@@ -419,7 +418,7 @@ pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_sendErrorMessag
     .get_string(&message)
     .expect("failed to get java string")
     .into();
-  let reporter = new_global!(ErrorReporterHandle, &mut env, error_reporter).unwrap();
+  let reporter = ErrorReporterHandle::new_global(&env, error_reporter).unwrap();
 
   reporter.report(&message, &None, &HashMap::new());
 }
@@ -454,41 +453,41 @@ pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_runLargeUploadT
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_runKeyValueStorageTest(
-  mut env: JNIEnv<'_>,
+  env: JNIEnv<'_>,
   _class: JClass<'_>,
   preferences: JObject<'_>,
 ) {
-  let storage = new_global!(PreferencesHandle, &mut env, preferences).unwrap();
+  let storage = PreferencesHandle::new_global(&env, preferences).unwrap();
   platform_test_helpers::run_key_value_storage_tests(&storage);
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_runResourceUtilizationTargetTest(
-  mut env: JNIEnv<'_>,
+  env: JNIEnv<'_>,
   _class: JClass<'_>,
   target: JObject<'_>,
 ) {
-  let target = new_global!(ResourceUtilizationTargetHandler, &mut env, target).unwrap();
+  let target = ResourceUtilizationTargetHandler::new_global(&env, target).unwrap();
   platform_test_helpers::run_resource_utilization_target_tests(&target);
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_runSessionReplayTargetTest(
-  mut env: JNIEnv<'_>,
+  env: JNIEnv<'_>,
   _class: JClass<'_>,
   target: JObject<'_>,
 ) {
-  let target = new_global!(SessionReplayTargetHandler, &mut env, target).unwrap();
+  let target = SessionReplayTargetHandler::new_global(&env, target).unwrap();
   platform_test_helpers::run_session_replay_target_tests(&target);
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Java_io_bitdrift_capture_CaptureTestJniLibrary_runEventsListenerTargetTest(
-  mut env: JNIEnv<'_>,
+  env: JNIEnv<'_>,
   _class: JClass<'_>,
   target: JObject<'_>,
 ) {
-  let target = new_global!(EventsListenerTargetHandler, &mut env, target).unwrap();
+  let target = EventsListenerTargetHandler::new_global(&env, target).unwrap();
   platform_test_helpers::run_events_listener_target_tests(&target);
 }
 


### PR DESCRIPTION
This can be done more succintly with a generated function on the type wrapper
