### PR TITLE
Fix _jvm_used_percent erronously using the device's locale to format the values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 **Fixed**
 
-- Nothing yet!
+- SDK was erronously reporting `_jvm_used_percent` in Resource Utilization logs using the device Locale
 
 ### iOS
 

--- a/platform/jvm/.gitignore
+++ b/platform/jvm/.gitignore
@@ -6,3 +6,6 @@ build
 
 # Local configuration file (sdk path, etc)
 local.properties
+
+# IDE Artifacts
+.artifacts/

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProvider.kt
@@ -9,13 +9,13 @@ package io.bitdrift.capture.events.performance
 
 import android.app.ActivityManager
 import android.os.Debug
-import java.util.Locale
 import io.bitdrift.capture.common.RuntimeConfig
 import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.combineFields
 import io.bitdrift.capture.providers.fieldOf
 import io.bitdrift.capture.providers.fieldsOf
 import io.bitdrift.capture.providers.fieldsOfOptional
+import java.util.Locale
 
 private const val KB = 1024L
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProvider.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProvider.kt
@@ -9,6 +9,7 @@ package io.bitdrift.capture.events.performance
 
 import android.app.ActivityManager
 import android.os.Debug
+import java.util.Locale
 import io.bitdrift.capture.common.RuntimeConfig
 import io.bitdrift.capture.providers.ArrayFields
 import io.bitdrift.capture.providers.combineFields
@@ -40,7 +41,7 @@ internal class MemoryMetricsProvider(
                 "_native_used_kb" to allocatedNativeHeapSizeBytes().bToKb(),
                 "_native_total_kb" to totalNativeHeapSizeBytes().bToKb(),
                 "_memory_class" to memoryClassMB().toString(),
-                "_jvm_used_percent" to "%.3f".format(jvmUsedPercent()),
+                "_jvm_used_percent" to String.format(Locale.ROOT, "%.3f", jvmUsedPercent()),
             ),
             fieldsOfOptional(
                 "_is_memory_low" to appCriticalMemoryConfigThreshold?.let { if (isMemoryLow()) "1" else "0" },

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProviderTest.kt
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.util.Locale
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [24])
@@ -193,5 +194,32 @@ class MemoryMetricsProviderTest {
         val result = memoryMetricsProvider.getCurrentJvmMemoryPressureLevel()
 
         assertThat(result).isEqualTo(MemoryPressureLevel.Critical)
+    }
+
+    @Test
+    fun getMemoryAttributes_jvmUsedPercent_isLocaleIndependent() {
+        val originalLocale = Locale.getDefault()
+        try {
+            whenever(jvmMemoryProvider.usedMemoryBytes()).thenReturn(16_664L)
+            whenever(jvmMemoryProvider.maxMemoryBytes()).thenReturn(100_000L)
+
+            val locales = listOf(
+                Locale.US, Locale.UK,
+                Locale.forLanguageTag("ar-EG"), Locale.forLanguageTag("fa-IR"),
+                Locale.FRANCE, Locale.GERMANY,
+                Locale.forLanguageTag("pt-BR"), Locale.forLanguageTag("in-ID"), Locale.forLanguageTag("tr-TR"),
+            )
+
+            locales.forEach { locale ->
+                Locale.setDefault(locale)
+                val result = memoryMetricsProvider.getMemoryAttributes()
+                val value = result["_jvm_used_percent"]
+                assertThat(value)
+                    .withFailMessage("Failed for locale: $locale. Expected 16.664 but got $value")
+                    .isEqualTo("16.664")
+            }
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
     }
 }

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProviderTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/events/performance/MemoryMetricsProviderTest.kt
@@ -203,12 +203,18 @@ class MemoryMetricsProviderTest {
             whenever(jvmMemoryProvider.usedMemoryBytes()).thenReturn(16_664L)
             whenever(jvmMemoryProvider.maxMemoryBytes()).thenReturn(100_000L)
 
-            val locales = listOf(
-                Locale.US, Locale.UK,
-                Locale.forLanguageTag("ar-EG"), Locale.forLanguageTag("fa-IR"),
-                Locale.FRANCE, Locale.GERMANY,
-                Locale.forLanguageTag("pt-BR"), Locale.forLanguageTag("in-ID"), Locale.forLanguageTag("tr-TR"),
-            )
+            val locales =
+                listOf(
+                    Locale.US,
+                    Locale.UK,
+                    Locale.forLanguageTag("ar-EG"),
+                    Locale.forLanguageTag("fa-IR"),
+                    Locale.FRANCE,
+                    Locale.GERMANY,
+                    Locale.forLanguageTag("pt-BR"),
+                    Locale.forLanguageTag("in-ID"),
+                    Locale.forLanguageTag("tr-TR"),
+                )
 
             locales.forEach { locale ->
                 Locale.setDefault(locale)


### PR DESCRIPTION
Values were being reported in formats that was tripping the chart actions 
<img width="399" height="251" alt="Screenshot 2026-09-04 at 5 21 37 PM" src="https://github.com/user-attachments/assets/8e5c5e41-40bd-45be-99ee-51044c2c59e1" />
<img width="385" height="258" alt="Screenshot 2026-09-04 at 5 20 50 PM" src="https://github.com/user-attachments/assets/ea5b24c5-633a-4e0d-ac23-c2ed3baa5f37" />

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.