### PR TITLE
[Flutter] Fix release tag action

### DIFF
--- a/.github/workflows/publish_flutter_alpha.yaml
+++ b/.github/workflows/publish_flutter_alpha.yaml
@@ -56,6 +56,8 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.release.outputs.tag }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
           git tag -a "$tag" -m "Flutter alpha ${{ steps.release.outputs.version }}"
           git push origin "$tag"
 


### PR DESCRIPTION
Small fix in the alpha release action

Failed job here https://github.com/bitdriftlabs/capture-sdk/actions/runs/33758754553

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.