### PR TITLE
perf(android): move default timestamps into native logger

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/Capture.kt
@@ -24,7 +24,6 @@ import io.bitdrift.capture.network.HttpRequestInfo
 import io.bitdrift.capture.network.HttpResponseInfo
 import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.FieldProvider
-import io.bitdrift.capture.providers.SystemDateProvider
 import io.bitdrift.capture.providers.session.SessionConfiguration
 import io.bitdrift.capture.providers.session.SessionStrategy
 import io.bitdrift.capture.reports.exitinfo.PreviousRunInfo
@@ -761,7 +760,7 @@ object Capture {
                         apiUrl = apiUrl,
                         context = appContext,
                         fieldProviders = fieldProviders,
-                        dateProvider = dateProvider ?: SystemDateProvider(),
+                        dateProvider = dateProvider,
                         configuration = configuration,
                         sessionStrategy = sessionStrategy,
                         bridge = bridge,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/CaptureJniLibrary.kt
@@ -48,6 +48,7 @@ internal object CaptureJniLibrary : IBridge {
      * to disable inactivity-driven rotation.
      * @param sessionCallback optional recipient for session ID changes.
      * @param metadataProvider used to provide metadata for emitted logs.
+     * @param timestampProvider optional custom timestamp provider; null uses the native system clock.
      * @param resourceUtilizationTarget used to inform platform layer about a need to emit a resource log.
      * @param sessionReplayTarget used to inform platform layer about a need to emit session replay logs.
      * @param eventsListenerTarget responsible for listening to platform events and emitting logs in response to them.
@@ -71,6 +72,7 @@ internal object CaptureJniLibrary : IBridge {
         inactivityTimeoutMilliseconds: Long,
         sessionCallback: SessionCallback?,
         metadataProvider: IMetadataProvider,
+        timestampProvider: ITimestampProvider?,
         resourceUtilizationTarget: IResourceUtilizationTarget,
         sessionReplayTarget: ISessionReplayTarget,
         eventsListenerTarget: IEventsListenerTarget,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IBridge.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IBridge.kt
@@ -20,6 +20,7 @@ internal interface IBridge {
         inactivityTimeoutMilliseconds: Long,
         sessionCallback: SessionCallback?,
         metadataProvider: IMetadataProvider,
+        timestampProvider: ITimestampProvider?,
         resourceUtilizationTarget: IResourceUtilizationTarget,
         sessionReplayTarget: ISessionReplayTarget,
         eventsListenerTarget: IEventsListenerTarget,

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IMetadataProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/IMetadataProvider.kt
@@ -11,14 +11,9 @@ import io.bitdrift.capture.providers.Field
 
 /**
  * Used to allow the logger to call back up into the platform layer to determine the current
- * group and timestamp.
+ * fields.
  */
 internal interface IMetadataProvider {
-    /**
-     * Returns the current ms since UTC epoch using the active DateProvider.
-     */
-    fun timestamp(): Long
-
     /**
      * Returns out of the box fields to be included with emitted logs. Out of the box fields
      * are fields that come from the SDK itself.

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ITimestampProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/ITimestampProvider.kt
@@ -1,0 +1,14 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture
+
+/** Provides an optional custom timestamp to the native logger. */
+internal fun interface ITimestampProvider {
+    /** Returns the current milliseconds since the UTC epoch. */
+    fun timestamp(): Long
+}

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/LoggerImpl.kt
@@ -48,6 +48,8 @@ import io.bitdrift.capture.providers.DateProvider
 import io.bitdrift.capture.providers.Field
 import io.bitdrift.capture.providers.FieldProvider
 import io.bitdrift.capture.providers.MetadataProvider
+import io.bitdrift.capture.providers.SystemDateProvider
+import io.bitdrift.capture.providers.TimestampProvider
 import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.providers.session.SessionStrategy
@@ -84,7 +86,7 @@ internal class LoggerImpl(
     errorReporter: IErrorReporter? = null,
     configuration: Configuration,
     fieldProviders: List<FieldProvider>,
-    dateProvider: DateProvider,
+    dateProvider: DateProvider?,
     private val errorHandler: ErrorHandler = ErrorHandler(),
     sessionStrategy: SessionStrategy,
     context: Context,
@@ -113,6 +115,8 @@ internal class LoggerImpl(
     internal val webViewConfiguration: WebViewConfiguration? = configuration.webViewConfiguration
 
     private val metadataProvider: MetadataProvider
+    private val timestampProvider = dateProvider?.let(::TimestampProvider)
+    private val effectiveDateProvider = dateProvider ?: SystemDateProvider()
     private val sdkDirectory: String
     private val batteryMonitor = BatteryMonitor(context)
     private val powerMonitor = PowerMonitor(context)
@@ -149,7 +153,7 @@ internal class LoggerImpl(
         if (configuration.enableFatalIssueReporting) {
             IssueReporter(
                 internalLogger = this,
-                dateProvider = dateProvider,
+                dateProvider = effectiveDateProvider,
                 latestAppExitInfoProvider = latestAppExitInfoProvider,
                 captureUncaughtExceptionHandler = captureUncaughtExceptionHandler,
                 memoryMetricsProvider = memoryMetricsProvider,
@@ -166,7 +170,6 @@ internal class LoggerImpl(
 
         metadataProvider =
             MetadataProvider(
-                dateProvider = dateProvider,
                 // order of providers matters in here, the earlier in the list the higher their priority in
                 // case of key conflicts.
                 ootbFieldProviders =
@@ -229,6 +232,7 @@ internal class LoggerImpl(
                 sessionConfiguration.inactivityTimeout?.inWholeMilliseconds ?: -1L,
                 sessionConfiguration.makeSessionCallback(),
                 metadataProvider,
+                timestampProvider,
                 // TODO(Augustyniak): Pass `resourceUtilizationTarget`, `sessionReplayTarget`,
                 //  and `eventsListenerTarget` as part of `startLogger` method call instead.
                 // Pass the event listener target here and finish setting up

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/MetadataProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/MetadataProvider.kt
@@ -12,14 +12,11 @@ import io.bitdrift.capture.ErrorHandler
 import io.bitdrift.capture.IMetadataProvider
 
 internal class MetadataProvider(
-    private val dateProvider: DateProvider,
     private val ootbFieldProviders: List<FieldProvider>,
     private val customFieldProviders: List<FieldProvider>,
     private val errorHandler: ErrorHandler,
     private val errorLog: ((String, Throwable) -> Unit) = { message, throwable -> Log.w("capture", message, throwable) },
 ) : IMetadataProvider {
-    override fun timestamp(): Long = dateProvider.invoke().time
-
     override fun ootbFields(): Array<Field> = fields(ootbFieldProviders)
 
     override fun customFields(): Array<Field> = fields(customFieldProviders)

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/TimestampProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/providers/TimestampProvider.kt
@@ -1,0 +1,16 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.providers
+
+import io.bitdrift.capture.ITimestampProvider
+
+internal class TimestampProvider(
+    private val dateProvider: DateProvider,
+) : ITimestampProvider {
+    override fun timestamp(): Long = dateProvider.invoke().time
+}

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/CaptureLoggerNetworkTest.kt
@@ -21,7 +21,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.util.Date
 
 class CaptureLoggerNetworkTest {
     init {
@@ -39,8 +38,6 @@ class CaptureLoggerNetworkTest {
     private val okHttpClient = OkHttpClient()
 
     class TestMetadataProvider : IMetadataProvider {
-        override fun timestamp(): Long = Date().time
-
         override fun ootbFields(): Array<Field> = emptyArray()
 
         override fun customFields(): Array<Field> = emptyArray()
@@ -91,6 +88,7 @@ class CaptureLoggerNetworkTest {
             inactivityTimeoutMilliseconds = -1L,
             sessionCallback = null,
             metadataProvider = loggerBridge,
+            timestampProvider = null,
             resourceUtilizationTarget = mock(),
             sessionReplayTarget = mock(),
             eventsListenerTarget = mock(),

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/ConfigurationTest.kt
@@ -54,6 +54,7 @@ class ConfigurationTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
             ),
         ).thenReturn(-1L)
 
@@ -72,6 +73,7 @@ class ConfigurationTest {
 
         // We confirm that we actually tried to configure the logger.
         verify(bridge, times(1)).createLogger(
+            anyOrNull(),
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
@@ -131,6 +133,7 @@ class ConfigurationTest {
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
+            anyOrNull(),
         )
     }
 
@@ -142,6 +145,7 @@ class ConfigurationTest {
         val bridge: IBridge = mock {}
         whenever(
             bridge.createLogger(
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/MetadataProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/MetadataProviderTest.kt
@@ -10,16 +10,11 @@ package io.bitdrift.capture.providers
 import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.Mockito.`when`
-import java.util.Date
 
 class MetadataProviderTest {
     @Suppress("TooGenericExceptionThrown")
     @Test
     fun metadata_provider_processes_field_providers_in_order_and_swallows_exceptions() {
-        val dateProvider = mock<DateProvider>()
-        `when`(dateProvider.invoke()).thenReturn(Date())
-
         // Processing of field providers continues even if one of them throws
         // an exception.
         val throwingFieldProvider1 =
@@ -41,7 +36,6 @@ class MetadataProviderTest {
             }
         val metadataProvider =
             MetadataProvider(
-                dateProvider = dateProvider,
                 ootbFieldProviders = listOf(throwingFieldProvider1, workingFieldProviders1),
                 customFieldProviders = listOf(throwingFieldProvider2, workingFieldProviders2),
                 errorHandler = mock { },

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/TimestampProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/providers/TimestampProviderTest.kt
@@ -1,0 +1,21 @@
+// capture-sdk - bitdrift's client SDK
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+package io.bitdrift.capture.providers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.Date
+
+class TimestampProviderTest {
+    @Test
+    fun timestamp_uses_custom_date_provider() {
+        val timestampProvider = TimestampProvider(DateProvider { Date(123L) })
+
+        assertThat(timestampProvider.timestamp()).isEqualTo(123L)
+    }
+}

--- a/platform/jvm/core/src/jni.rs
+++ b/platform/jvm/core/src/jni.rs
@@ -10,6 +10,7 @@
 mod tests;
 
 use crate::events::ListenerTargetHandler as EventsListenerTargetHandler;
+use crate::executor::ObjectHandle;
 use crate::key_value_storage::PreferencesHandle;
 use crate::resource_utilization::TargetHandler as ResourceUtilizationTargetHandler;
 use crate::session::SessionCallback;
@@ -199,9 +200,9 @@ impl CachedClass {
 
 // Cached method IDs
 
-static METADATA_PROVIDER_TIMESTAMP: OnceLock<CachedMethod> = OnceLock::new();
 static METADATA_PROVIDER_OOTB_FIELDS: OnceLock<CachedMethod> = OnceLock::new();
 static METADATA_PROVIDER_CUSTOM_FIELDS: OnceLock<CachedMethod> = OnceLock::new();
+static TIMESTAMP_PROVIDER_TIMESTAMP: OnceLock<CachedMethod> = OnceLock::new();
 
 static NETWORK_START_STREAM: OnceLock<CachedMethod> = OnceLock::new();
 
@@ -300,16 +301,19 @@ fn jni_load_inner(vm: &JavaVM) -> anyhow::Result<jint> {
   initialize_method_handle(
     &mut env,
     &metadata_provider.class,
-    "timestamp",
-    "()J",
-    &METADATA_PROVIDER_TIMESTAMP,
-  )?;
-  initialize_method_handle(
-    &mut env,
-    &metadata_provider.class,
     "ootbFields",
     "()[Lio/bitdrift/capture/providers/Field;",
     &METADATA_PROVIDER_OOTB_FIELDS,
+  )?;
+
+  let timestamp_provider =
+    initialize_class(&mut env, "io/bitdrift/capture/ITimestampProvider", None)?;
+  initialize_method_handle(
+    &mut env,
+    &timestamp_provider.class,
+    "timestamp",
+    "()J",
+    &TIMESTAMP_PROVIDER_TIMESTAMP,
   )?;
   initialize_method_handle(
     &mut env,
@@ -632,13 +636,35 @@ impl bd_error_reporter::reporter::Reporter for ErrorReporterHandle {
   }
 }
 
-define_object_wrapper!(MetadataProvider);
+struct MetadataProvider {
+  fields: ObjectHandle,
+  timestamp: Option<ObjectHandle>,
+}
+
+impl MetadataProvider {
+  fn new_global(
+    env: &JNIEnv<'_>,
+    fields: JObject<'_>,
+    timestamp: JObject<'_>,
+  ) -> jni::errors::Result<Self> {
+    Ok(Self {
+      fields: ObjectHandle::new(env, fields)?,
+      timestamp: (!timestamp.is_null())
+        .then(|| ObjectHandle::new(env, timestamp))
+        .transpose()?,
+    })
+  }
+}
 
 impl bd_logger::MetadataProvider for MetadataProvider {
   #[allow(clippy::cast_possible_truncation)]
   fn timestamp(&self) -> anyhow::Result<time::OffsetDateTime> {
-    self.execute(|e, provider| {
-      let millis_since_utc_epoch = METADATA_PROVIDER_TIMESTAMP
+    let Some(timestamp_provider) = &self.timestamp else {
+      return native_timestamp();
+    };
+
+    timestamp_provider.execute(|e, provider| {
+      let millis_since_utc_epoch = TIMESTAMP_PROVIDER_TIMESTAMP
         .get()
         .ok_or(InvariantError::Invariant)?
         .call_method(e, provider, ReturnType::Primitive(Primitive::Long), &[])?
@@ -649,7 +675,7 @@ impl bd_logger::MetadataProvider for MetadataProvider {
   }
 
   fn fields(&self) -> anyhow::Result<(LogFields, LogFields)> {
-    self.execute(|e, provider| {
+    self.fields.execute(|e, provider| {
       let ootb_fields = METADATA_PROVIDER_OOTB_FIELDS
         .get()
         .ok_or(InvariantError::Invariant)?
@@ -742,6 +768,7 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
   inactivity_timeout_milliseconds: jlong,
   session_callback: JObject<'_>,
   metadata_provider: JObject<'_>,
+  timestamp_provider: JObject<'_>,
   resource_utilization_target: JObject<'_>,
   session_replay_target: JObject<'_>,
   events_listener_target: JObject<'_>,
@@ -853,7 +880,11 @@ pub extern "system" fn Java_io_bitdrift_capture_CaptureJniLibrary_createLogger(
         sdk_directory,
         api_key: unsafe { env.get_string_unchecked(&api_key) }?.into(),
         session,
-        metadata_provider: Arc::new(MetadataProvider::new_global(&env, metadata_provider)?),
+        metadata_provider: Arc::new(MetadataProvider::new_global(
+          &env,
+          metadata_provider,
+          timestamp_provider,
+        )?),
         initial_ootb_fields,
         initial_custom_fields: [].into(),
         resource_utilization_target,
@@ -1837,4 +1868,8 @@ fn unix_milliseconds_to_date(millis_since_utc_epoch: i64) -> anyhow::Result<Offs
   let nano = (millis_since_utc_epoch % 1000) * 10_i64.pow(6);
 
   Ok(time::OffsetDateTime::from_unix_timestamp(seconds)? + Duration::nanoseconds(nano))
+}
+
+fn native_timestamp() -> anyhow::Result<OffsetDateTime> {
+  unix_milliseconds_to_date(date_to_unix_milliseconds(Some(OffsetDateTime::now_utc())))
 }

--- a/platform/jvm/core/src/jni_test.rs
+++ b/platform/jvm/core/src/jni_test.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use super::initialize_class;
+use super::{initialize_class, native_timestamp};
 use crate::test_jvm::with_env;
 use anyhow::Result;
 
@@ -24,4 +24,10 @@ fn initialize_class_clears_failed_lookup_exception() -> Result<()> {
     assert!(!env.exception_check()?);
     Ok(())
   })
+}
+
+#[test]
+fn native_timestamp_has_millisecond_precision() -> Result<()> {
+  assert_eq!(native_timestamp()?.nanosecond() % 1_000_000, 0);
+  Ok(())
 }


### PR DESCRIPTION
This third PR separates field metadata from optional timestamp callbacks. Default Android logging now passes no timestamp provider and obtains the millisecond-precision wall clock in Rust; a supplied DateProvider remains a JVM callback.

On the connected Pixel 9a running Android 16, the no-field median was 508.7 ns for the parent and 512.5 ns for this PR, a 0.7% difference within run variation (1.2–1.6% CV), so this refactor has no measurable no-field performance win. This PR measured 6.556 µs at 10 fields and 29.871 µs at 50 fields. Each benchmark completed and produced valid JSON before the known AndroidX Benchmark IsolationActivity teardown timeout.