### PR TITLE
[Android] [gradle plugin] Support `BITDRIFT_API_KEY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 **Changed**
 
+- Updated the `bd` CLI bundled with capture-plugin from version `0.1.37` to `0.2.23`.
 - Reduced overhead when logging multiple string fields by batching JNI local-reference cleanup.
 
 **Fixed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 **Added**
 
-- Nothing yet!
+- Added support for `BITDRIFT_API_KEY` when uploading ProGuard mappings using capture-plugin. `API_KEY` remains supported for compatibility.
 
 **Changed**
 

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
@@ -37,11 +37,17 @@ abstract class CLIUploadMappingTask : CLITask() {
         val appId = manifest.getAttribute("package")
         val versionCode = manifest.getAttribute("android:versionCode")
         val versionName = manifest.getAttribute("android:versionName")
+        val apiKey = System.getenv("BITDRIFT_API_KEY") ?: System.getenv("API_KEY")
+        checkNotNull(apiKey) {
+            "Environment variable BITDRIFT_API_KEY or API_KEY must be set to your Bitdrift API key before running this task"
+        }
 
         runBDCLI(
             listOf(
                 "debug-files",
                 "upload-proguard",
+                "--api-key",
+                apiKey,
                 "--app-id",
                 appId,
                 "--app-version",
@@ -105,7 +111,6 @@ abstract class CLITask : DefaultTask() {
         get() = BDCLIDownloader(bdcliFile)
 
     fun runBDCLI(args: List<String>) {
-        checkEnvironment()
         downloader.downloadIfNeeded()
         runCommand(listOf(bdcliFile.absolutePath) + withBaseDomain(args))
     }
@@ -130,12 +135,6 @@ abstract class CLITask : DefaultTask() {
         }
     }
 
-    private fun checkEnvironment() {
-        val apiKeyEnvName = "API_KEY"
-        if (System.getenv(apiKeyEnvName) == null) {
-            throw IllegalStateException("Environment variable $apiKeyEnvName must be set to your Bitdrift API key before running this task")
-        }
-    }
 }
 
 class BDCLIDownloader(

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
@@ -37,11 +37,17 @@ abstract class CLIUploadMappingTask : CLITask() {
         val appId = manifest.getAttribute("package")
         val versionCode = manifest.getAttribute("android:versionCode")
         val versionName = manifest.getAttribute("android:versionName")
+        val apiKey = System.getenv("BITDRIFT_API_KEY") ?: System.getenv("API_KEY")
+        checkNotNull(apiKey) {
+            "Environment variable BITDRIFT_API_KEY or API_KEY must be set to your bitdrift API key before running this task"
+        }
 
         runBDCLI(
             listOf(
                 "debug-files",
                 "upload-proguard",
+                "--api-key",
+                apiKey,
                 "--app-id",
                 appId,
                 "--app-version",
@@ -105,7 +111,6 @@ abstract class CLITask : DefaultTask() {
         get() = BDCLIDownloader(bdcliFile)
 
     fun runBDCLI(args: List<String>) {
-        checkEnvironment()
         downloader.downloadIfNeeded()
         runCommand(listOf(bdcliFile.absolutePath) + withBaseDomain(args))
     }
@@ -130,12 +135,6 @@ abstract class CLITask : DefaultTask() {
         }
     }
 
-    private fun checkEnvironment() {
-        val apiKeyEnvName = "API_KEY"
-        if (System.getenv(apiKeyEnvName) == null) {
-            throw IllegalStateException("Environment variable $apiKeyEnvName must be set to your Bitdrift API key before running this task")
-        }
-    }
 }
 
 class BDCLIDownloader(

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
@@ -39,7 +39,7 @@ abstract class CLIUploadMappingTask : CLITask() {
         val versionName = manifest.getAttribute("android:versionName")
         val apiKey = System.getenv("BITDRIFT_API_KEY") ?: System.getenv("API_KEY")
         checkNotNull(apiKey) {
-            "Environment variable BITDRIFT_API_KEY or API_KEY must be set to your Bitdrift API key before running this task"
+            "Environment variable BITDRIFT_API_KEY or API_KEY must be set to your bitdrift API key before running this task"
         }
 
         runBDCLI(

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
@@ -140,7 +140,7 @@ abstract class CLITask : DefaultTask() {
 class BDCLIDownloader(
     val executableFilePath: File,
 ) {
-    val bdcliVersion = "0.1.37"
+    val bdcliVersion = "0.2.23"
     val bdcliDownloadLoc: URI = URI.create("https://dl.bitdrift.io/bd-cli/$bdcliVersion/${downloadFilename()}/bd")
 
     private enum class OSType {

--- a/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/task/CLITaskTest.kt
+++ b/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/task/CLITaskTest.kt
@@ -34,6 +34,24 @@ class CLITaskTest {
         val result = runGradle(projectDir, "bdUploadMapping")
         assertTrue(result.output.contains("BUILD SUCCESSFUL"))
         assertTrue(recordedArgs.readText().contains("--base-domain api.bitdrift.dev"))
+        assertTrue(recordedArgs.readText().contains("--api-key test-api-key"))
+    }
+
+    @Test
+    fun `falls back to legacy API key environment variable`() {
+        val projectDir = tempDir.root
+        val buildDir = File(projectDir, "build")
+        val binDir = File(buildDir, "bin")
+        val recordedArgs = File(buildDir, "bd-cli-args.txt")
+
+        writeSettingsFile(projectDir)
+        writeBuildFile(projectDir)
+        writeManifestAndMappingFiles(buildDir)
+        writeFakeBdExecutable(binDir, recordedArgs)
+
+        val result = runGradle(projectDir, "bdUploadMapping", environment = mapOf("API_KEY" to "legacy-api-key"))
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+        assertTrue(recordedArgs.readText().contains("--api-key legacy-api-key"))
     }
 
     private fun writeSettingsFile(projectDir: File) {
@@ -129,12 +147,13 @@ class CLITaskTest {
     private fun runGradle(
         projectDir: File,
         vararg args: String,
+        environment: Map<String, String> = mapOf("BITDRIFT_API_KEY" to "test-api-key"),
     ): BuildResult =
         GradleRunner
             .create()
             .withProjectDir(projectDir)
             .withArguments(*args, "-Pandroid.injected.build.api=33", "-Pandroid.injected.build.abi=arm64-v8a")
             .withPluginClasspath()
-            .withEnvironment(mapOf("API_KEY" to "test-api-key"))
+            .withEnvironment(environment)
             .build()
 }


### PR DESCRIPTION
## Problem

Resolves BIT-9723

- Current `API_KEY` can conflict with other env variables that a customer may have.

## Solution 

- Add `BITDRIFT_API_KEY` to differentiate
- Also updates bd-cli version to latest published version `(0.2.23)`

## Verification 

- Unit tests
- maven local 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.