### PR TITLE
flutter: migrate capture_flutter plugin to Built-in Kotlin support

### DIFF
--- a/ci/license_header.py
+++ b/ci/license_header.py
@@ -26,6 +26,10 @@ exclude_dirs = (
     './.git',
     './target/',
 )
+exclude_files = (
+    # Swift Package Manager requires swift-tools-version to be the first line.
+    './platform/capture_flutter/ios/capture_flutter/Package.swift',
+)
 
 extensions_to_check = ('.rs', '.toml', '.kt', '.java', '.swift', '.js', '.ts')
 
@@ -34,6 +38,9 @@ def check_file(file_path):
     for dir in exclude_dirs:
         if file_path.startswith(dir):
             return
+
+    if file_path in exclude_files:
+        return
 
     _, ext = os.path.splitext(file_path)
     if not ext in extensions_to_check:

--- a/examples/flutter/README.md
+++ b/examples/flutter/README.md
@@ -5,17 +5,19 @@ using platform channels.
 
 ## Setup
 
-1. Install dependencies:
+1. Install Flutter 3.44+ / Dart 3.12+.
+
+2. Install dependencies:
    ```bash
    flutter pub get
    ```
 
-2. Run:
+3. Run:
    ```bash
    flutter run
    ```
 
-3. Tap the settings icon and enter your Bitdrift API key (and optionally override the API URL).
+4. Tap the settings icon and enter your Bitdrift API key (and optionally override the API URL).
 
 ## Architecture
 

--- a/examples/flutter/pubspec.yaml
+++ b/examples/flutter/pubspec.yaml
@@ -4,8 +4,8 @@ description: A sample Flutter app demonstrating Bitdrift Capture SDK integration
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:

--- a/platform/capture_flutter/ALPHA_RELEASES.md
+++ b/platform/capture_flutter/ALPHA_RELEASES.md
@@ -17,11 +17,12 @@ TODO: Before publishing, update the native SDK dependencies in `android/build.gr
 
 **Changed**
 
-- Nothing yet!
+- **Breaking:** minimum Flutter bumped to 3.44+ and Dart to 3.12+ (was 3.10+), required for Android's migration to Flutter's Built-in Kotlin support (below).
 
 **Fixed**
 
-- Nothing yet!
+- Android: plugin no longer applies `org.jetbrains.kotlin.android` directly, which was triggering Flutter's Kotlin Gradle Plugin (KGP) deprecation warning and could cause a JVM-target mismatch build failure in consuming apps. Migrated to Flutter's Built-in Kotlin support instead.
+- iOS: fixed `ios/capture_flutter/Package.swift` — the `swift-tools-version` comment must be the first line of the manifest; it was preceded by a (duplicated) license header, which made Swift Package Manager reject the manifest entirely (`the manifest is backward-incompatible with Swift < 6.0...`).
 
 ## [0.0.3]
 [0.0.3]: https://github.com/bitdriftlabs/capture-sdk/tree/flutter-prototype-0.0.3

--- a/platform/capture_flutter/README.md
+++ b/platform/capture_flutter/README.md
@@ -99,7 +99,7 @@ Capture.stopSessionReplay();
 
 - iOS 15.0+
 - Android minSdk 23
-- Flutter 3.10+
+- Flutter 3.44+ / Dart 3.12+ (required for Android's Built-in Kotlin support — see `ALPHA_RELEASES.md`)
 
 ## Releases
 

--- a/platform/capture_flutter/android/build.gradle.kts
+++ b/platform/capture_flutter/android/build.gradle.kts
@@ -1,8 +1,10 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+// Migrated to Flutter's Built-in Kotlin support (AGP 9+): the plugin no
+// longer applies org.jetbrains.kotlin.android directly. See
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 group = "io.bitdrift"
@@ -20,11 +22,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/platform/capture_flutter/ios/capture_flutter/Package.swift
+++ b/platform/capture_flutter/ios/capture_flutter/Package.swift
@@ -1,10 +1,3 @@
-// capture-sdk - bitdrift's client SDK
-// Copyright Bitdrift, Inc. All rights reserved.
-//
-// Use of this source code is governed by a source available license that can be found in the
-// LICENSE file or at:
-// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
-
 // swift-tools-version: 5.9
 // capture-sdk - bitdrift's client SDK
 // Copyright Bitdrift, Inc. All rights reserved.

--- a/platform/capture_flutter/pubspec.yaml
+++ b/platform/capture_flutter/pubspec.yaml
@@ -5,8 +5,11 @@ homepage: https://bitdrift.io
 repository: https://github.com/bitdriftlabs/capture-sdk
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  # 3.44.0 / 3.12.0 minimums required for Flutter's Built-in Kotlin support
+  # (see android/build.gradle.kts — this plugin no longer applies
+  # org.jetbrains.kotlin.android directly).
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
Removes the explicit `org.jetbrains.kotlin.android` plugin application in `platform/capture_flutter/android/build.gradle.kts`, which was triggering Flutter's Kotlin Gradle Plugin (KGP) deprecation warning:

> Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): capture_flutter.
> Future versions of Flutter will fail to build if your app uses plugins that apply KGP.

## Changes
- `platform/capture_flutter/android/build.gradle.kts` — drop `id("org.jetbrains.kotlin.android")`; move the `kotlin { compilerOptions { jvmTarget } }` block to the top level (required once the plugin no longer applies the Kotlin Gradle Plugin itself, per [Flutter's Built-in Kotlin migration guide for plugin authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors))
- `platform/capture_flutter/pubspec.yaml` — bump minimum Flutter/Dart SDK constraints (Flutter >=3.44.0, Dart >=3.12.0), the versions Built-in Kotlin support requires

## Verification
Built the `bitdrift-shop/flutter` consuming app against this branch via a temporary `dependency_override` pointing at a local checkout — clean `flutter build apk --release`, no KGP warning, no JVM-target mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
