### PR TITLE
Make issueReporterState volatile for thread safety

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IssueReporter.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/reports/IssueReporter.kt
@@ -54,6 +54,9 @@ internal class IssueReporter(
     private val memoryMetricsProvider: IMemoryMetricsProvider,
 ) : IIssueReporter,
     IJvmCrashListener {
+    // written on the background worker once prior reports are processed, and read from whichever
+    // thread happens to be crashing
+    @Volatile
     @VisibleForTesting
     internal var issueReporterState: IssueReporterState = NotInitialized
         private set


### PR DESCRIPTION
Follow-up to https://github.com/bitdriftlabs/capture-sdk/pull/1101/#discussion_r3779013657: The `Initialized` write currently occurs on the background thread through a non-volatile issueReporterState, so the crashing thread is not guaranteed to observe it. 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.