### PR TITLE
[Android] Avoid reporting null protocol for failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 **Fixed**
 
 - SDK was erronously reporting `_jvm_used_percent` in Resource Utilization logs using the device Locale
+- Fixed OkHttp logs including an invalid `_protocol` value when a request fails before receiving a response.
 
 ### iOS
 

--- a/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
+++ b/platform/jvm/capture/src/main/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListener.kt
@@ -479,7 +479,7 @@ internal class CaptureOkHttpEventListener internal constructor(
             tcpDurationMs = tcpDurationMs,
             fetchInitializationMs = fetchInitializationMs,
             responseLatencyMs = responseLatencyMs,
-            protocolName = lastResponse?.protocol.toString(),
+            protocolName = lastResponse?.protocol?.toString(),
         )
 
     private fun isInterruptedException(e: Throwable): Boolean {

--- a/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
+++ b/platform/jvm/capture/src/test/kotlin/io/bitdrift/capture/network/okhttp/CaptureOkHttpEventListenerFactoryTest.kt
@@ -355,6 +355,26 @@ class CaptureOkHttpEventListenerFactoryTest {
     }
 
     @Test
+    fun testRequestFailureBeforeResponseHeadersOmitsProtocol() {
+        val request =
+            Request
+                .Builder()
+                .url(endpoint)
+                .build()
+        val call: Call = mock()
+        whenever(call.request()).thenReturn(request)
+
+        val listener = createListenerFactory().create(call)
+        listener.callStart(call)
+        listener.callFailed(call, FileNotFoundException("test error"))
+
+        val httpResponseInfoCapture = argumentCaptor<HttpResponseInfo>()
+        verify(logger).log(httpResponseInfoCapture.capture())
+
+        assertThat(httpResponseInfoCapture.firstValue.arrayFields.toStringMap()).doesNotContainKey("_protocol")
+    }
+
+    @Test
     fun testRequestAndErrorThrownCanceled() {
         // ARRANGE
         val request =

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/model/Actions.kt
@@ -65,6 +65,8 @@ sealed class DiagnosticsAction : AppAction {
 sealed class NetworkTestAction : AppAction {
     object PerformOkHttpRequest : NetworkTestAction()
 
+    object PerformOkHttpFailureBeforeResponseHeaders : NetworkTestAction()
+
     object PerformGraphQlRequest : NetworkTestAction()
 
     object PerformRetrofitRequest : NetworkTestAction()

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/data/repository/NetworkTestingRepository.kt
@@ -191,6 +191,17 @@ class NetworkTestingRepository(context: Context) {
         )
     }
 
+    fun performOkHttpFailureBeforeResponseHeaders() {
+        val request =
+            Request
+                .Builder()
+                .url("https://nonexistent.invalid/")
+                .build()
+
+        Timber.i("Performing OkHttp request expected to fail before response headers: ${request.url}")
+        performRequestWithPreExistingHeaders(request, "Pre-response failure")
+    }
+
     fun performGraphQlRequest() {
         val operation = graphQlOperations.random()
         MainScope().launch {

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/MainScreen.kt
@@ -356,6 +356,9 @@ private fun SdkApisTabContent(
         item {
             NetworkTestingCard(
                 onOkHttpRequest = { onAction(NetworkTestAction.PerformOkHttpRequest) },
+                onOkHttpFailureBeforeResponseHeaders = {
+                    onAction(NetworkTestAction.PerformOkHttpFailureBeforeResponseHeaders)
+                },
                 onGraphQlRequest = { onAction(NetworkTestAction.PerformGraphQlRequest) },
                 onRetrofitRequest = { onAction(NetworkTestAction.PerformRetrofitRequest) },
                 onPreExistingW3cRequest = { onAction(NetworkTestAction.PerformPreExistingW3cRequest) },

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NetworkTestingCard.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/compose/components/NetworkTestingCard.kt
@@ -21,6 +21,7 @@ import io.bitdrift.gradletestapp.ui.theme.BitdriftColors
 @Composable
 fun NetworkTestingCard(
     onOkHttpRequest: () -> Unit,
+    onOkHttpFailureBeforeResponseHeaders: () -> Unit,
     onGraphQlRequest: () -> Unit,
     onRetrofitRequest: () -> Unit,
     onPreExistingW3cRequest: () -> Unit,
@@ -69,6 +70,17 @@ fun NetworkTestingCard(
                         ),
                 ) {
                     Text("OkHttp", maxLines = 1, softWrap = false)
+                }
+
+                OutlinedButton(
+                    onClick = onOkHttpFailureBeforeResponseHeaders,
+                    modifier = Modifier.weight(1f),
+                    colors =
+                        ButtonDefaults.outlinedButtonColors(
+                            contentColor = BitdriftColors.TextPrimary,
+                        ),
+                ) {
+                    Text("Fail DNS", maxLines = 1, softWrap = false)
                 }
             }
 

--- a/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
+++ b/platform/jvm/gradle-test-app/src/main/java/io/bitdrift/gradletestapp/ui/viewmodel/MainViewModel.kt
@@ -146,6 +146,9 @@ class MainViewModel(
             is NetworkTestAction.PerformOkHttpRequest -> {
                 networkTestingRepository.performOkHttpRequest()
             }
+            is NetworkTestAction.PerformOkHttpFailureBeforeResponseHeaders -> {
+                networkTestingRepository.performOkHttpFailureBeforeResponseHeaders()
+            }
             is NetworkTestAction.PerformGraphQlRequest -> {
                 networkTestingRepository.performGraphQlRequest()
             }


### PR DESCRIPTION
Fix Android OkHttp logs emitting _protocol: "null" for failed request (iOS already doesn't report nil for nullable protocol)

## Verification

Added a new entry in the gradle-test-app to easily validate this

<img width="317" height="163" alt="Screenshot 2026-09-07 at 11 22 55" src="https://github.com/user-attachments/assets/9e00fb9a-3fe3-42d8-a55e-41736fd86aa3" />

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.