### PR TITLE
perf(android): batch JNI local reference cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@
 
 **Changed**
 
-- Nothing yet!
-
 - Legacy fixed-session strategy generator callbacks have been removed. Use
   `SessionConfiguration` to provide an initial session ID.
 
@@ -34,7 +32,7 @@
 
 **Changed**
 
-- Nothing yet!
+- Reduced overhead when logging multiple string fields by batching JNI local-reference cleanup.
 
 **Fixed**
 

--- a/ci/parse_benchmark_results.py
+++ b/ci/parse_benchmark_results.py
@@ -30,6 +30,7 @@ BENCHMARKS_EXCLUDED_FROM_REPORT = frozenset(
         "logNotMatched10Fields",
         "logNotMatched50Fields",
         "logNotMatched100Fields",
+        "logNotMatched1000Fields",
     }
 )
 

--- a/ci/parse_benchmark_results.py
+++ b/ci/parse_benchmark_results.py
@@ -22,6 +22,18 @@ import re
 import sys
 
 
+# These focused cases are retained for local and CI-run diagnostics, but would otherwise add
+# short-lived, low-signal rows to every PR benchmark comment.
+BENCHMARKS_EXCLUDED_FROM_REPORT = frozenset(
+    {
+        "logNotMatched1Field",
+        "logNotMatched10Fields",
+        "logNotMatched50Fields",
+        "logNotMatched100Fields",
+    }
+)
+
+
 def format_time_ns(ns):
     """Format nanoseconds into a human-readable string."""
     if ns >= 1_000_000_000:
@@ -103,6 +115,8 @@ def parse_benchmark_json(json_path):
 
     for benchmark in benchmarks:
         name = clean_test_name(benchmark.get("name", "unknown"))
+        if name in BENCHMARKS_EXCLUDED_FROM_REPORT:
+            continue
         metrics = benchmark.get("metrics", {})
 
         # Extract time metrics (timeNs)

--- a/ci/parse_benchmark_results_test.py
+++ b/ci/parse_benchmark_results_test.py
@@ -23,6 +23,7 @@ class ParseBenchmarkResultsTest(unittest.TestCase):
                 {"name": "logNotMatched10Fields", "metrics": {}},
                 {"name": "logNotMatched50Fields", "metrics": {}},
                 {"name": "logNotMatched100Fields", "metrics": {}},
+                {"name": "logNotMatched1000Fields", "metrics": {}},
                 {"name": "logNotMatched5000Fields", "metrics": {}},
             ]
         }

--- a/ci/parse_benchmark_results_test.py
+++ b/ci/parse_benchmark_results_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# capture-sdk - bitdrift's client SDK
+# Copyright Bitdrift, Inc. All rights reserved.
+#
+# Use of this source code is governed by a source available license that can be found in the
+# LICENSE file or at:
+# https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.txt
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from parse_benchmark_results import parse_benchmark_json
+
+
+class ParseBenchmarkResultsTest(unittest.TestCase):
+    def test_excludes_focused_log_field_benchmarks_from_reports(self):
+        benchmark_data = {
+            "benchmarks": [
+                {"name": "logNotMatchedNoFields", "metrics": {}},
+                {"name": "logNotMatched1Field", "metrics": {}},
+                {"name": "logNotMatched10Fields", "metrics": {}},
+                {"name": "logNotMatched50Fields", "metrics": {}},
+                {"name": "logNotMatched100Fields", "metrics": {}},
+                {"name": "logNotMatched5000Fields", "metrics": {}},
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "benchmark.json"
+            path.write_text(json.dumps(benchmark_data))
+            results, _ = parse_benchmark_json(path)
+
+        self.assertEqual(set(results), {"logNotMatchedNoFields", "logNotMatched5000Fields"})

--- a/platform/jvm/capture/build.gradle.kts
+++ b/platform/jvm/capture/build.gradle.kts
@@ -132,8 +132,8 @@ enum class BazelRustStripLevel(
     NONE("none"),
 }
 
-// Keep Gradle's historical cargo-ndk target names so existing local and CI invocations select
-// the corresponding Bazel platform and APK JNI directory together.
+// Accept Gradle's historical cargo-ndk target names and the canonical Rust target triple so local
+// and CI invocations select the corresponding Bazel platform and APK JNI directory together.
 data class BazelAndroidTarget(
     val platform: String,
     val abi: String,
@@ -141,7 +141,8 @@ data class BazelAndroidTarget(
 
 val bazelAndroidTarget =
     when (val rustTarget = providers.gradleProperty("rust-target").getOrElse("arm64")) {
-        "arm64", "arm64-v8a" -> BazelAndroidTarget("@rules_android//:arm64-v8a", "arm64-v8a")
+        "arm64", "arm64-v8a", "aarch64-linux-android" ->
+            BazelAndroidTarget("@rules_android//:arm64-v8a", "arm64-v8a")
         "arm", "armv7", "armeabi-v7a" ->
             BazelAndroidTarget("@rules_android//:armeabi-v7a", "armeabi-v7a")
         "x86" -> BazelAndroidTarget("@rules_android//:x86", "x86")

--- a/platform/jvm/core/src/ffi.rs
+++ b/platform/jvm/core/src/ffi.rs
@@ -35,6 +35,8 @@ static FIELD_STRING: OnceLock<CachedMethod> = OnceLock::new();
 static BINARY_FIELD_BYTE_ARRAY: OnceLock<CachedMethod> = OnceLock::new();
 static STRING_FIELD_STRING: OnceLock<CachedMethod> = OnceLock::new();
 
+const STRING_ARRAY_LOCAL_REF_BATCH_SIZE: usize = 64;
+
 pub(crate) fn initialize(env: &mut JNIEnv<'_>) -> anyhow::Result<()> {
   let field_class = initialize_class(env, "io/bitdrift/capture/providers/Field", None)?;
   initialize_method_handle(
@@ -206,27 +208,33 @@ pub fn string_arrays_to_annotated_fields(
   #[allow(clippy::cast_sign_loss)]
   let mut fields = AnnotatedLogFields::with_capacity(len as usize);
 
-  for i in 0 .. len {
-    env.with_local_frame(4, |env| -> anyhow::Result<()> {
-      let key_obj = env.get_object_array_element(keys, i)?;
-      let value_obj = env.get_object_array_element(values, i)?;
+  // Converted strings are owned before each frame is popped. Processing a bounded window keeps
+  // local-reference use predictable while avoiding a frame transition for every field.
+  let batch_size = i32::try_from(STRING_ARRAY_LOCAL_REF_BATCH_SIZE)?;
+  for batch_start in (0 .. len).step_by(STRING_ARRAY_LOCAL_REF_BATCH_SIZE) {
+    let batch_end = (batch_start + batch_size).min(len);
+    env.with_local_frame((batch_end - batch_start) * 4, |env| -> anyhow::Result<()> {
+      for i in batch_start .. batch_end {
+        let key_obj = env.get_object_array_element(keys, i)?;
+        let value_obj = env.get_object_array_element(values, i)?;
 
-      let key_obj = JString::from(key_obj);
-      let key = unsafe { env.get_string_unchecked(&key_obj) }?
-        .to_string_lossy()
-        .to_string();
-      let value_obj = JString::from(value_obj);
-      let value = unsafe { env.get_string_unchecked(&value_obj) }?
-        .to_string_lossy()
-        .to_string();
+        let key_obj = JString::from(key_obj);
+        let key = unsafe { env.get_string_unchecked(&key_obj) }?
+          .to_string_lossy()
+          .to_string();
+        let value_obj = JString::from(value_obj);
+        let value = unsafe { env.get_string_unchecked(&value_obj) }?
+          .to_string_lossy()
+          .to_string();
 
-      fields.insert(
-        key.into(),
-        AnnotatedLogField {
-          value: LogFieldValue::String(value),
-          kind,
-        },
-      );
+        fields.insert(
+          key.into(),
+          AnnotatedLogField {
+            value: LogFieldValue::String(value),
+            kind,
+          },
+        );
+      }
       Ok(())
     })?;
   }

--- a/platform/jvm/core/src/ffi.rs
+++ b/platform/jvm/core/src/ffi.rs
@@ -36,6 +36,7 @@ static BINARY_FIELD_BYTE_ARRAY: OnceLock<CachedMethod> = OnceLock::new();
 static STRING_FIELD_STRING: OnceLock<CachedMethod> = OnceLock::new();
 
 const STRING_ARRAY_LOCAL_REF_BATCH_SIZE: usize = 64;
+const STRING_ARRAY_LOCAL_REFS_PER_FIELD: i32 = 2;
 
 pub(crate) fn initialize(env: &mut JNIEnv<'_>) -> anyhow::Result<()> {
   let field_class = initialize_class(env, "io/bitdrift/capture/providers/Field", None)?;
@@ -208,35 +209,39 @@ pub fn string_arrays_to_annotated_fields(
   #[allow(clippy::cast_sign_loss)]
   let mut fields = AnnotatedLogFields::with_capacity(len as usize);
 
-  // Converted strings are owned before each frame is popped. Processing a bounded window keeps
-  // local-reference use predictable while avoiding a frame transition for every field.
+  // Each array-element lookup creates one local ref, and converted strings are owned before the
+  // frame is popped. Processing a bounded window keeps local-ref use predictable while avoiding a
+  // frame transition for every field.
   let batch_size = i32::try_from(STRING_ARRAY_LOCAL_REF_BATCH_SIZE)?;
   for batch_start in (0 .. len).step_by(STRING_ARRAY_LOCAL_REF_BATCH_SIZE) {
     let batch_end = (batch_start + batch_size).min(len);
-    env.with_local_frame((batch_end - batch_start) * 4, |env| -> anyhow::Result<()> {
-      for i in batch_start .. batch_end {
-        let key_obj = env.get_object_array_element(keys, i)?;
-        let value_obj = env.get_object_array_element(values, i)?;
+    env.with_local_frame(
+      (batch_end - batch_start) * STRING_ARRAY_LOCAL_REFS_PER_FIELD,
+      |env| -> anyhow::Result<()> {
+        for i in batch_start .. batch_end {
+          let key_obj = env.get_object_array_element(keys, i)?;
+          let value_obj = env.get_object_array_element(values, i)?;
 
-        let key_obj = JString::from(key_obj);
-        let key = unsafe { env.get_string_unchecked(&key_obj) }?
-          .to_string_lossy()
-          .to_string();
-        let value_obj = JString::from(value_obj);
-        let value = unsafe { env.get_string_unchecked(&value_obj) }?
-          .to_string_lossy()
-          .to_string();
+          let key_obj = JString::from(key_obj);
+          let key = unsafe { env.get_string_unchecked(&key_obj) }?
+            .to_string_lossy()
+            .to_string();
+          let value_obj = JString::from(value_obj);
+          let value = unsafe { env.get_string_unchecked(&value_obj) }?
+            .to_string_lossy()
+            .to_string();
 
-        fields.insert(
-          key.into(),
-          AnnotatedLogField {
-            value: LogFieldValue::String(value),
-            kind,
-          },
-        );
-      }
-      Ok(())
-    })?;
+          fields.insert(
+            key.into(),
+            AnnotatedLogField {
+              value: LogFieldValue::String(value),
+              kind,
+            },
+          );
+        }
+        Ok(())
+      },
+    )?;
   }
 
   Ok(fields)

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -96,8 +96,32 @@ class LogBenchmarkTest {
 
     @Test
     fun logNotMatched5000Fields() {
+        logNotMatchedFields(5000)
+    }
+
+    @Test
+    fun logNotMatched1Field() {
+        logNotMatchedFields(1)
+    }
+
+    @Test
+    fun logNotMatched10Fields() {
+        logNotMatchedFields(10)
+    }
+
+    @Test
+    fun logNotMatched50Fields() {
+        logNotMatchedFields(50)
+    }
+
+    @Test
+    fun logNotMatched100Fields() {
+        logNotMatchedFields(100)
+    }
+
+    private fun logNotMatchedFields(fieldCount: Int) {
         startLogger()
-        val fields = buildFieldsMap(5000)
+        val fields = buildFieldsMap(fieldCount)
 
         benchmarkRule.measureRepeated {
             Capture.Logger.logInfo(fields) { LOG_MESSAGE }

--- a/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
+++ b/platform/jvm/microbenchmark/src/androidTest/java/io/bitdrift/microbenchmark/LogBenchmarkTest.kt
@@ -119,6 +119,11 @@ class LogBenchmarkTest {
         logNotMatchedFields(100)
     }
 
+    @Test
+    fun logNotMatched1000Fields() {
+        logNotMatchedFields(1000)
+    }
+
     private fun logNotMatchedFields(fieldCount: Int) {
         startLogger()
         val fields = buildFieldsMap(fieldCount)


### PR DESCRIPTION
Batches string-field conversion in bounded 64-entry JNI local-reference frames, avoiding a frame transition for every field. Each batch reserves only its 128 actual element refs, and `aarch64-linux-android` maps to the arm64 Gradle build. Focused field benchmarks remain available for diagnostics but are omitted from the CI PR report.

On the same locally connected Pixel 9a, the 64-entry frame improved the 10/50/100-field samples by 6.8%/7.7%/7.4%, respectively. An API 23 arm64 emulator also passed the 100- and 1000-field scenarios without local-reference or CheckJNI errors.