### PR TITLE
Fix Flutter Android build: apply Kotlin Gradle plugin

### DIFF
--- a/examples/flutter/android/app/build.gradle.kts
+++ b/examples/flutter/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
+    id("org.jetbrains.kotlin.android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 

--- a/examples/flutter/android/settings.gradle.kts
+++ b/examples/flutter/android/settings.gradle.kts
@@ -19,6 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 rootProject.name = "flutter_capture_example"

--- a/platform/capture_flutter/ALPHA_RELEASES.md
+++ b/platform/capture_flutter/ALPHA_RELEASES.md
@@ -23,6 +23,23 @@ TODO: Before publishing, update the native SDK dependencies in `android/build.gr
 
 - Nothing yet!
 
+## [0.0.3]
+[0.0.3]: https://github.com/bitdriftlabs/capture-sdk/tree/flutter-prototype-0.0.3
+
+### Both
+
+**Added**
+
+- Nothing yet!
+
+**Changed**
+
+- Nothing yet!
+
+**Fixed**
+
+- Fixed Android builds for apps using `capture_flutter` by applying the Kotlin Android Gradle plugin.
+
 ## [0.0.2]
 [0.0.2]: https://github.com/bitdriftlabs/capture-sdk/tree/flutter-prototype-0.0.2
 

--- a/platform/capture_flutter/README.md
+++ b/platform/capture_flutter/README.md
@@ -13,7 +13,7 @@ dependencies:
   capture_flutter:
     git:
       url: https://github.com/bitdriftlabs/capture-sdk.git
-      ref: flutter-prototype-0.0.2
+      ref: flutter-prototype-0.0.3
       path: platform/capture_flutter
 ```
 

--- a/platform/capture_flutter/android/build.gradle.kts
+++ b/platform/capture_flutter/android/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
 }
 
 group = "io.bitdrift"


### PR DESCRIPTION
## Goal

`capture_flutter`'s Android module and the in-repo `examples/flutter` app both fail to build on `main`. Found while validating the Flutter alpha demo in `sa-public` off the merged #996.

## Root cause

Both `platform/capture_flutter/android/build.gradle.kts` and `examples/flutter/android/app/build.gradle.kts` use a `kotlin { compilerOptions { jvmTarget = ... } }` block, but neither declares `org.jetbrains.kotlin.android` in its own `plugins {}` block. Gradle only generates the typed `kotlin {}` DSL accessor for plugins applied within that same script's `plugins {}` block — not for ones applied transitively (e.g. by the Flutter Gradle plugin) — so both scripts fail to compile:

```
e: .../build.gradle.kts: None of the following candidates is applicable:
    fun DependencyHandler.kotlin(module: String, version: String? = ...): Any
    fun PluginDependenciesSpec.kotlin(module: String): PluginDependencySpec
e: .../build.gradle.kts: Unresolved reference 'compilerOptions'.
e: .../build.gradle.kts: Unresolved reference 'jvmTarget'.
```

Because `capture_flutter`'s own Kotlin sources (`CaptureFlutterPlugin.kt`) never compile as a result, **any Android app that depends on `capture_flutter` fails to build**, hitting:

```
cannot find symbol: class CaptureFlutterPlugin
```

## Fix

- Add `id("org.jetbrains.kotlin.android")` to the `plugins {}` block in both `platform/capture_flutter/android/build.gradle.kts` and `examples/flutter/android/app/build.gradle.kts`.
- Pin a Kotlin Gradle plugin version (`2.3.20`, matching `platform/jvm`) in `examples/flutter/android/settings.gradle.kts` — neither module declared one, and without a pin Gradle falls back to a default older than Flutter's minimum supported Kotlin version (1.8.10).

## Verification

```
cd examples/flutter && flutter build apk --release
```

- Before this branch (on `main`): fails with the errors above.
- After: `✓ Built build/app/outputs/flutter-apk/app-release.apk`.

Also confirmed the in-repo example app runs end-to-end on an arm64 emulator (SDK initializes, authenticates, welcome screen renders) once pointed at a valid API key.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable. (Skipped — build/tooling-only fix, no SDK behavior change, per repo convention.)