### PR TITLE
[Flutter] Add setEntity/clearEntity + bump version

### DIFF
--- a/examples/flutter/lib/main.dart
+++ b/examples/flutter/lib/main.dart
@@ -30,6 +30,7 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   String _status = 'Not initialized';
   String? _sessionId;
+  String? _entityId;
   String? _apiKey;
   String _apiUrl = 'https://api.bitdrift.io';
 
@@ -62,9 +63,14 @@ class _HomePageState extends State<HomePage> {
         enableSessionReplay: true,
       );
       final sessionId = await Capture.sessionId;
+      const entityId = 'flutter-example-user';
+      if (success) {
+        await Capture.setEntityId(entityId);
+      }
       setState(() {
         _status = success ? 'Started successfully' : 'Start failed';
         _sessionId = sessionId;
+        _entityId = success ? entityId : null;
       });
     } catch (e) {
       setState(() => _status = 'Error: $e');
@@ -94,15 +100,17 @@ class _HomePageState extends State<HomePage> {
           ),
         ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Status: $_status'),
-            if (_sessionId != null) Text('Session ID: $_sessionId'),
-            const SizedBox(height: 24),
-            ElevatedButton(
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Status: $_status'),
+              if (_sessionId != null) Text('Session ID: $_sessionId'),
+              if (_entityId != null) Text('Entity ID: $_entityId'),
+              const SizedBox(height: 24),
+              ElevatedButton(
               onPressed: () =>
                   Capture.logInfo('Button tapped', fields: {'screen': 'home'}),
               child: const Text('Log Info'),
@@ -140,6 +148,33 @@ class _HomePageState extends State<HomePage> {
                 setState(() => _sessionId = id);
               },
               child: const Text('New Session'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () async {
+                const entityId = 'flutter-example-user';
+                await Capture.setEntityId(entityId);
+                setState(() => _entityId = entityId);
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Entity ID set')),
+                  );
+                }
+              },
+              child: const Text('Set Entity ID'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () async {
+                await Capture.clearEntityId();
+                setState(() => _entityId = null);
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Entity ID cleared')),
+                  );
+                }
+              },
+              child: const Text('Clear Entity ID'),
             ),
             const SizedBox(height: 8),
             ElevatedButton.icon(
@@ -199,7 +234,8 @@ class _HomePageState extends State<HomePage> {
               icon: const Icon(Icons.info_outline),
               label: const Text('SDK Status'),
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/examples/flutter/pubspec.lock
+++ b/examples/flutter/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: "../../platform/capture_flutter"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   characters:
     dependency: transitive
     description:

--- a/platform/capture_flutter/ALPHA_RELEASES.md
+++ b/platform/capture_flutter/ALPHA_RELEASES.md
@@ -22,6 +22,19 @@ TODO: Before publishing, update the native SDK dependencies in `android/build.gr
 
 - Nothing yet!
 
+## [0.0.2]
+[0.0.2]: https://github.com/bitdriftlabs/capture-sdk/tree/flutter-prototype-0.0.2
+
+### Both
+
+**Added**
+
+- Added `Capture.setEntityId` and `Capture.clearEntityId`.
+
+**Changed**
+
+- Updated the Android and iOS Capture SDK dependencies to 0.23.12.
+
 ## [0.0.1]
 [0.0.1]: https://github.com/bitdriftlabs/capture-sdk/tree/flutter-prototype-0.0.1
 
@@ -35,7 +48,7 @@ TODO: Before publishing, update the native SDK dependencies in `android/build.gr
 
 **Changed**
 
-- Uses the `BitdriftCapture` iOS SDK `~> 0.22` dependency constraint.
+- Uses Android Capture SDK 0.23.0 and the `BitdriftCapture` iOS SDK `~> 0.22` dependency constraint.
 
 **Fixed**
 

--- a/platform/capture_flutter/README.md
+++ b/platform/capture_flutter/README.md
@@ -13,7 +13,7 @@ dependencies:
   capture_flutter:
     git:
       url: https://github.com/bitdriftlabs/capture-sdk.git
-      ref: flutter-prototype-0.0.1
+      ref: flutter-prototype-0.0.2
       path: platform/capture_flutter
 ```
 
@@ -58,6 +58,13 @@ await Capture.startNewSession();
 ```dart
 Capture.addField('app_version', '2.1.0');
 Capture.removeField('app_version');
+```
+
+## Entity
+
+```dart
+Capture.setEntityId('user-123');
+Capture.clearEntityId();
 ```
 
 ## Spans

--- a/platform/capture_flutter/README.md
+++ b/platform/capture_flutter/README.md
@@ -103,7 +103,7 @@ Capture.stopSessionReplay();
 
 ## Releases
 
-The `version` in `pubspec.yaml` is the release source of truth. The matching customer-facing Git tag is `flutter-prototype-<version>`; with the current version, use `flutter-prototype-0.0.1`.
+The `version` in `pubspec.yaml` is the release source of truth. The matching customer-facing Git tag is `flutter-prototype-<version>`.
 
 Prepare a release in a PR: update `pubspec.yaml`, the installation tag above, and move the reviewed notes from `## [Next release]` to a matching versioned entry in `ALPHA_RELEASES.md`; then restore the empty `Next release` template. When that PR merges to `main`, the `Publish Flutter Alpha Release Tag` GitHub Actions workflow validates the prepared release metadata and creates `flutter-prototype-<version>` from the merge commit.
 

--- a/platform/capture_flutter/README.md
+++ b/platform/capture_flutter/README.md
@@ -4,7 +4,7 @@
 
 Official Flutter plugin for the [Bitdrift Capture SDK](https://bitdrift.io).
 
-Provides logging, session management, and distributed tracing for Flutter apps on iOS and Android. Wireframe session replay is currently available on Android only.
+Provides logging, session management, entity correlation, and distributed tracing for Flutter apps on iOS and Android. Wireframe session replay is currently available on Android only.
 
 ## Installation
 
@@ -61,6 +61,8 @@ Capture.removeField('app_version');
 ```
 
 ## Entity
+
+Set an entity identifier to correlate events from this device with an application entity.
 
 ```dart
 Capture.setEntityId('user-123');

--- a/platform/capture_flutter/android/build.gradle.kts
+++ b/platform/capture_flutter/android/build.gradle.kts
@@ -28,6 +28,6 @@ android {
 }
 
 dependencies {
-    implementation("io.bitdrift:capture:0.23.0")
+    implementation("io.bitdrift:capture:0.23.12")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }

--- a/platform/capture_flutter/android/src/main/kotlin/io/bitdrift/capture_flutter/CaptureFlutterPlugin.kt
+++ b/platform/capture_flutter/android/src/main/kotlin/io/bitdrift/capture_flutter/CaptureFlutterPlugin.kt
@@ -74,6 +74,15 @@ class CaptureFlutterPlugin : FlutterPlugin, MethodCallHandler {
                 Logger.removeField(key)
                 result.success(null)
             }
+            "setEntityId" -> {
+                val entityId = call.argument<String>("entityId")!!
+                Logger.setEntityId(entityId)
+                result.success(null)
+            }
+            "clearEntityId" -> {
+                Logger.clearEntityId()
+                result.success(null)
+            }
             "startSpan" -> handleStartSpan(call, result)
             "endSpan" -> handleEndSpan(call, result)
             "logReplayScreen" -> handleLogReplayScreen(call, result)

--- a/platform/capture_flutter/ios/Classes/CaptureFlutterPlugin.swift
+++ b/platform/capture_flutter/ios/Classes/CaptureFlutterPlugin.swift
@@ -73,6 +73,17 @@ public class CaptureFlutterPlugin: NSObject, FlutterPlugin {
             }
             Logger.removeField(withKey: key)
             result(nil)
+        case "setEntityId":
+            guard let args = call.arguments as? [String: Any],
+                  let entityId = args["entityId"] as? String else {
+                result(FlutterError(code: "INVALID_ARGS", message: "Missing entityId", details: nil))
+                return
+            }
+            Logger.setEntityID(entityId)
+            result(nil)
+        case "clearEntityId":
+            Logger.clearEntityID()
+            result(nil)
         case "startSpan":
             handleStartSpan(call, result: result)
         case "endSpan":

--- a/platform/capture_flutter/ios/capture_flutter.podspec
+++ b/platform/capture_flutter/ios/capture_flutter.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'BitdriftCapture', '~> 0.22'
+  s.dependency 'BitdriftCapture', '0.23.12'
   s.static_framework = true
   s.platform         = :ios, '15.0'
   s.swift_version    = '5.9'

--- a/platform/capture_flutter/lib/src/capture.dart
+++ b/platform/capture_flutter/lib/src/capture.dart
@@ -132,6 +132,15 @@ class Capture {
   static Future<void> removeField(String key) =>
       _channel.invokeMethod('removeField', {'key': key});
 
+  // -- Entity --
+
+  /// Sets the entity identifier used for backend correlation with this device.
+  static Future<void> setEntityId(String entityId) =>
+      _channel.invokeMethod('setEntityId', {'entityId': entityId});
+
+  /// Clears the entity identifier used for backend correlation with this device.
+  static Future<void> clearEntityId() => _channel.invokeMethod('clearEntityId');
+
   // -- Spans --
 
   /// Start a new span for tracing.

--- a/platform/capture_flutter/pubspec.yaml
+++ b/platform/capture_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: capture_flutter
 description: Official Flutter plugin for the Bitdrift Capture SDK. Provides logging, session management, and session replay for Flutter apps.
-version: 0.0.1
+version: 0.0.2
 homepage: https://bitdrift.io
 repository: https://github.com/bitdriftlabs/capture-sdk
 


### PR DESCRIPTION
## Goal

Resolves BIT-9645

- Add setEntity/clearEntity APIs to flutter
- Bump to release 0.0.2 

## Verification

Update internal example app and test entities feature

<img width="524" height="938" alt="Screenshot 2026-09-03 at 14 49 11" src="https://github.com/user-attachments/assets/cf5a0a26-0fe5-4fc4-8826-0dea00b80206" />


---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.