### PR TITLE
[Android] [gradle-test-app] Add option to fill disk

### DIFF
--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -120,6 +120,12 @@ sealed class StressTestAction : AppAction {
     data class TriggerStrictModeViolation(val type: StrictModeViolationType) : StressTestAction()
 
     data class TriggerScreenReplayCapture(val activity: android.app.Activity) : StressTestAction()
+
+    object FillDiskSpace : StressTestAction()
+
+    object ClearDiskSpace : StressTestAction()
+
+    object RefreshDiskSpace : StressTestAction()
 }
 
 enum class StrictModeViolationType(val displayName: String) {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/AppState.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/AppState.kt
@@ -15,13 +15,26 @@ data class AppState(
     val session: SessionState = SessionState(),
     val diagnostics: DiagnosticsState = DiagnosticsState(),
     val globalFields: List<GlobalFieldEntry> = emptyList(),
-    val diskPressure: DiskPressureState = DiskPressureState(),
+    val diskPressure: DiskPressureState = DiskPressureState.Loading,
     val isLoading: Boolean = false,
     val error: String? = null,
 )
 
-data class DiskPressureState(
-    val availableBytes: Long? = null,
-    val isFilling: Boolean = false,
-    val error: String? = null,
-)
+sealed interface DiskPressureState {
+    data object Loading : DiskPressureState
+
+    data object UnsupportedDevice : DiskPressureState
+
+    data class Ready(
+        val availableBytes: Long,
+    ) : DiskPressureState
+
+    data class Filling(
+        val availableBytes: Long,
+    ) : DiskPressureState
+
+    data class Failed(
+        val availableBytes: Long,
+        val message: String,
+    ) : DiskPressureState
+}

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/AppState.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/AppState.kt
@@ -15,6 +15,13 @@ data class AppState(
     val session: SessionState = SessionState(),
     val diagnostics: DiagnosticsState = DiagnosticsState(),
     val globalFields: List<GlobalFieldEntry> = emptyList(),
+    val diskPressure: DiskPressureState = DiskPressureState(),
     val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+data class DiskPressureState(
+    val availableBytes: Long? = null,
+    val isFilling: Boolean = false,
     val error: String? = null,
 )

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
@@ -16,6 +16,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.StatFs
 import android.os.StrictMode
+import android.os.Build
 import android.view.Gravity
 import android.view.View
 import android.view.Window
@@ -51,13 +52,24 @@ class StressTestRepository(
     private val oomList = mutableListOf<ByteArray>()
     private var memoryPressureThread: Thread? = null
 
+    private val isDiskPressureAvailable: Boolean by lazy {
+        // "ranchu"   — QEMU2-based AVD, the default since Android Studio 2.x
+        // "goldfish" — legacy QEMU1 AVD, still reported by very old system images
+        Build.HARDWARE == "ranchu" || Build.HARDWARE == "goldfish"
+    }
+
     fun fillDiskSpace(): Flow<DiskPressureState> =
         flow {
+            if (!isDiskPressureAvailable) {
+                emit(DiskPressureState.UnsupportedDevice)
+                return@flow
+            }
+
             val fillerFile = File(context.filesDir, DISK_FILLER_FILE_NAME)
             val buffer = ByteArray(DISK_FILL_CHUNK_SIZE_BYTES)
             var availableBytes = clearDiskSpaceFile()
 
-            emit(DiskPressureState(availableBytes = availableBytes, isFilling = true))
+            emit(DiskPressureState.Filling(availableBytes))
 
             try {
                 FileOutputStream(fillerFile).use { output ->
@@ -65,28 +77,35 @@ class StressTestRepository(
                         currentCoroutineContext().ensureActive()
                         output.write(buffer)
                         availableBytes = availableDiskSpace()
-                        emit(DiskPressureState(availableBytes = availableBytes, isFilling = true))
+                        emit(DiskPressureState.Filling(availableBytes))
                     }
                 }
             } catch (e: IOException) {
                 emit(
-                    DiskPressureState(
+                    DiskPressureState.Failed(
                         availableBytes = availableDiskSpace(),
-                        error = e.message ?: "Disk write failed",
+                        message = e.message ?: "Disk write failed",
                     ),
                 )
                 return@flow
             }
 
-            emit(DiskPressureState(availableBytes = availableBytes))
+            emit(DiskPressureState.Ready(availableBytes))
         }.flowOn(Dispatchers.IO)
 
     fun clearDiskSpace(): Flow<DiskPressureState> =
-        flow { emit(DiskPressureState(availableBytes = clearDiskSpaceFile())) }.flowOn(Dispatchers.IO)
+        flow {
+            emit(
+                DiskPressureState.Ready(clearDiskSpaceFile()),
+            )
+        }.flowOn(Dispatchers.IO)
 
     fun refreshDiskSpace(): DiskPressureState =
-        DiskPressureState(availableBytes = availableDiskSpace())
+        diskPressureReadyState()
 
+    private fun diskPressureReadyState(): DiskPressureState =
+        if (isDiskPressureAvailable) DiskPressureState.Ready(availableDiskSpace()) else DiskPressureState.UnsupportedDevice
+    
     private fun clearDiskSpaceFile(): Long {
         File(context.filesDir, DISK_FILLER_FILE_NAME).delete()
         return availableDiskSpace()
@@ -333,7 +352,7 @@ class StressTestRepository(
                 1,
                 WindowManager.LayoutParams.TYPE_APPLICATION_PANEL,
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
-                    WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
                 PixelFormat.TRANSLUCENT,
             ).apply { this.token = token }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/StressTestRepository.kt
@@ -14,6 +14,7 @@ import android.graphics.PixelFormat
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.os.StatFs
 import android.os.StrictMode
 import android.view.Gravity
 import android.view.View
@@ -25,21 +26,71 @@ import android.widget.TextView
 import android.widget.Toast
 import io.bitdrift.capture.Capture
 import io.bitdrift.gradletestapp.diagnostics.fatalissues.FatalIssueGenerator
+import io.bitdrift.gradletestapp.data.model.DiskPressureState
 import io.bitdrift.gradletestapp.data.model.StrictModeViolationType
 import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.URL
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 class StressTestRepository(
     private val context: Context,
 ) {
     private val oomList = mutableListOf<ByteArray>()
     private var memoryPressureThread: Thread? = null
+
+    fun fillDiskSpace(): Flow<DiskPressureState> =
+        flow {
+            val fillerFile = File(context.filesDir, DISK_FILLER_FILE_NAME)
+            val buffer = ByteArray(DISK_FILL_CHUNK_SIZE_BYTES)
+            var availableBytes = clearDiskSpaceFile()
+
+            emit(DiskPressureState(availableBytes = availableBytes, isFilling = true))
+
+            try {
+                FileOutputStream(fillerFile).use { output ->
+                    while (availableBytes > 0) {
+                        currentCoroutineContext().ensureActive()
+                        output.write(buffer)
+                        availableBytes = availableDiskSpace()
+                        emit(DiskPressureState(availableBytes = availableBytes, isFilling = true))
+                    }
+                }
+            } catch (e: IOException) {
+                emit(
+                    DiskPressureState(
+                        availableBytes = availableDiskSpace(),
+                        error = e.message ?: "Disk write failed",
+                    ),
+                )
+                return@flow
+            }
+
+            emit(DiskPressureState(availableBytes = availableBytes))
+        }.flowOn(Dispatchers.IO)
+
+    fun clearDiskSpace(): Flow<DiskPressureState> =
+        flow { emit(DiskPressureState(availableBytes = clearDiskSpaceFile())) }.flowOn(Dispatchers.IO)
+
+    fun refreshDiskSpace(): DiskPressureState =
+        DiskPressureState(availableBytes = availableDiskSpace())
+
+    private fun clearDiskSpaceFile(): Long {
+        File(context.filesDir, DISK_FILLER_FILE_NAME).delete()
+        return availableDiskSpace()
+    }
 
     fun increaseMemoryPressure(targetPercent: Int) {
         Capture.Logger.logWarning {
@@ -265,6 +316,8 @@ class StressTestRepository(
     }
 
     companion object {
+        private const val DISK_FILLER_FILE_NAME = "disk-pressure-filler"
+        private const val DISK_FILL_CHUNK_SIZE_BYTES = 1024 * 1024
         private const val REPLAY_RACE_DURATION_MS = 10_000L
         private const val REPLAY_CAPTURE_INTERVAL_MS = 20L
         private const val CHURN_INTERVAL_MS = 16L
@@ -357,4 +410,6 @@ class StressTestRepository(
     private fun usedMemory(): Long {
         return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
     }
+
+    private fun availableDiskSpace(): Long = StatFs(context.filesDir.path).availableBytes
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
@@ -43,6 +43,7 @@ import io.bitdrift.gradletestapp.data.model.AppState
 import io.bitdrift.gradletestapp.data.model.ClearError
 import io.bitdrift.gradletestapp.data.model.ConfigAction
 import io.bitdrift.gradletestapp.data.model.DiagnosticsAction
+import io.bitdrift.gradletestapp.data.model.DiskPressureState
 import io.bitdrift.gradletestapp.data.model.FeatureFlagsTestAction
 import io.bitdrift.gradletestapp.data.model.GlobalFieldAction
 import io.bitdrift.gradletestapp.data.model.NetworkTestAction
@@ -173,6 +174,7 @@ fun MainScreen(
                         currentEntityId = currentEntityId,
                     )
                 BottomNavTab.STRESS_TESTS -> StressTestsTabContent(
+                    diskPressure = uiState.diskPressure,
                     onAction = onAction,
                 )
                 BottomNavTab.APP_TERMINATIONS -> AppTerminationsTabContent(
@@ -401,11 +403,13 @@ private fun AppTerminationsTabContent(
 
 @Composable
 private fun StressTestsTabContent(
+    diskPressure: DiskPressureState,
     onAction: (AppAction) -> Unit,
 ) {
     StressTestScreen(
         onAction = onAction,
         onNavigateBack = {},
+        diskPressure = diskPressure,
     )
 }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import android.app.Activity
+import android.text.format.Formatter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
@@ -26,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.bitdrift.gradletestapp.R
 import io.bitdrift.gradletestapp.data.model.AppAction
+import io.bitdrift.gradletestapp.data.model.DiskPressureState
 import io.bitdrift.gradletestapp.data.model.JankType
 import io.bitdrift.gradletestapp.data.model.StrictModeViolationType
 import io.bitdrift.gradletestapp.data.model.StressTestAction
@@ -36,7 +38,12 @@ import io.bitdrift.gradletestapp.ui.theme.BitdriftColors
 fun StressTestScreen(
     onAction: (AppAction) -> Unit,
     onNavigateBack: () -> Unit,
+    diskPressure: DiskPressureState,
 ) {
+    LaunchedEffect(Unit) {
+        onAction(StressTestAction.RefreshDiskSpace)
+    }
+
     LazyColumn(
         modifier =
             Modifier
@@ -49,6 +56,12 @@ fun StressTestScreen(
             MemoryPressureCard(onAction = onAction)
         }
         item {
+            DiskPressureCard(
+                diskPressure = diskPressure,
+                onAction = onAction,
+            )
+        }
+        item {
             ThreadCountCard(onAction = onAction)
         }
         item {
@@ -59,6 +72,59 @@ fun StressTestScreen(
         }
         item {
             ScreenReplayCard(onAction = onAction)
+        }
+    }
+}
+
+@Composable
+private fun DiskPressureCard(
+    diskPressure: DiskPressureState,
+    onAction: (AppAction) -> Unit,
+) {
+    val context = LocalContext.current
+
+    StressTestCard(title = "Disk Pressure") {
+        Text(
+            text = "Enable Deferred SDK Start in Settings, fill storage, then manually start the SDK to test initialization under ENOSPC.",
+            style = MaterialTheme.typography.bodySmall,
+            color = BitdriftColors.TextSecondary,
+        )
+
+        Text(
+            text = diskPressure.availableBytes?.let { "Available: ${Formatter.formatFileSize(context, it)}" } ?: "Available: loading",
+            style = MaterialTheme.typography.bodySmall,
+            color = BitdriftColors.TextPrimary,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        diskPressure.error?.let { error ->
+            Text(
+                text = "Disk filler error: $error",
+                style = MaterialTheme.typography.bodySmall,
+                color = BitdriftColors.Error,
+            )
+        }
+
+        Button(
+            onClick = { onAction(StressTestAction.FillDiskSpace) },
+            enabled = !diskPressure.isFilling,
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = BitdriftColors.Error,
+                    contentColor = Color.White,
+                ),
+        ) {
+            Text(if (diskPressure.isFilling) "Filling Internal Storage" else "Fill Internal Storage")
+        }
+
+        OutlinedButton(
+            onClick = { onAction(StressTestAction.ClearDiskSpace) },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = BitdriftColors.TextPrimary),
+        ) {
+            Text("Clear Disk Pressure")
         }
     }
 }
@@ -391,5 +457,5 @@ private fun StressTestCard(
 @Preview
 @Composable
 fun StressTestScreenPreview(){
-    StressTestScreen({},{})
+    StressTestScreen({}, {}, DiskPressureState())
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/StressTestScreen.kt
@@ -82,25 +82,42 @@ private fun DiskPressureCard(
     onAction: (AppAction) -> Unit,
 ) {
     val context = LocalContext.current
+    val availableBytes =
+        when (diskPressure) {
+            is DiskPressureState.Ready -> diskPressure.availableBytes
+            is DiskPressureState.Filling -> diskPressure.availableBytes
+            is DiskPressureState.Failed -> diskPressure.availableBytes
+            DiskPressureState.Loading -> null
+            DiskPressureState.UnsupportedDevice -> null
+        }
 
     StressTestCard(title = "Disk Pressure") {
         Text(
-            text = "Enable Deferred SDK Start in Settings, fill storage, then manually start the SDK to test initialization under ENOSPC.",
+            text =
+                if (diskPressure == DiskPressureState.Loading) {
+                    "Checking whether disk pressure testing is supported."
+                } else if (diskPressure != DiskPressureState.UnsupportedDevice) {
+                    "Enable Deferred SDK Start in Settings, fill storage, then manually start the SDK to test initialization under ENOSPC."
+                } else {
+                    "Unavailable. Disk pressure testing requires an Android emulator."
+                },
             style = MaterialTheme.typography.bodySmall,
             color = BitdriftColors.TextSecondary,
         )
 
-        Text(
-            text = diskPressure.availableBytes?.let { "Available: ${Formatter.formatFileSize(context, it)}" } ?: "Available: loading",
-            style = MaterialTheme.typography.bodySmall,
-            color = BitdriftColors.TextPrimary,
-        )
+        availableBytes?.let {
+            Text(
+                text = "Available: ${Formatter.formatFileSize(context, it)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = BitdriftColors.TextPrimary,
+            )
+        }
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        diskPressure.error?.let { error ->
+        (diskPressure as? DiskPressureState.Failed)?.let { failure ->
             Text(
-                text = "Disk filler error: $error",
+                text = "Disk filler error: ${failure.message}",
                 style = MaterialTheme.typography.bodySmall,
                 color = BitdriftColors.Error,
             )
@@ -108,7 +125,7 @@ private fun DiskPressureCard(
 
         Button(
             onClick = { onAction(StressTestAction.FillDiskSpace) },
-            enabled = !diskPressure.isFilling,
+            enabled = diskPressure is DiskPressureState.Ready || diskPressure is DiskPressureState.Failed,
             modifier = Modifier.fillMaxWidth(),
             colors =
                 ButtonDefaults.buttonColors(
@@ -116,11 +133,14 @@ private fun DiskPressureCard(
                     contentColor = Color.White,
                 ),
         ) {
-            Text(if (diskPressure.isFilling) "Filling Internal Storage" else "Fill Internal Storage")
+            Text(if (diskPressure is DiskPressureState.Filling) "Filling Internal Storage" else "Fill Internal Storage")
         }
 
         OutlinedButton(
             onClick = { onAction(StressTestAction.ClearDiskSpace) },
+            enabled = diskPressure is DiskPressureState.Ready ||
+                diskPressure is DiskPressureState.Filling ||
+                diskPressure is DiskPressureState.Failed,
             modifier = Modifier.fillMaxWidth(),
             colors = ButtonDefaults.outlinedButtonColors(contentColor = BitdriftColors.TextPrimary),
         ) {
@@ -457,5 +477,5 @@ private fun StressTestCard(
 @Preview
 @Composable
 fun StressTestScreenPreview(){
-    StressTestScreen({}, {}, DiskPressureState())
+    StressTestScreen({}, {}, DiskPressureState.Ready(0))
 }

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/StressTestFragment.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/fragments/StressTestFragment.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.material3.MaterialTheme
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
@@ -48,9 +49,11 @@ class StressTestFragment : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialTheme {
+                    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
                     StressTestScreen(
-                        onAction = { action -> viewModel.handleAction(action) },
+                        onAction = viewModel::handleAction,
                         onNavigateBack = { findNavController().popBackStack() },
+                        diskPressure = uiState.diskPressure,
                     )
                 }
             }
@@ -62,4 +65,3 @@ class StressTestFragment : Fragment() {
         Logger.logScreenView("stress_test_fragment")
     }
 }
-

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -32,10 +32,14 @@ import io.bitdrift.gradletestapp.data.repository.SdkRepository
 import io.bitdrift.gradletestapp.data.repository.StressTestRepository
 import io.bitdrift.gradletestapp.init.CaptureSdkInitializer
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.BufferOverflow
 import timber.log.Timber
 
 /**
@@ -51,8 +55,26 @@ class MainViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(AppState())
     val uiState: StateFlow<AppState> = _uiState.asStateFlow()
+    private val diskPressureCommands =
+        MutableSharedFlow<DiskPressureCommand>(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
     init {
+        viewModelScope.launch {
+            diskPressureCommands.collectLatest { command ->
+                val diskPressureFlow =
+                    when (command) {
+                        DiskPressureCommand.Fill -> stressTestRepository.fillDiskSpace()
+                        DiskPressureCommand.Clear -> stressTestRepository.clearDiskSpace()
+                    }
+                diskPressureFlow.collect { diskPressure ->
+                    _uiState.update { it.copy(diskPressure = diskPressure) }
+                }
+            }
+        }
+        refreshDiskSpace()
         viewModelScope.launch {
             initializeSdkConfig()
         }
@@ -189,6 +211,9 @@ class MainViewModel(
             is StressTestAction.TriggerJankyFrames -> stressTestRepository.triggerJankyFrames(action.type.durationMs)
             is StressTestAction.TriggerStrictModeViolation -> stressTestRepository.triggerStrictModeViolation(action.type)
             is StressTestAction.TriggerScreenReplayCapture -> stressTestRepository.triggerScreenReplayCapture(action.activity)
+            is StressTestAction.FillDiskSpace -> fillDiskSpace()
+            is StressTestAction.ClearDiskSpace -> clearDiskSpace()
+            is StressTestAction.RefreshDiskSpace -> refreshDiskSpace()
             is ClearError -> clearError()
 
             // For now, navigation actions are handled at the Fragment level
@@ -202,6 +227,25 @@ class MainViewModel(
             is NavigationAction.InvokeService -> {}
 
         }
+    }
+
+    private fun fillDiskSpace() {
+        diskPressureCommands.tryEmit(DiskPressureCommand.Fill)
+    }
+
+    private fun clearDiskSpace() {
+        diskPressureCommands.tryEmit(DiskPressureCommand.Clear)
+    }
+
+    private fun refreshDiskSpace() {
+        _uiState.update {
+            it.copy(diskPressure = stressTestRepository.refreshDiskSpace())
+        }
+    }
+
+    private enum class DiskPressureCommand {
+        Fill,
+        Clear,
     }
 
     private fun initializeSdk() {


### PR DESCRIPTION
Resolves BIT-9847

Adding a new Card under stress Tab to test full disk space situations

This logic can only be run from an emulator

<img width="450" height="708" alt="Screenshot 2026-09-03 at 11 11 17" src="https://github.com/user-attachments/assets/4feae9e7-1040-4a9c-ab47-382b1b75b0b7" />

<img width="316" height="258" alt="Screenshot 2026-09-03 at 13 33 16" src="https://github.com/user-attachments/assets/6e7d02c4-25dd-40a2-974b-9238e02200ac" />

<img width="272" height="176" alt="Screenshot 2026-09-03 at 13 35 39" src="https://github.com/user-attachments/assets/564d54ae-08ba-43fd-9be5-0f8806d9e63d" />

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.