### PR TITLE
andr; screenshot fix: revert 'screen' field to 'screen_px'

### DIFF
--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/SessionReplayTarget.kt
@@ -130,6 +130,6 @@ internal class SessionReplayTarget(
     ): Array<Field> =
         combineJniFields(
             metrics.toArray().toFields(),
-            jniFieldsOf("screen" to compressedScreen.toFieldValue()),
+            jniFieldsOf("screen_px" to compressedScreen.toFieldValue()),
         )
 }


### PR DESCRIPTION
Expected field name for screenshots is screen_px in the front-end plus matches what iOS sends. This was a regression caused by https://github.com/bitdriftlabs/capture-sdk/pull/805/changes#diff-d8abe077b96925f8355b39d4f8875b9c5257700b955a00bf831a1a0f7fa60099R135

Fixes BIT-9738

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.