### PR TITLE
[Flutter] Re-trigger 0.0.2 alpha

### DIFF
--- a/platform/capture_flutter/ALPHA_RELEASES.md
+++ b/platform/capture_flutter/ALPHA_RELEASES.md
@@ -8,6 +8,7 @@ Before releasing, update `pubspec.yaml` with the new Flutter alpha version, move
 
 TODO: Before publishing, update the native SDK dependencies in `android/build.gradle.kts` and `ios/capture_flutter.podspec` to the latest compatible published Capture SDK releases.
 
+## [Unreleased notes here]
 ### Both
 
 **Added**


### PR DESCRIPTION
To trigger flutter release after latest fixes

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.