### PR TITLE
[Android] [gradle plugin] Support BITDRIFT_API_KEY (follow ups)

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -51,7 +51,7 @@ jobs:
         id: gradle_check
         uses: ./.github/actions/files-changed
         with:
-          regex: '^(platform/jvm/gradle-test-app/.*\.(gradle|kts|kt|xml)|platform/jvm/capture/src/test/.*)$'
+          regex: '^(platform/jvm/(capture-plugin/.*|gradle-test-app/.*\.(gradle|kts|kt|xml))|platform/jvm/capture/src/test/.*)$'
 
       - name: Check for Cargo.toml changes
         id: cargo_check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,11 @@
 
 **Added**
 
-- Added support for `BITDRIFT_API_KEY` when uploading ProGuard mappings using capture-plugin. `API_KEY` remains supported for compatibility.
+- Added support for `BITDRIFT_API_KEY` in capture-plugin debug-file upload tasks. `API_KEY` remains supported for compatibility.
 
 **Changed**
 
-- Updated the `bd` CLI bundled with capture-plugin from version `0.1.37` to `0.2.23`.
+- Updated the `bd` CLI bundled with capture-plugin from version `0.1.37` to `0.2.23`. The plugin refreshes a cached CLI when its pinned version changes.
 - Reduced overhead when logging multiple string fields by batching JNI local-reference cleanup.
 
 **Fixed**

--- a/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
+++ b/platform/jvm/capture-plugin/src/main/kotlin/io/bitdrift/capture/task/CLITask.kt
@@ -8,6 +8,7 @@
 package io.bitdrift.capture.task
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
@@ -37,17 +38,11 @@ abstract class CLIUploadMappingTask : CLITask() {
         val appId = manifest.getAttribute("package")
         val versionCode = manifest.getAttribute("android:versionCode")
         val versionName = manifest.getAttribute("android:versionName")
-        val apiKey = System.getenv("BITDRIFT_API_KEY") ?: System.getenv("API_KEY")
-        checkNotNull(apiKey) {
-            "Environment variable BITDRIFT_API_KEY or API_KEY must be set to your bitdrift API key before running this task"
-        }
 
         runBDCLI(
             listOf(
                 "debug-files",
                 "upload-proguard",
-                "--api-key",
-                apiKey,
                 "--app-id",
                 appId,
                 "--app-version",
@@ -110,18 +105,23 @@ abstract class CLITask : DefaultTask() {
     val downloader: BDCLIDownloader
         get() = BDCLIDownloader(bdcliFile)
 
-    fun runBDCLI(args: List<String>) {
-        downloader.downloadIfNeeded()
-        runCommand(listOf(bdcliFile.absolutePath) + withBaseDomain(args))
-    }
+    /**
+     * Runs the bd CLI with the given command arguments. Global flags (`--base-domain` and
+     * `--api-key`) are added here, so callers must not include them.
+     *
+     * The API key is resolved and validated before anything is downloaded, so a misconfigured
+     * build fails immediately instead of after fetching the binary.
+     */
+    fun runBDCLI(subcommand: List<String>) {
+        val apiKey = envOrNull(BITDRIFT_API_KEY_ENV_VAR_NAME)
+            ?: envOrNull(DEPRECATED_API_KEY_ENV_VAR_NAME)
+            ?: throw GradleException(
+                "Environment variable $BITDRIFT_API_KEY_ENV_VAR_NAME or $DEPRECATED_API_KEY_ENV_VAR_NAME must be set with a non-empty bitdrift API key before running this task."
+            )
 
-    private fun withBaseDomain(args: List<String>): List<String> {
-        val baseDomain = baseDomain.orNull?.trim().orEmpty()
-        return if (baseDomain.isNotEmpty()) {
-            listOf("--base-domain", baseDomain) + args
-        } else {
-            args
-        }
+        downloader.downloadIfNeeded()
+
+        runCommand(listOf(bdcliFile.absolutePath) + globalArguments(apiKey) + subcommand)
     }
 
     fun runCommand(command: List<String>) {
@@ -131,14 +131,40 @@ abstract class CLITask : DefaultTask() {
                 .start()
         process.inputStream.transferTo(System.out)
         if (process.waitFor() != 0) {
-            throw RuntimeException("Command $command failed")
+            throw GradleException("Command ${command.maskedCommandArguments()} failed")
         }
     }
 
+    private fun envOrNull(name: String): String? =
+        System.getenv(name)?.takeIf { it.isNotBlank() }
+
+    private fun globalArguments(apiKey: String): List<String> {
+        val apiKeyArguments = listOf(API_KEY_FLAG, apiKey)
+
+        val baseDomain = baseDomain.orNull?.trim().orEmpty()
+        return if (baseDomain.isNotEmpty()) {
+            listOf(BASE_DOMAIN_FLAG, baseDomain) + apiKeyArguments
+        } else {
+            apiKeyArguments
+        }
+    }
+
+    private fun List<String>.maskedCommandArguments(): List<String> =
+        mapIndexed { index, argument ->
+            if (index > 0 && this[index - 1] == API_KEY_FLAG) "*****" else argument
+        }
+
+    private companion object {
+        private const val API_KEY_FLAG = "--api-key"
+        private const val BASE_DOMAIN_FLAG = "--base-domain"
+        private const val BITDRIFT_API_KEY_ENV_VAR_NAME = "BITDRIFT_API_KEY"
+        private const val DEPRECATED_API_KEY_ENV_VAR_NAME = "API_KEY"
+    }
 }
 
 class BDCLIDownloader(
     val executableFilePath: File,
+    private val download: (URI) -> ByteArray = { it.toURL().readBytes() },
 ) {
     val bdcliVersion = "0.2.23"
     val bdcliDownloadLoc: URI = URI.create("https://dl.bitdrift.io/bd-cli/$bdcliVersion/${downloadFilename()}/bd")
@@ -174,7 +200,7 @@ class BDCLIDownloader(
 
     fun downloadIfNeeded() {
         synchronized(lock) {
-            if (executableFilePath.exists()) return
+            if (isCurrentVersionInstalled()) return
 
             val parentDir = executableFilePath.parentFile
             if (!parentDir.exists() && !parentDir.mkdirs()) {
@@ -188,13 +214,14 @@ class BDCLIDownloader(
                 StandardOpenOption.WRITE,
             ).use { fileChannel ->
                 fileChannel.lock().use {
-                    if (executableFilePath.exists()) return
+                    if (isCurrentVersionInstalled()) return
 
                     val tempPath = parentDir.toPath().resolve("bd.${UUID.randomUUID()}.tmp")
                     try {
-                        Files.write(tempPath, bdcliDownloadLoc.toURL().readBytes())
+                        Files.write(tempPath, download(bdcliDownloadLoc))
                         tempPath.markAsExecutable()
                         tempPath.moveSafelyTo(executableFilePath.toPath())
+                        cliVersionFile().writeText(bdcliVersion)
                     } catch (e: Exception) {
                         runCatching { Files.deleteIfExists(tempPath) }
                         throw IOException(
@@ -206,6 +233,11 @@ class BDCLIDownloader(
             }
         }
     }
+
+    private fun isCurrentVersionInstalled(): Boolean =
+        executableFilePath.exists() && cliVersionFile().takeIf(File::exists)?.readText()?.trim() == bdcliVersion
+
+    private fun cliVersionFile(): File = File(executableFilePath.parentFile, "bd.version")
 
     private fun Path.moveSafelyTo(dest: Path) {
         try {

--- a/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/task/BDCLIDownloaderTest.kt
+++ b/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/task/BDCLIDownloaderTest.kt
@@ -15,7 +15,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -23,7 +22,7 @@ class BDCLIDownloaderTest {
     @get:Rule
     val tempDir = TemporaryFolder()
 
-    @Ignore("TODO(FRAN): BIT-7392 To resolve this flaky test")
+    @Test
     fun `downloadIfNeeded does not throw when called concurrently`() {
         val binDir = tempDir.newFolder("bin")
         val bdFile = File(binDir, "bd")
@@ -34,12 +33,13 @@ class BDCLIDownloaderTest {
         val doneLatch = CountDownLatch(threadCount)
 
         val errorCounter = AtomicInteger(0)
-
         repeat(threadCount) {
             executor.submit {
                 try {
                     startLatch.await()
-                    val downloader = BDCLIDownloader(bdFile)
+                    val downloader = BDCLIDownloader(bdFile) {
+                        "bd".toByteArray()
+                    }
                     downloader.downloadIfNeeded()
                 } catch (e: Exception) {
                     errorCounter.incrementAndGet()
@@ -56,7 +56,26 @@ class BDCLIDownloaderTest {
         assertEquals(0, errorCounter.get())
         assertTrue(bdFile.exists())
         assertTrue(bdFile.isFile)
+        assertEquals("0.2.23", File(binDir, "bd.version").readText())
         val tempFiles = binDir.listFiles()?.filter { it.name.endsWith(".tmp") } ?: emptyList()
         assertTrue(tempFiles.isEmpty())
+    }
+
+    @Test
+    fun `downloadIfNeeded replaces an older CLI version`() {
+        val binDir = tempDir.newFolder("bin")
+        val bdFile = File(binDir, "bd")
+        bdFile.writeText("old-bd")
+        File(binDir, "bd.version").writeText("0.1.37")
+        val downloadCount = AtomicInteger(0)
+
+        BDCLIDownloader(bdFile) {
+            downloadCount.incrementAndGet()
+            "new-bd".toByteArray()
+        }.downloadIfNeeded()
+
+        assertEquals(1, downloadCount.get())
+        assertEquals("new-bd", bdFile.readText())
+        assertEquals("0.2.23", File(binDir, "bd.version").readText())
     }
 }

--- a/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/task/CLITaskTest.kt
+++ b/platform/jvm/capture-plugin/src/test/kotlin/io/bitdrift/capture/task/CLITaskTest.kt
@@ -13,6 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CLITaskTest {
@@ -52,6 +53,74 @@ class CLITaskTest {
         val result = runGradle(projectDir, "bdUploadMapping", environment = mapOf("API_KEY" to "legacy-api-key"))
         assertTrue(result.output.contains("BUILD SUCCESSFUL"))
         assertTrue(recordedArgs.readText().contains("--api-key legacy-api-key"))
+    }
+
+    @Test
+    fun `uses BITDRIFT API key for source map uploads`() {
+        val projectDir = tempDir.root
+        val buildDir = File(projectDir, "build")
+        val binDir = File(buildDir, "bin")
+        val recordedArgs = File(buildDir, "bd-cli-args.txt")
+
+        writeSettingsFile(projectDir)
+        writeBuildFile(projectDir)
+        writeSourceMapFiles(buildDir)
+        writeFakeBdExecutable(binDir, recordedArgs)
+
+        val result = runGradle(projectDir, "bdUploadSourceMap")
+        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+        assertTrue(recordedArgs.readText().contains("--api-key test-api-key"))
+    }
+
+    @Test
+    fun `requires a non-empty API key for every upload task`() {
+        val projectDir = tempDir.root
+        val buildDir = File(projectDir, "build")
+        val binDir = File(buildDir, "bin")
+        val recordedArgs = File(buildDir, "bd-cli-args.txt")
+
+        writeSettingsFile(projectDir)
+        writeBuildFile(projectDir)
+        writeManifestAndMappingFiles(buildDir)
+        writeNativeLibraries(buildDir)
+        writeSourceMapFiles(buildDir)
+        writeFakeBdExecutable(binDir, recordedArgs)
+
+        listOf("bdUploadMapping", "bdUploadSymbols", "bdUploadSourceMap").forEach { task ->
+            val result = runGradle(projectDir, task, environment = emptyMap(), shouldFail = true)
+            assertTrue(
+                result.output.contains(
+                    "Environment variable BITDRIFT_API_KEY or API_KEY must be set with a non-empty bitdrift API key before running this task.",
+                ),
+            )
+        }
+
+        val result =
+            runGradle(
+                projectDir,
+                "bdUploadMapping",
+                environment = mapOf("BITDRIFT_API_KEY" to "   "),
+                shouldFail = true,
+            )
+        assertTrue(result.output.contains("must be set with a non-empty bitdrift API key"))
+    }
+
+    @Test
+    fun `masks API keys when the CLI command fails`() {
+        val projectDir = tempDir.root
+        val buildDir = File(projectDir, "build")
+        val binDir = File(buildDir, "bin")
+        val recordedArgs = File(buildDir, "bd-cli-args.txt")
+        val apiKey = "secret-api-key"
+
+        writeSettingsFile(projectDir)
+        writeBuildFile(projectDir)
+        writeManifestAndMappingFiles(buildDir)
+        writeFakeBdExecutable(binDir, recordedArgs, exitCode = 1)
+
+        val result = runGradle(projectDir, "bdUploadMapping", environment = mapOf("BITDRIFT_API_KEY" to apiKey), shouldFail = true)
+        assertTrue(result.output.contains("--base-domain, api.bitdrift.dev, --api-key, *****, debug-files, upload-proguard"))
+        assertFalse(result.output.contains(apiKey))
     }
 
     private fun writeSettingsFile(projectDir: File) {
@@ -128,9 +197,26 @@ class CLITaskTest {
         File(mappingDir, "mapping.txt").writeText("# mapping\n")
     }
 
+    private fun writeSourceMapFiles(buildDir: File) {
+        val sourceMapFile = File(buildDir, "generated/sourcemaps/react/release/index.android.bundle.map")
+        sourceMapFile.parentFile.mkdirs()
+        sourceMapFile.writeText("{}\n")
+
+        val bundleFile = File(buildDir, "generated/assets/createBundleReleaseJsAndAssets/index.android.bundle")
+        bundleFile.parentFile.mkdirs()
+        bundleFile.writeText("console.log('test')\n")
+    }
+
+    private fun writeNativeLibraries(buildDir: File) {
+        val nativeLibsDir = File(buildDir, "intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/arm64-v8a")
+        nativeLibsDir.mkdirs()
+        File(nativeLibsDir, "libtest.so").writeText("test\n")
+    }
+
     private fun writeFakeBdExecutable(
         binDir: File,
         recordedArgs: File,
+        exitCode: Int = 0,
     ) {
         binDir.mkdirs()
         val bd = File(binDir, "bd")
@@ -138,22 +224,25 @@ class CLITaskTest {
             """
             #!/bin/sh
             echo "$@" > "${recordedArgs.absolutePath}"
-            exit 0
+            exit $exitCode
             """.trimIndent() + "\n",
         )
         bd.setExecutable(true)
+        File(binDir, "bd.version").writeText("0.2.23")
     }
 
     private fun runGradle(
         projectDir: File,
         vararg args: String,
         environment: Map<String, String> = mapOf("BITDRIFT_API_KEY" to "test-api-key"),
-    ): BuildResult =
-        GradleRunner
+        shouldFail: Boolean = false,
+    ): BuildResult {
+        val runner = GradleRunner
             .create()
             .withProjectDir(projectDir)
             .withArguments(*args, "-Pandroid.injected.build.api=33", "-Pandroid.injected.build.abi=arm64-v8a")
             .withPluginClasspath()
             .withEnvironment(environment)
-            .build()
+        return if (shouldFail) runner.buildAndFail() else runner.build()
+    }
 }

--- a/tools/setup_android_sdk.sh
+++ b/tools/setup_android_sdk.sh
@@ -81,8 +81,26 @@ function provision_android_sdk_packages() {
   if [[ ! -d "$package_path" ]]; then
     accept_licenses
 
-    ANDROID_HOME="$android_sdk_unarchived_dir" "$sdkmanager" "--install" \
-      "platform-tools" "platforms;android-$android_sdk_api_level" "build-tools;$android_build_tools_version" | (grep -v = || true)
+    local -r packages=(
+      "platform-tools"
+      "platforms;android-$android_sdk_api_level"
+      "build-tools;$android_build_tools_version"
+    )
+    local attempt
+
+    for attempt in 1 2; do
+      if ANDROID_HOME="$android_sdk_unarchived_dir" "$sdkmanager" "--install" "${packages[@]}"; then
+        return
+      fi
+
+      if [[ "$attempt" == 1 ]]; then
+        echo "Android SDK package installation failed; retrying once." >&2
+        sleep 5
+      fi
+    done
+
+    echo "Android SDK package installation failed after two attempts." >&2
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Follow up to https://github.com/bitdriftlabs/capture-sdk/pull/1169

Resolves BIT-9723, BIT-7392

- Make sure the env var api key check also applies to other commands like `bdUploadSourceMap` and `bdUploadSymbols`
- Ensure the expected latest version is installed
- Run related capture-plugin tests on CI
- Fix flaky test 

## Verification
- JUnit tests
- Manual verification via maven local publish (downloaded old cli version, passing empty api key, etc)

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.