### PR TITLE
flutter: bump native Capture SDK deps to 0.24.1, fix Package.swift manifest

### DIFF
--- a/ci/license_header.py
+++ b/ci/license_header.py
@@ -26,6 +26,10 @@ exclude_dirs = (
     './.git',
     './target/',
 )
+exclude_files = (
+    # Swift Package Manager requires swift-tools-version to be the first line.
+    './platform/capture_flutter/ios/capture_flutter/Package.swift',
+)
 
 extensions_to_check = ('.rs', '.toml', '.kt', '.java', '.swift', '.js', '.ts')
 
@@ -34,6 +38,9 @@ def check_file(file_path):
     for dir in exclude_dirs:
         if file_path.startswith(dir):
             return
+
+    if file_path in exclude_files:
+        return
 
     _, ext = os.path.splitext(file_path)
     if not ext in extensions_to_check:

--- a/platform/capture_flutter/ALPHA_RELEASES.md
+++ b/platform/capture_flutter/ALPHA_RELEASES.md
@@ -18,11 +18,11 @@ TODO: Before publishing, update the native SDK dependencies in `android/build.gr
 
 **Changed**
 
-- Nothing yet!
+- Updated the Android and iOS Capture SDK dependencies to 0.24.1.
 
 **Fixed**
 
-- Nothing yet!
+- iOS: fixed `ios/capture_flutter/Package.swift` — the `swift-tools-version` comment must be the first line of the manifest; it was preceded by a (duplicated) license header, which made Swift Package Manager reject the manifest entirely (`the manifest is backward-incompatible with Swift < 6.0...`).
 
 ## [0.0.2]
 [0.0.2]: https://github.com/bitdriftlabs/capture-sdk/tree/flutter-prototype-0.0.2

--- a/platform/capture_flutter/android/build.gradle.kts
+++ b/platform/capture_flutter/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.bitdrift"
-version = "0.22.16"
+version = "0.24.1"
 
 android {
     namespace = "io.bitdrift.capture_flutter"
@@ -29,6 +29,6 @@ android {
 }
 
 dependencies {
-    implementation("io.bitdrift:capture:0.23.12")
+    implementation("io.bitdrift:capture:0.24.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }

--- a/platform/capture_flutter/ios/capture_flutter.podspec
+++ b/platform/capture_flutter/ios/capture_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'capture_flutter'
-  s.version          = '0.22.16'
+  s.version          = '0.24.1'
   s.summary          = 'Flutter plugin for the Bitdrift Capture SDK'
   s.description      = 'Official Flutter plugin for the Bitdrift Capture SDK, providing logging, session management, and session replay.'
   s.homepage         = 'https://bitdrift.io'
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'BitdriftCapture', '0.23.12'
+  s.dependency 'BitdriftCapture', '0.24.1'
   s.static_framework = true
   s.platform         = :ios, '15.0'
   s.swift_version    = '5.9'

--- a/platform/capture_flutter/ios/capture_flutter/Package.swift
+++ b/platform/capture_flutter/ios/capture_flutter/Package.swift
@@ -1,10 +1,3 @@
-// capture-sdk - bitdrift's client SDK
-// Copyright Bitdrift, Inc. All rights reserved.
-//
-// Use of this source code is governed by a source available license that can be found in the
-// LICENSE file or at:
-// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
-
 // swift-tools-version: 5.9
 // capture-sdk - bitdrift's client SDK
 // Copyright Bitdrift, Inc. All rights reserved.
@@ -24,7 +17,7 @@ let package = Package(
         .library(name: "capture-flutter", targets: ["capture_flutter"])
     ],
     dependencies: [
-        .package(url: "https://github.com/bitdriftlabs/capture-ios.git", from: "0.22.0")
+        .package(url: "https://github.com/bitdriftlabs/capture-ios.git", from: "0.24.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- We have our first Flutter customer, whose app is pinned to Flutter 3.41.9 / Dart 3.11.5 — below the 3.44+/3.12+ minimums that `flutter-prototype-0.0.4` now requires (raised in #1194 for Android's Built-in Kotlin migration).
- Rather than force them onto that migration, this bumps the native Android/iOS Capture SDK dependency from 0.23.12 to 0.24.1 directly on `iain/flutter-network-logging`, which still targets the pre-migration toolchain (Flutter 3.10+/Dart 3.0+). This keeps them on current native SDK code without requiring their Flutter upgrade.
- Also fixes the `ios/capture_flutter/Package.swift` manifest bug independently of the Kotlin migration: `swift-tools-version` must be the first line, but a duplicated license header preceded it, causing SPM to reject the manifest outright. Excluded that file from `ci/license_header.py` accordingly (mirrors the fix already merged to main in #1194).
- Updated `ALPHA_RELEASES.md` unreleased notes for both changes.

## Why base off `iain/flutter-network-logging` instead of `main`
That branch (open in #1187) already carries the networking work built against the same pre-migration toolchain constraints. Basing here avoids duplicating that diff and keeps this PR focused on just the dependency bump + manifest fix, so we can cut a customer-compatible release from `iain/flutter-network-logging` once both PRs land.

## Test plan
- [ ] Confirm `flutter pub get` / build succeeds against Flutter 3.10+/Dart 3.0+ with these native dependency versions
- [ ] Confirm iOS build via SPM no longer rejects `Package.swift`
- [ ] Confirm `ci/license_header.py` passes with the new exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)