### PR TITLE
andr/ios: introduce initial fields and deprecate FieldProviders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@
 
 **Added**
 
-- Nothing yet!
+- Add `initialFields` to seed custom global fields during Capture SDK startup.
 
 **Changed**
 
-- Nothing yet!
+- Deprecate `FieldProvider`; use `initialFields` to seed global fields and `addField` to update them.
 
 **Fixed**
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -24,6 +24,7 @@ import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
 import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.FieldProvider
+import io.bitdrift.capture.providers.Fields
 import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
@@ -128,7 +129,8 @@ object Capture {
          * @param apiKey The API key provided by bitdrift. This is required.
          * @param sessionStrategy session strategy for the management of session id.
          * @param configuration A configuration that is used to set up Capture features.
-         * @param fieldProviders list of extra field providers to apply to all logs.
+         * @param fieldProviders list of extra field providers to apply to all logs. Deprecated; use
+         *                       [initialFields] to seed fields at startup and [addField] to update them.
          * @param dateProvider optional date provider used to override how the current timestamp is computed.
          * @param apiUrl The base URL of Capture API. Depend on its default value unless specifically
          *               instructed otherwise during discussions with bitdrift. Defaults to bitdrift's hosted
@@ -139,6 +141,7 @@ object Capture {
          *                     The callback is always called on the calling thread before [start] returns.
          *                     On success, it receives a [CaptureResult.Success] containing an [ILogger] instance.
          *                     On failure, it receives a [CaptureResult.Failure] with a [SdkStartFailure].
+         * @param initialFields fields to seed at SDK startup. Use [addField] to update their values later.
          */
         @Synchronized
         @JvmStatic
@@ -151,6 +154,7 @@ object Capture {
             dateProvider: DateProvider? = null,
             apiUrl: HttpUrl = defaultCaptureApiUrl,
             context: Context? = null,
+            initialFields: Fields = emptyMap(),
             startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
         ) {
             start(
@@ -162,6 +166,7 @@ object Capture {
                 apiUrl,
                 CaptureJniLibrary,
                 context,
+                initialFields,
                 startResult,
             )
         }
@@ -180,6 +185,7 @@ object Capture {
             apiUrl: HttpUrl = defaultCaptureApiUrl,
             bridge: IBridge,
             context: Context? = null,
+            initialFields: Fields = emptyMap(),
             startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
         ) {
             // There's nothing we can do if we don't have yet access to the application context.
@@ -202,6 +208,7 @@ object Capture {
                     bridge = bridge,
                     context = context,
                     startResult = startResult,
+                    initialFields = initialFields,
                 )
             } else {
                 Log.w(LOG_TAG, "Multiple attempts to start Capture")
@@ -685,6 +692,7 @@ object Capture {
         bridge: IBridge,
         context: Context?,
         startResult: ((CaptureResult<ILogger>) -> Unit)? = null,
+        initialFields: Fields,
     ) {
         try {
             val startSdkTimer = TimeSource.Monotonic.markNow()
@@ -712,6 +720,7 @@ object Capture {
                         apiUrl = apiUrl,
                         context = appContext,
                         fieldProviders = fieldProviders,
+                        initialFields = initialFields,
                         dateProvider = dateProvider ?: SystemDateProvider(),
                         configuration = configuration,
                         sessionStrategy = sessionStrategy,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -61,6 +61,7 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
      * @param preferences the preferences storage to use for persistent storage of simple settings and configuration.
      * @param errorReporter the error reporter to use for reporting error to bitdrift services.
      * @param startInSleepMode true to initialize in sleep mode
+     * @param initialFields fields to seed at SDK startup. Later addField calls can update them.
      */
     external override fun createLogger(
         sdkDirectory: String,
@@ -83,6 +84,7 @@ internal object CaptureJniLibrary : IBridge, IStreamingReportProcessor {
         errorReporter: IErrorReporter,
         startInSleepMode: Boolean,
         issueCallbackConfiguration: IssueCallbackConfiguration?,
+        initialFields: Array<Field>,
     ): Long
 
     /**

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IBridge.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IBridge.kt
@@ -9,6 +9,7 @@ package io.bitdrift.capture
 
 import io.bitdrift.capture.error.IErrorReporter
 import io.bitdrift.capture.network.ICaptureNetwork
+import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.session.SessionStrategyConfiguration
 import io.bitdrift.capture.reports.IssueCallbackConfiguration
 
@@ -34,5 +35,6 @@ internal interface IBridge {
         errorReporter: IErrorReporter,
         startInSleepMode: Boolean,
         issueCallbackConfiguration: IssueCallbackConfiguration?,
+        initialFields: Array<Field> = emptyArray(),
     ): Long
 }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -47,10 +47,12 @@ import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.FieldProvider
+import io.bitdrift.capture.providers.Fields
 import io.bitdrift.capture.providers.MetadataProvider
 import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.providers.session.SessionStrategy
+import io.bitdrift.capture.providers.toFieldValue
 import io.bitdrift.capture.providers.toFields
 import io.bitdrift.capture.providers.toLegacyJniFields
 import io.bitdrift.capture.reports.IssueCallbackConfiguration
@@ -84,6 +86,7 @@ internal class LoggerImpl(
     errorReporter: IErrorReporter? = null,
     configuration: Configuration,
     fieldProviders: List<FieldProvider>,
+    initialFields: Fields = emptyMap(),
     dateProvider: DateProvider,
     private val errorHandler: ErrorHandler = ErrorHandler(),
     sessionStrategy: SessionStrategy,
@@ -248,6 +251,9 @@ internal class LoggerImpl(
                 localErrorReporter,
                 configuration.sleepMode == SleepMode.ENABLED,
                 getIssueCallbackConfiguration(configuration),
+                initialFields
+                    .map { (key, value) -> Field(key, value.toFieldValue()) }
+                    .toTypedArray(),
             )
 
         check(loggerId != -1L) { "initialization of the rust logger failed" }

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/FieldProvider.kt
@@ -92,6 +92,11 @@ typealias Fields = Map<String, String>
  *
  * It is invoked inline during logging, and so should therefore avoid doing expensive or blocking work.
  */
+@Deprecated(
+    message =
+        "FieldProvider is deprecated. Use Capture.Logger.start(initialFields = ...) to seed fields at " +
+            "startup and Capture.Logger.addField(...) to update them.",
+)
 fun interface FieldProvider : () -> Fields
 
 /**

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerTest.kt
@@ -90,13 +90,14 @@ class CaptureLoggerTest {
      */
     private fun <T> withLogger(
         fieldProvider: FieldProvider? = null,
+        initialFields: Map<String, String> = emptyMap(),
         dateProvider: DateProvider = systemDateProvider,
         sessionStrategy: SessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
         context: android.content.Context = ContextHolder.APP_CONTEXT,
         windowManager: IWindowManager = WindowManager(ErrorHandler()),
         block: (LoggerImpl) -> T,
     ): T {
-        val logger = buildLogger(fieldProvider, dateProvider, sessionStrategy, context, windowManager)
+        val logger = buildLogger(fieldProvider, initialFields, dateProvider, sessionStrategy, context, windowManager)
         try {
             return block(logger)
         } finally {
@@ -313,6 +314,23 @@ class CaptureLoggerTest {
         }
 
     @Test
+    fun `initial fields are attached to logs and can be updated`(): Unit =
+        withLogger(initialFields = mapOf("initial_key" to "initial_value")) { logger ->
+            val streamId = CaptureTestJniLibrary.awaitNextApiStream()
+            assertThat(streamId).isNotEqualTo(-1)
+
+            CaptureTestJniLibrary.configureAggressiveContinuousUploads(streamId)
+            logger.addField("initial_key", "updated_value")
+            logger.log(LogLevel.DEBUG) { "test log" }
+
+            CaptureTestJniLibrary.nextUploadedLog()
+            CaptureTestJniLibrary.nextUploadedLog()
+            val log = CaptureTestJniLibrary.nextUploadedLog()
+
+            assertThat(log.fields).containsEntry("initial_key", "updated_value".toFieldValue())
+        }
+
+    @Test
     @Config(qualifiers = "+ar")
     fun `logger works end-to-end with arabic locale`(): Unit =
         withLogger { logger ->
@@ -490,6 +508,7 @@ class CaptureLoggerTest {
 
     private fun buildLogger(
         fieldProvider: FieldProvider? = null,
+        initialFields: Map<String, String> = emptyMap(),
         dateProvider: DateProvider = mock<DateProvider>(),
         sessionStrategy: SessionStrategy = SessionStrategy.Fixed { "SESSION_ID" },
         context: android.content.Context = ContextHolder.APP_CONTEXT,
@@ -501,6 +520,7 @@ class CaptureLoggerTest {
                 apiKey = "test",
                 apiUrl = testServerUrl(),
                 fieldProviders = fieldProviders,
+                initialFields = initialFields,
                 sessionStrategy = sessionStrategy,
                 context = context,
                 dateProvider = dateProvider,

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
@@ -51,6 +51,7 @@ class ConfigurationTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             ),
         ).thenReturn(-1L)
 
@@ -69,6 +70,7 @@ class ConfigurationTest {
 
         // We confirm that we actually tried to configure the logger.
         verify(bridge, times(1)).createLogger(
+            anyOrNull(),
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
@@ -124,6 +126,7 @@ class ConfigurationTest {
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
+            anyOrNull(),
         )
     }
 
@@ -135,6 +138,7 @@ class ConfigurationTest {
         val bridge: IBridge = mock {}
         whenever(
             bridge.createLogger(
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),

--- a/platform/jvm/core/src/jni.rs
+++ b/platform/jvm/core/src/jni.rs
@@ -728,7 +728,7 @@ impl CrashReportHook for IssueCallbackConfigurationHandle {
 
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
-  env: JNIEnv<'_>,
+  mut env: JNIEnv<'_>,
   _class: JClass<'_>,
   directory: JString<'_>,
   api_key: JString<'_>,
@@ -750,6 +750,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
   error_reporter: JObject<'_>,
   start_in_sleep_mode: jboolean,
   issue_report_callback: JObject<'_>,
+  initial_fields: JObject<'_>,
 ) -> jlong {
   with_handle_unexpected_or(
     || {
@@ -788,7 +789,10 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
             .to_string(),
         },
       ));
+      let initial_fields = unsafe { JObjectArray::from_raw(initial_fields.as_raw()) };
+      let initial_custom_fields = ffi::jarray_to_fields(&mut env, &initial_fields)?;
       let initial_ootb_fields = static_metadata.static_log_fields();
+      let metadata_provider = Arc::new(MetadataProvider::new_global(&env, metadata_provider)?);
 
       let error_reporter = Arc::new(ErrorReporterHandle::new_global(&env, error_reporter)?);
       let error_reporter = MetadataErrorReporter::new(
@@ -833,7 +837,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
         sdk_directory,
         api_key: unsafe { env.get_string_unchecked(&api_key) }?.into(),
         session,
-        metadata_provider: Arc::new(MetadataProvider::new_global(&env, metadata_provider)?),
+        metadata_provider,
         initial_ootb_fields,
         resource_utilization_target,
         session_replay_target,
@@ -848,7 +852,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
       .with_crash_report_hook(crash_report_hook)
       .build()
       .map(|(logger, _, future, _)| {
-        LoggerHolder::new(
+        let logger = LoggerHolder::new(
           logger,
           async move {
             handle_unexpected(
@@ -863,7 +867,15 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
             future.await
           }
           .boxed(),
-        )
+        );
+
+        // Seed the same custom-field state that addLogField updates so later calls can override
+        // these initial values.
+        for (key, value) in initial_custom_fields {
+          logger.add_log_field(key.into_owned(), value);
+        }
+
+        logger
       })?;
 
       Ok(logger.into_raw().into())

--- a/platform/swift/source/Capture.swift
+++ b/platform/swift/source/Capture.swift
@@ -40,7 +40,10 @@ extension Logger {
     /// - parameter sessionStrategy: A session strategy for the management of session ID.
     /// - parameter configuration:   A configuration that used to set up Capture features.
     /// - parameter fieldProviders:  An optional array of additional FieldProviders to include on the default
-    ///                              Logger.
+    ///                              Logger. Deprecated; use `initialFields` to seed fields at startup and
+    ///                              `addField(withKey:value:)` to update them.
+    /// - parameter initialFields:   Fields to seed at SDK startup. `addField(withKey:value:)` can update
+    ///                              their values later.
     /// - parameter dateProvider:    An optional date provider to set on the default logger.
     /// - parameter startResult:     An optional callback invoked with the result of the SDK initialization.
     ///                              The callback is always called on the calling thread before `start` returns.
@@ -53,6 +56,7 @@ extension Logger {
         sessionStrategy: SessionStrategy,
         configuration: Configuration = .init(),
         fieldProviders: [FieldProvider] = [],
+        initialFields: Fields = [:],
         dateProvider: DateProvider? = nil,
         startResult: ((Result<Logging, Swift.Error>) -> Void)? = nil
     ) -> LoggerIntegrator?
@@ -62,6 +66,7 @@ extension Logger {
             sessionStrategy: sessionStrategy,
             configuration: configuration,
             fieldProviders: fieldProviders,
+            initialFields: initialFields,
             dateProvider: dateProvider,
             loggerBridgingFactoryProvider: LoggerBridgingFactory(),
             startResult: startResult
@@ -74,6 +79,7 @@ extension Logger {
         sessionStrategy: SessionStrategy,
         configuration: Configuration,
         fieldProviders: [FieldProvider],
+        initialFields: Fields = [:],
         dateProvider: DateProvider?,
         loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider,
         startResult: ((Result<Logging, Swift.Error>) -> Void)? = nil
@@ -86,6 +92,7 @@ extension Logger {
                 sessionStrategy: sessionStrategy,
                 dateProvider: dateProvider,
                 fieldProviders: fieldProviders,
+                initialFields: initialFields,
                 loggerBridgingFactoryProvider: loggerBridgingFactoryProvider
             )
 

--- a/platform/swift/source/CaptureRustBridge.h
+++ b/platform/swift/source/CaptureRustBridge.h
@@ -37,6 +37,7 @@ void capture_report_error(const char *message);
  * @param network the Capture Network protocol to use for performing network requests.
  * @param error_reporter the error reported protocol to use for reporting errors.
  * @param start_in_sleep_mode true if sleep mode should initialize now
+ * @param initial_fields fields to seed at SDK startup; they can later be updated with addField.
  * @param issue_callback_configuration optional issue callback configuration.
  */
 logger_id capture_create_logger(
@@ -55,6 +56,7 @@ logger_id capture_create_logger(
     _Nullable id<Network> network,
     _Nullable id<RemoteErrorReporting> error_reporter,
     bool start_in_sleep_mode,
+    const NSArray<const Field *> *_Nonnull initial_fields,
     _Nullable id issue_callback_configuration
 );
 

--- a/platform/swift/source/Logger.swift
+++ b/platform/swift/source/Logger.swift
@@ -72,6 +72,7 @@ public final class Logger {
         sessionStrategy: SessionStrategy,
         dateProvider: DateProvider?,
         fieldProviders: [FieldProvider],
+        initialFields: Fields = [:],
         loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider = LoggerBridgingFactory()
     )
     {
@@ -82,6 +83,7 @@ public final class Logger {
             sessionStrategy: sessionStrategy,
             dateProvider: dateProvider,
             fieldProviders: fieldProviders,
+            initialFields: initialFields,
             storageProvider: Storage.shared,
             timeProvider: SystemTimeProvider(),
             loggerBridgingFactoryProvider: loggerBridgingFactoryProvider
@@ -119,6 +121,7 @@ public final class Logger {
         sessionStrategy: SessionStrategy,
         dateProvider: DateProvider?,
         fieldProviders: [FieldProvider],
+        initialFields: Fields = [:],
         enableNetwork: Bool = true,
         storageProvider: StorageProvider,
         timeProvider: TimeProvider,
@@ -189,6 +192,7 @@ public final class Logger {
             network: network,
             errorReporting: self.remoteErrorReporter,
             sleepMode: configuration.sleepMode,
+            initialFields: initialFields.compactMap { try? Field.make(keyValue: $0) },
             issueCallbackConfiguration: configuration.enableFatalIssueReporting
                 ? configuration.issueCallbackConfiguration
                 : nil

--- a/platform/swift/source/LoggerBridge.swift
+++ b/platform/swift/source/LoggerBridge.swift
@@ -85,6 +85,7 @@ final class LoggerBridge: LoggerBridging {
         network: Network?,
         errorReporting: RemoteErrorReporting,
         sleepMode: SleepMode,
+        initialFields: [CapturePassable.Field],
         issueCallbackConfiguration: IssueCallbackConfiguration?
     ) {
         do {
@@ -111,6 +112,7 @@ final class LoggerBridge: LoggerBridging {
             network,
             errorReporting,
             sleepMode == SleepMode.enabled,
+            initialFields,
             issueCallbackConfiguration
         )
 
@@ -145,6 +147,7 @@ final class LoggerBridge: LoggerBridging {
         network: Network?,
         errorReporting: RemoteErrorReporting,
         sleepMode: SleepMode,
+        initialFields: [CapturePassable.Field],
         issueCallbackConfiguration: IssueCallbackConfiguration?
     ) -> LoggerBridging? {
         return LoggerBridge(
@@ -163,6 +166,7 @@ final class LoggerBridge: LoggerBridging {
             network: network,
             errorReporting: errorReporting,
             sleepMode: sleepMode,
+            initialFields: initialFields,
             issueCallbackConfiguration: issueCallbackConfiguration
         )
     }

--- a/platform/swift/source/LoggerBridgingFactory.swift
+++ b/platform/swift/source/LoggerBridgingFactory.swift
@@ -24,6 +24,7 @@ final class LoggerBridgingFactory: LoggerBridgingFactoryProvider {
         network: Network?,
         errorReporting: RemoteErrorReporting,
         sleepMode: SleepMode,
+        initialFields: [CapturePassable.Field],
         issueCallbackConfiguration: IssueCallbackConfiguration?
     ) -> LoggerBridging? {
         return LoggerBridge(
@@ -42,6 +43,7 @@ final class LoggerBridgingFactory: LoggerBridgingFactoryProvider {
             network: network,
             errorReporting: errorReporting,
             sleepMode: sleepMode,
+            initialFields: initialFields,
             issueCallbackConfiguration: issueCallbackConfiguration
         )
     }

--- a/platform/swift/source/LoggerBridgingFactoryProvider.swift
+++ b/platform/swift/source/LoggerBridgingFactoryProvider.swift
@@ -26,6 +26,7 @@ protocol LoggerBridgingFactoryProvider {
     /// - parameter network:                    The interface to use for network operations.
     /// - parameter errorReporting:             The interface to use for reporting errors.
     /// - parameter sleepMode:                  .enabled if sleep mode should be initialized now.
+    /// - parameter initialFields:              Fields to seed at SDK startup and later update with addField.
     /// - parameter issueCallbackConfiguration: Optional callback configuration for issue reports.
     ///
     /// - returns: The logger bridging instance.
@@ -45,6 +46,7 @@ protocol LoggerBridgingFactoryProvider {
         network: Network?,
         errorReporting: RemoteErrorReporting,
         sleepMode: SleepMode,
+        initialFields: [CapturePassable.Field],
         issueCallbackConfiguration: IssueCallbackConfiguration?
     ) -> LoggerBridging?
 }

--- a/platform/swift/source/providers/FieldProvider.swift
+++ b/platform/swift/source/providers/FieldProvider.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 /// This interface defines the accessors to provide custom fields that will be sent alongside all log lines.
+@available(
+*,
+deprecated,
+message: "Use Logger.start(initialFields:) to seed fields at startup and Logger.addField(withKey:value:) to update them."
+)
 public protocol FieldProvider {
     /// Returns the set of fields that will be included on every log line. Keep in mind this function could be
     /// called multiple times per second so it’s recommended to access expensive fields sporadically.

--- a/platform/swift/source/src/bridge.rs
+++ b/platform/swift/source/src/bridge.rs
@@ -499,6 +499,7 @@ extern "C" fn capture_create_logger(
   bd_network_nsobject: *mut Object,
   error_reporter_ns_object: *mut Object,
   start_in_sleep_mode: bool,
+  initial_fields: *const Object,
   issue_callback_configuration: *mut Object,
 ) -> LoggerId<'static> {
   initialize_logging();
@@ -531,6 +532,7 @@ extern "C" fn capture_create_logger(
             .to_string(),
         },
       ));
+      let initial_custom_fields = unsafe { ffi::convert_fields(initial_fields) }?;
       let initial_ootb_fields = static_metadata.static_log_fields();
 
       let error_reporter = MetadataErrorReporter::new(
@@ -585,7 +587,17 @@ extern "C" fn capture_create_logger(
       )
       .with_internal_logger(true)
       .build()
-      .map(|(logger, _, future, _)| LoggerHolder::new(logger, future))?;
+      .map(|(logger, _, future, _)| {
+        let logger = LoggerHolder::new(logger, future);
+
+        // Seed the same custom-field state that addField updates so later calls can override
+        // these initial values.
+        for (key, value) in initial_custom_fields {
+          logger.add_log_field(key.into_owned(), value);
+        }
+
+        logger
+      })?;
 
       Ok(logger.into_raw())
     },

--- a/test/platform/swift/unit_integration/core/Logger+Tests.swift
+++ b/test/platform/swift/unit_integration/core/Logger+Tests.swift
@@ -16,6 +16,7 @@ extension Logger {
         sessionStrategy: SessionStrategy = .fixed(),
         dateProvider: DateProvider? = nil,
         fieldProviders: [FieldProvider] = [],
+        initialFields: Fields = [:],
         configuration: Configuration = .testConfiguration,
         loggerBridgingFactoryProvider: LoggerBridgingFactoryProvider = LoggerBridgingFactory()
     ) throws -> Logger
@@ -28,6 +29,7 @@ extension Logger {
                 sessionStrategy: sessionStrategy,
                 dateProvider: dateProvider,
                 fieldProviders: fieldProviders,
+                initialFields: initialFields,
                 storageProvider: MockStorageProvider(),
                 timeProvider: SystemTimeProvider(),
                 loggerBridgingFactoryProvider: loggerBridgingFactoryProvider

--- a/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
+++ b/test/platform/swift/unit_integration/core/network/LoggerE2ETest.swift
@@ -56,7 +56,10 @@ final class CaptureE2ENetworkTests: XCTestCase {
         self.server = nil
     }
 
-    private func setUpLogger(fieldProviders: [FieldProvider]? = nil) throws -> Logger {
+    private func setUpLogger(
+        fieldProviders: [FieldProvider]? = nil,
+        initialFields: Fields = [:]
+    ) throws -> Logger {
         self.storage = MockStorageProvider()
 
         // Use instance-based server for test isolation
@@ -78,6 +81,7 @@ final class CaptureE2ENetworkTests: XCTestCase {
                         }
                     ),
                 ],
+                initialFields: initialFields,
                 storageProvider: self.storage,
                 timeProvider: SystemTimeProvider(),
                 networkDelegateQueue: .global(qos: .userInteractive)
@@ -110,6 +114,21 @@ final class CaptureE2ENetworkTests: XCTestCase {
         ])
 
         XCTAssertEqual(logs.count, 3, "Did not find all expected initial logs")
+    }
+
+    func testInitialFieldsAreIncludedInLogs() async throws {
+        let logger = try self.setUpLogger(initialFields: ["initial_field": "initial_value"])
+
+        let streamID = try await self.server.waitForStream(testName: #function)
+        try await self.server.configureAggressiveUploads(streamId: streamID)
+
+        logger.addField(withKey: "initial_field", value: "updated_value")
+        logger.log(level: .debug, message: "initial fields")
+
+        let log = await self.server.nextUploadedLogMatching { $0.message == "initial fields" }
+        let uploadedLog = try XCTUnwrap(log, "Did not receive initial fields log")
+
+        XCTAssertEqual(uploadedLog.field(withKey: "initial_field")?.value as? String, "updated_value")
     }
 
     // swiftlint:disable:next function_body_length

--- a/test/platform/swift/unit_integration/core/network/helper/NetworkTestEnvironment.swift
+++ b/test/platform/swift/unit_integration/core/network/helper/NetworkTestEnvironment.swift
@@ -59,6 +59,7 @@ final class NetworkTestEnvironment {
                 network: network,
                 errorReporting: MockRemoteErrorReporter(),
                 sleepMode: .disabled,
+                initialFields: [],
                 issueCallbackConfiguration: nil
             )
         )

--- a/test/platform/swift/unit_integration/mocks/MockLoggerBridgingFactory.swift
+++ b/test/platform/swift/unit_integration/mocks/MockLoggerBridgingFactory.swift
@@ -33,6 +33,7 @@ public final class MockLoggerBridgingFactory: LoggerBridgingFactoryProvider {
         network _: Network?,
         errorReporting _: RemoteErrorReporting,
         sleepMode _: Capture.SleepMode,
+        initialFields _: [CapturePassable.Field],
         issueCallbackConfiguration _: IssueCallbackConfiguration?
     ) -> LoggerBridging? {
         self.makeLoggerCallsCount += 1


### PR DESCRIPTION
This adds `initialFields` to the constructor on both iOS and Android, which should make it possible to set fields that should be set from the start of the logger, then update them later on with addField. 

With this we can move to deprecate FieldProviders which are much more expensive due to high FFI overhead per field, especially on Android.